### PR TITLE
Tech Debt: Add Edge Case Tests for Core Services

### DIFF
--- a/tests/unit/test_services/test_batch_edge_cases.py
+++ b/tests/unit/test_services/test_batch_edge_cases.py
@@ -1,0 +1,175 @@
+"""Batch Processing Edge Case Tests
+
+Additional tests for extraction service batch handling.
+"""
+
+import pytest
+from unittest.mock import Mock, AsyncMock
+
+from src.services.extraction_service import ExtractionService
+from src.services.pdf_service import PDFService
+from src.services.llm_service import LLMService
+from src.models.paper import PaperMetadata, Author
+from src.models.extraction import PaperExtraction, ExtractedPaper
+from src.utils.exceptions import PDFDownloadError
+
+
+@pytest.fixture
+def mock_pdf_service():
+    """Create mock PDF service"""
+    return Mock(spec=PDFService)
+
+
+@pytest.fixture
+def mock_llm_service():
+    """Create mock LLM service"""
+    return Mock(spec=LLMService)
+
+
+@pytest.fixture
+def extraction_service(mock_pdf_service, mock_llm_service):
+    """Create extraction service with mocked dependencies"""
+    return ExtractionService(
+        pdf_service=mock_pdf_service,
+        llm_service=mock_llm_service,
+        keep_pdfs=True,
+    )
+
+
+@pytest.fixture
+def sample_papers():
+    """Create list of sample paper metadata"""
+    papers = []
+    for i in range(3):
+        papers.append(
+            PaperMetadata(
+                paper_id=f"paper_{i}",
+                title=f"Test Paper {i}",
+                abstract=f"Abstract for paper {i}",
+                url=f"https://example.com/paper_{i}",
+                authors=[Author(name=f"Author {i}")],
+                year=2023,
+                open_access_pdf=f"https://example.com/paper_{i}.pdf",
+            )
+        )
+    return papers
+
+
+class TestEmptyBatch:
+    """Tests for empty batch handling"""
+
+    @pytest.mark.asyncio
+    async def test_empty_batch_returns_empty_list(self, extraction_service):
+        """Test processing of empty paper list"""
+        results = await extraction_service.process_papers(papers=[], targets=[])
+        assert results == []
+
+
+class TestPapersWithoutPDF:
+    """Tests for papers without open access PDF"""
+
+    @pytest.mark.asyncio
+    async def test_paper_without_pdf_url_uses_abstract(
+        self, extraction_service, mock_llm_service
+    ):
+        """Test processing paper without PDF URL"""
+        paper = PaperMetadata(
+            paper_id="no_pdf_paper",
+            title="No PDF Paper",
+            abstract="This paper has no PDF",
+            url="https://example.com/no_pdf",
+            authors=[Author(name="Test Author")],
+            year=2023,
+            open_access_pdf=None,
+        )
+
+        extraction = PaperExtraction(
+            paper_id=paper.paper_id,
+            extraction_results=[],
+            tokens_used=500,
+            cost_usd=0.005,
+        )
+        mock_llm_service.extract = AsyncMock(return_value=extraction)
+
+        result = await extraction_service.process_paper(paper, [])
+
+        assert result is not None
+        assert result.pdf_available is False
+
+
+class TestExtractionSummary:
+    """Tests for extraction summary functionality"""
+
+    def test_summary_with_mixed_results(self, extraction_service):
+        """Test summary calculation with mixed results"""
+        paper1 = PaperMetadata(
+            paper_id="p1",
+            title="Paper 1",
+            abstract="Abstract 1",
+            url="https://example.com/1",
+            authors=[Author(name="Author")],
+            year=2023,
+        )
+        paper2 = PaperMetadata(
+            paper_id="p2",
+            title="Paper 2",
+            abstract="Abstract 2",
+            url="https://example.com/2",
+            authors=[Author(name="Author")],
+            year=2023,
+        )
+
+        extraction = PaperExtraction(
+            paper_id="p1",
+            extraction_results=[],
+            tokens_used=1000,
+            cost_usd=0.01,
+        )
+
+        results = [
+            ExtractedPaper(metadata=paper1, pdf_available=True, extraction=extraction),
+            ExtractedPaper(metadata=paper2, pdf_available=False, extraction=extraction),
+        ]
+
+        summary = extraction_service.get_extraction_summary(results)
+
+        assert summary["total_papers"] == 2
+        assert summary["papers_with_pdf"] == 1
+        assert summary["pdf_success_rate"] == 50.0
+
+
+class TestPDFDownloadFailure:
+    """Tests for PDF download failure fallback"""
+
+    @pytest.mark.asyncio
+    async def test_pdf_failure_falls_back_to_abstract(
+        self, extraction_service, mock_pdf_service, mock_llm_service
+    ):
+        """Test fallback to abstract when PDF download fails"""
+        paper = PaperMetadata(
+            paper_id="fail_paper",
+            title="Failing Paper",
+            abstract="Test abstract content",
+            url="https://example.com/fail",
+            authors=[Author(name="Test Author")],
+            year=2023,
+            open_access_pdf="https://example.com/fail.pdf",
+        )
+
+        mock_pdf_service.download_pdf = AsyncMock(
+            side_effect=PDFDownloadError("Network error")
+        )
+
+        extraction = PaperExtraction(
+            paper_id=paper.paper_id,
+            extraction_results=[],
+            tokens_used=500,
+            cost_usd=0.005,
+        )
+        mock_llm_service.extract = AsyncMock(return_value=extraction)
+
+        result = await extraction_service.process_paper(paper, [])
+
+        assert result is not None
+        assert result.pdf_available is False
+        assert result.extraction == extraction

--- a/tests/unit/test_services/test_llm_service_failures.py
+++ b/tests/unit/test_services/test_llm_service_failures.py
@@ -1,0 +1,150 @@
+"""LLM Service Failure Scenario Tests
+
+Additional tests for edge cases in LLM service response parsing.
+"""
+
+import pytest
+from unittest.mock import Mock, patch
+
+from src.services.llm_service import LLMService
+from src.models.llm import LLMConfig, CostLimits
+from src.models.extraction import ExtractionTarget
+from src.utils.exceptions import JSONParseError
+
+
+@pytest.fixture
+def anthropic_config():
+    """Create test Anthropic LLM configuration"""
+    return LLMConfig(
+        provider="anthropic",
+        model="claude-3-5-sonnet-20250122",
+        api_key="sk-ant-test12345",
+        max_tokens=100000,
+        temperature=0.0,
+        timeout=300,
+    )
+
+
+@pytest.fixture
+def cost_limits():
+    """Create test cost limits"""
+    return CostLimits(
+        max_tokens_per_paper=100000,
+        max_daily_spend_usd=50.0,
+        max_total_spend_usd=500.0,
+    )
+
+
+@pytest.fixture
+def extraction_targets():
+    """Create test extraction targets"""
+    return [
+        ExtractionTarget(
+            name="system_prompts",
+            description="Extract system prompts",
+            output_format="list",
+            required=False,
+        ),
+    ]
+
+
+class TestResponseParsingEdgeCases:
+    """Tests for response parsing edge cases"""
+
+    def test_parse_response_with_non_json_text(
+        self, anthropic_config, cost_limits, extraction_targets
+    ):
+        """Test handling of non-JSON response text"""
+        with patch("anthropic.AsyncAnthropic"):
+            service = LLMService(anthropic_config, cost_limits)
+
+            mock_response = Mock()
+            mock_response.content = [Mock(text="This is plain text, not JSON")]
+
+            with pytest.raises(JSONParseError):
+                service._parse_response(mock_response, extraction_targets)
+
+    def test_parse_response_with_malformed_json(
+        self, anthropic_config, cost_limits, extraction_targets
+    ):
+        """Test handling of malformed JSON"""
+        with patch("anthropic.AsyncAnthropic"):
+            service = LLMService(anthropic_config, cost_limits)
+
+            mock_response = Mock()
+            mock_response.content = [Mock(text="{invalid json structure")]
+
+            with pytest.raises(JSONParseError):
+                service._parse_response(mock_response, extraction_targets)
+
+    def test_parse_response_missing_extractions_key(
+        self, anthropic_config, cost_limits, extraction_targets
+    ):
+        """Test handling of JSON without extractions key"""
+        with patch("anthropic.AsyncAnthropic"):
+            service = LLMService(anthropic_config, cost_limits)
+
+            mock_response = Mock()
+            mock_response.content = [Mock(text='{"wrong_key": []}')]
+
+            with pytest.raises(JSONParseError):
+                service._parse_response(mock_response, extraction_targets)
+
+
+class TestCostCalculationEdgeCases:
+    """Tests for cost calculation edge cases"""
+
+    def test_calculate_cost_anthropic_zero_tokens(self, anthropic_config, cost_limits):
+        """Test cost calculation with zero tokens"""
+        with patch("anthropic.AsyncAnthropic"):
+            service = LLMService(anthropic_config, cost_limits)
+
+            mock_usage = Mock()
+            mock_usage.input_tokens = 0
+            mock_usage.output_tokens = 0
+
+            cost = service._calculate_cost_anthropic(mock_usage)
+            assert cost == 0.0
+
+    def test_calculate_cost_anthropic_large_tokens(self, anthropic_config, cost_limits):
+        """Test cost calculation with large token counts"""
+        with patch("anthropic.AsyncAnthropic"):
+            service = LLMService(anthropic_config, cost_limits)
+
+            mock_usage = Mock()
+            mock_usage.input_tokens = 1000000  # 1M tokens
+            mock_usage.output_tokens = 100000  # 100K tokens
+
+            cost = service._calculate_cost_anthropic(mock_usage)
+            # Expected: (1M/1M * 3.00) + (100K/1M * 15.00) = 3.0 + 1.5 = 4.5
+            assert abs(cost - 4.5) < 0.01
+
+
+class TestProviderInitialization:
+    """Tests for provider initialization"""
+
+    def test_anthropic_initialization(self, anthropic_config, cost_limits):
+        """Test Anthropic client initialization"""
+        with patch("anthropic.AsyncAnthropic") as mock_client:
+            service = LLMService(anthropic_config, cost_limits)
+
+            assert service.client is not None
+            mock_client.assert_called_once_with(api_key=anthropic_config.api_key)
+
+    def test_google_initialization(self, cost_limits):
+        """Test Google client initialization"""
+        config = LLMConfig(
+            provider="google",
+            model="gemini-1.5-pro",
+            api_key="google-test-key",
+        )
+
+        with (
+            patch("google.generativeai.configure") as mock_configure,
+            patch("google.generativeai.GenerativeModel") as mock_model,
+        ):
+            service = LLMService(config, cost_limits)
+
+            assert service.client is not None
+            mock_configure.assert_called_once_with(api_key=config.api_key)
+            mock_model.assert_called_once_with(config.model)

--- a/tests/unit/test_services/test_pdf_edge_cases.py
+++ b/tests/unit/test_services/test_pdf_edge_cases.py
@@ -1,0 +1,150 @@
+"""PDF Service Edge Case Tests
+
+Additional tests for PDF service validation and sanitization.
+"""
+
+import pytest
+from pathlib import Path
+import tempfile
+
+from src.services.pdf_service import PDFService
+from src.utils.exceptions import PDFDownloadError
+
+
+@pytest.fixture
+def temp_dir():
+    """Create temporary directory for tests"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir)
+
+
+@pytest.fixture
+def pdf_service(temp_dir):
+    """Create PDF service instance"""
+    return PDFService(temp_dir=temp_dir, max_size_mb=10, timeout_seconds=30)
+
+
+@pytest.fixture
+def valid_pdf_bytes():
+    """Create valid PDF magic bytes"""
+    return b"%PDF-1.4\n%test content\n%%EOF"
+
+
+class TestPDFValidation:
+    """Tests for PDF validation functionality"""
+
+    def test_validate_pdf_with_valid_file(self, pdf_service, temp_dir, valid_pdf_bytes):
+        """Test validation passes for valid PDF"""
+        pdf_path = temp_dir / "valid.pdf"
+        pdf_path.write_bytes(valid_pdf_bytes)
+
+        result = pdf_service.validate_pdf(pdf_path)
+        assert result is True
+
+    def test_validate_pdf_with_empty_file(self, pdf_service, temp_dir):
+        """Test validation fails for empty file"""
+        pdf_path = temp_dir / "empty.pdf"
+        pdf_path.write_bytes(b"")
+
+        result = pdf_service.validate_pdf(pdf_path)
+        assert result is False
+
+    def test_validate_pdf_with_non_pdf_content(self, pdf_service, temp_dir):
+        """Test validation fails for non-PDF content"""
+        pdf_path = temp_dir / "not_pdf.pdf"
+        pdf_path.write_bytes(b"This is not a PDF file")
+
+        result = pdf_service.validate_pdf(pdf_path)
+        assert result is False
+
+    def test_validate_pdf_with_html_content(self, pdf_service, temp_dir):
+        """Test validation fails for HTML content"""
+        pdf_path = temp_dir / "fake.pdf"
+        pdf_path.write_bytes(b"<!DOCTYPE html><html><body>Not a PDF</body></html>")
+
+        result = pdf_service.validate_pdf(pdf_path)
+        assert result is False
+
+    def test_validate_pdf_nonexistent_file(self, pdf_service, temp_dir):
+        """Test validation handles nonexistent file"""
+        pdf_path = temp_dir / "nonexistent.pdf"
+
+        result = pdf_service.validate_pdf(pdf_path)
+        assert result is False
+
+
+class TestFilenameSanitization:
+    """Tests for filename sanitization functionality"""
+
+    def test_sanitize_removes_path_traversal(self, pdf_service):
+        """Test sanitization removes path traversal attempts"""
+        dangerous_name = "../../../etc/passwd"
+        sanitized = pdf_service._sanitize_filename(dangerous_name)
+
+        assert "/" not in sanitized
+        assert ".." not in sanitized
+
+    def test_sanitize_removes_null_bytes(self, pdf_service):
+        """Test sanitization removes null bytes"""
+        dangerous_name = "file\x00name.pdf"
+        sanitized = pdf_service._sanitize_filename(dangerous_name)
+
+        assert "\x00" not in sanitized
+
+    def test_sanitize_preserves_extension(self, pdf_service):
+        """Test sanitization preserves file extension"""
+        name = "paper_v2.0_(final).pdf"
+        sanitized = pdf_service._sanitize_filename(name)
+
+        assert sanitized.endswith(".pdf")
+
+    def test_sanitize_handles_hidden_files(self, pdf_service):
+        """Test sanitization makes hidden files visible"""
+        hidden_name = ".hidden_file.pdf"
+        sanitized = pdf_service._sanitize_filename(hidden_name)
+
+        assert not sanitized.startswith(".")
+
+
+class TestDownloadErrors:
+    """Tests for download error handling"""
+
+    @pytest.mark.asyncio
+    async def test_download_non_https_url_rejected(self, pdf_service):
+        """Test that non-HTTPS URLs are rejected"""
+        with pytest.raises(PDFDownloadError) as exc_info:
+            await pdf_service.download_pdf(
+                url="http://example.com/paper.pdf", paper_id="test123"
+            )
+
+        assert "HTTPS" in str(exc_info.value)
+
+
+class TestServiceInitialization:
+    """Tests for service initialization"""
+
+    def test_creates_temp_directories(self, temp_dir):
+        """Test that service creates required temp directories"""
+        service = PDFService(temp_dir=temp_dir)
+
+        assert service.pdf_dir.exists()
+        assert service.markdown_dir.exists()
+
+    def test_resolves_temp_dir_to_absolute(self, temp_dir):
+        """Test that temp_dir is resolved to absolute path"""
+        service = PDFService(temp_dir=temp_dir)
+
+        assert service.temp_dir.is_absolute()
+
+    def test_custom_size_limit(self, temp_dir):
+        """Test custom file size limit"""
+        service = PDFService(temp_dir=temp_dir, max_size_mb=5)
+
+        expected_bytes = 5 * 1024 * 1024
+        assert service.max_size_bytes == expected_bytes
+
+    def test_custom_timeout(self, temp_dir):
+        """Test custom timeout setting"""
+        service = PDFService(temp_dir=temp_dir, timeout_seconds=600)
+
+        assert service.timeout_seconds == 600


### PR DESCRIPTION
## Summary
Addresses technical debt by implementing comprehensive edge case tests for LLM service, PDF service, and batch processing.

## Changes
- **Added:** LLM service failure tests (`test_llm_service_failures.py`)
  - Response parsing edge cases (malformed JSON, missing keys)
  - Cost calculation edge cases
  - Provider initialization tests
- **Added:** PDF service edge case tests (`test_pdf_edge_cases.py`)
  - PDF validation (empty, invalid, HTML, non-PDF content)
  - Filename sanitization (path traversal, null bytes, hidden files)
  - Download error handling (non-HTTPS rejection)
  - Service initialization verification
- **Added:** Batch processing edge case tests (`test_batch_edge_cases.py`)
  - Empty batch handling
  - Papers without PDF URL
  - Extraction summary calculation
  - PDF download failure fallback

## Test Coverage
- **Total Tests:** 416 (25 new tests added)
- **Pass Rate:** 100% (0 failures)
- **Coverage:** 99.24% overall (exceeds ≥95% requirement)

## Verification
All quality gates passed:
- ✅ Black formatting
- ✅ Flake8 linting (0 issues)
- ✅ Mypy type checking (0 errors)
- ✅ Pytest (100% pass rate)
- ✅ Coverage ≥95% per module

## Test plan
- [x] Run `./verify.sh` locally - all checks pass
- [x] Ensure new tests cover previously untested edge cases
- [x] Verify no regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)