### PR TITLE
fix: Enable multi-provider discovery and fix ArXiv ID validation

### DIFF
--- a/config/research_config.yaml
+++ b/config/research_config.yaml
@@ -97,6 +97,14 @@ settings:
     enable_backpressure: true
     backpressure_threshold: 0.8
 
+  # Provider Selection (Phase 3.2 Multi-Provider)
+  # Enables querying multiple academic sources per topic
+  provider_selection:
+    benchmark_mode: true  # Query ALL providers for each topic (ArXiv + Semantic Scholar + HuggingFace)
+    auto_select: false    # Disable auto-selection when benchmark_mode is true
+    fallback_enabled: true
+    fallback_timeout_seconds: 30
+
   # Cache Settings (Phase 3)
   cache:
     enabled: true

--- a/src/models/registry.py
+++ b/src/models/registry.py
@@ -120,8 +120,10 @@ class RegistryEntry(BaseModel):
 
             # Validate ArXiv ID format
             elif key == "arxiv":
-                # ArXiv: YYMM.NNNNN or category/YYMMNNN
-                if not re.match(r"^(\d{4}\.\d{4,5}|[a-z-]+/\d{7})$", value):
+                # ArXiv: YYMM.NNNNN[vN] or category/YYMMNNN[vN] (with optional version)
+                if not re.match(
+                    r"^(\d{4}\.\d{4,5}(v\d+)?|[a-z-]+/\d{7}(v\d+)?)$", value
+                ):
                     raise ValueError(f"Invalid ArXiv ID format: {value}")
 
             # Validate Semantic Scholar ID (alphanumeric, 40 chars hex)

--- a/src/orchestration/pipeline.py
+++ b/src/orchestration/pipeline.py
@@ -170,7 +170,8 @@ class ResearchPipeline:
 
         # Core services
         discovery_service = DiscoveryService(
-            api_key=config.settings.semantic_scholar_api_key or ""
+            api_key=config.settings.semantic_scholar_api_key or "",
+            config=config.settings.provider_selection,
         )
 
         catalog_service = CatalogService(config_manager)

--- a/tests/unit/test_cli_coverage.py
+++ b/tests/unit/test_cli_coverage.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, patch, AsyncMock
 
 from src.cli import app
 from src.services.config_manager import ConfigValidationError
-from src.orchestration.research_pipeline import PipelineResult
+from src.orchestration import PipelineResult
 
 runner = CliRunner()
 
@@ -151,13 +151,13 @@ class TestCLICoverage:
             mock_config.settings.llm_settings = None
             mock_config.settings.cost_limits = None
             mock_config.settings.semantic_scholar_api_key = None
+            mock_config.settings.provider_selection = None
             mock_config.research_topics = [Mock(query="topic1")]
 
             mock_cm.return_value.load_config.return_value = mock_config
 
-            with patch(
-                "src.orchestration.research_pipeline.ResearchPipeline"
-            ) as mock_pipeline_class:
+            # Patch at the package level where CLI imports from
+            with patch("src.orchestration.ResearchPipeline") as mock_pipeline_class:
                 mock_result = PipelineResult()
                 mock_result.topics_processed = 0
                 mock_result.topics_failed = 1


### PR DESCRIPTION
## Summary

This PR enables multi-provider paper discovery and fixes bugs found during QA testing:

- **ArXiv ID validation**: IDs with version suffixes (e.g., `2602.22966v1`) were incorrectly rejected
- **Test mock path**: `test_run_with_errors` was failing due to incorrect mock location  
- **Provider config**: `provider_selection` config was not being passed to DiscoveryService
- **Multi-provider mode**: Enabled `benchmark_mode` to query ALL providers per topic

## Changes

| File | Change |
|------|--------|
| `src/models/registry.py` | Fix ArXiv ID regex to allow version suffixes (`v1`, `v2`, etc.) |
| `src/orchestration/pipeline.py` | Pass `provider_selection` config to DiscoveryService |
| `tests/unit/test_cli_coverage.py` | Fix mock path and import deprecation warning |
| `config/research_config.yaml` | Add `provider_selection` block with `benchmark_mode: true` |

## Bug Details

### ArXiv ID Validation
```python
# Before - rejects "2602.22966v1"
r"^(\d{4}\.\d{4,5}|[a-z-]+/\d{7})$"

# After - accepts version suffixes
r"^(\d{4}\.\d{4,5}(v\d+)?|[a-z-]+/\d{7}(v\d+)?)$"
```

### Provider Selection Config
```python
# Before - config not passed
discovery_service = DiscoveryService(api_key=...)

# After - config passed for benchmark_mode
discovery_service = DiscoveryService(api_key=..., config=config.settings.provider_selection)
```

### Multi-Provider Configuration
```yaml
provider_selection:
  benchmark_mode: true  # Query ALL providers (ArXiv + Semantic Scholar + HuggingFace)
  auto_select: false
  fallback_enabled: true
  fallback_timeout_seconds: 30
```

## Test Plan

- [x] `test_run_with_errors` now passes (was failing)
- [x] ArXiv ID with version suffix accepted: `{'arxiv': '2602.22966v1'}`
- [x] 1902 tests pass (2 pre-existing flaky LLM tests)
- [x] Coverage: 99.22% (meets ≥99% requirement)
- [x] Black/Flake8/Mypy pass