### PR TITLE
docs: sync README and PHASED_DELIVERY_PLAN to Phase 8.1 (post-PR #89)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Python 3.14](https://img.shields.io/badge/python-3.14-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Security: High](https://img.shields.io/badge/security-high-green.svg)](docs/security/)
-[![Test Coverage: 99%](https://img.shields.io/badge/coverage-99%25-brightgreen.svg)](tests/)
+[![Test Coverage: 99.25%](https://img.shields.io/badge/coverage-99.25%25-brightgreen.svg)](tests/)
 
 ## 🎯 Overview
 
@@ -15,7 +15,7 @@ ARISP automates the research process by:
 - 🤖 **Extracting** prompts, code, and insights using LLM (Claude/Gemini)
 - 📝 **Synthesizing** Obsidian-ready markdown briefs for engineering teams
 
-**✨ Phase 8.1 Complete:** Corpus Infrastructure for Deep Research Agent — hybrid search (FAISS + BM25), paper ingestion pipeline, semantic chunking, and trajectory storage. Plus full Intelligence Services Consolidation (Phase 1), Human Feedback Loop (Phase 7.3), and 3,642 tests at 99%+ coverage!
+**✨ Phase 8.1 Complete:** Corpus Infrastructure for Deep Research Agent — paper ingestion pipeline, semantic chunking, and trajectory storage. Plus Intelligence Services Consolidation Phase 1 (Core Services), Human Feedback Loop (Phase 7.3), and 3,642 tests at 99.25% coverage!
 
 ## ✨ Key Features
 
@@ -50,15 +50,16 @@ ARISP automates the research process by:
 - **Full Integration**: Works with cache, dedup, filter, and checkpoint services
 
 ### Production (Phase 4) ✅ Complete
-- **Observable**: Structured logging, Prometheus metrics, Grafana dashboards
-- **Resilient**: Retry logic, circuit breakers, checkpoint/resume
+- **Observable**: Structured logging with correlation IDs, Prometheus metrics, Grafana dashboards
+- **Resilient**: Infrastructure-level checkpoint/resume, graceful degradation (complements Phase 3.3's LLM-level retries)
 - **Secure**: Security-first design, secrets scanning, input validation
 
-### Global Registry & CLI (Phase 5.x) ✅ Complete
-- **Paper Registry**: Global paper identity with Semantic Scholar, ArXiv, HuggingFace integration
-- **LLM Decomposition**: Break complex queries into targeted search strategies
-- **Research Pipeline**: Multi-source discovery with cross-provider deduplication
+### CLI & Pipeline Decomposition (Phase 5.x) ✅ Complete
+*Builds on Phase 3.5's Global Registry foundation*
+- **LLM Service Decomposition**: Modular provider architecture (Anthropic, Google)
+- **Research Pipeline Phases**: Separated Discovery, Extraction, Synthesis, CrossSynthesis
 - **CLI Commands**: Full command-line interface for all pipeline operations
+- **Query Decomposition**: Break complex queries into targeted search strategies
 
 ### Enhanced Discovery (Phase 6) ✅ Complete
 - **Multi-Provider Orchestration**: Unified discovery across ArXiv, Semantic Scholar, HuggingFace
@@ -74,11 +75,11 @@ ARISP automates the research process by:
 - **VenueRepository**: YAML-based venue quality scoring with LRU caching
 - **QualityIntelligenceService**: Unified quality scoring with recency decay
 - **QueryIntelligenceService**: Provider selection and LLM-powered query expansion
-- **Hybrid Search**: FAISS + BM25 retrieval outperforming dense-only approaches
+- **Hybrid Search Service**: FAISS + BM25 retrieval infrastructure (applied by DRA in Phase 8.1)
 
 ### Deep Research Agent — Corpus (Phase 8.1) ✅ Complete
 - **Corpus Manager**: Offline indexed corpus from ARISP papers with semantic chunking
-- **Hybrid Retrieval**: FAISS + BM25 hybrid search with <200ms latency targets
+- **Hybrid Retrieval**: Applies Phase 7.x's FAISS + BM25 service to DRA corpus (<200ms latency)
 - **Paper Ingestion**: Automated pipeline to index and search over all discovered papers
 - **Trajectory Storage**: Batch trajectory storage for learning from research sessions
 
@@ -234,10 +235,11 @@ output/
 - [Phase 3: Intelligence Layer](docs/specs/PHASE_3_SPEC.md) - ✅ Complete (Cache, Dedup, Filters, Checkpoint)
 - [Phase 3.1: Concurrent Orchestration](docs/specs/PHASE_3.1_SPEC.md) - ✅ Complete (Async Workers & Resource Limiting)
 - [Phase 3.3: LLM Resilience](docs/specs/PHASE_3.3_LLM_FALLBACK_SPEC.md) - ✅ Complete (Retry, Circuit Breaker, Provider Failover)
-- [Phase 3.4: Multi-Provider Discovery](docs/specs/PHASE_3.4_PDF_PRIORITY_SPEC.md) - ✅ Complete (HuggingFace, Cross-Provider)
+- [Phase 3.4: Quality-First Discovery](docs/specs/PHASE_3.4_PDF_PRIORITY_SPEC.md) - ✅ Complete (Quality Ranking, PDF Availability Tracking)
 - [Phase 3.5: Global Registry](docs/specs/PHASE_3.5_SPEC.md) - ✅ Complete (Paper Identity & Registry)
 - [Phase 3.6: Delta Briefs](docs/specs/PHASE_3.6_SPEC.md) - ✅ Complete (Topic-Level Change Tracking)
-- [Phase 3.8: Cross-Topic Synthesis](docs/specs/PHASE_3.8_SPEC.md) - ✅ Complete (Multi-Topic Query Synthesis)
+- Phase 3.7: Cross-Topic Synthesis - ✅ Complete (LLM-Powered Multi-Topic Analysis; see [Phased Delivery Plan](docs/PHASED_DELIVERY_PLAN.md#phase-37-cross-topic-synthesis))
+- [Phase 3.8: Cross-Topic Synthesis Output](docs/specs/PHASE_3.8_SPEC.md) - ✅ Complete (Multi-Topic Query Synthesis)
 - [Phase 4: Production Hardening](docs/specs/PHASE_4_SPEC.md) - ✅ Complete (Observability, Security, Deployment)
 - [Phase 5.x: CLI & Decomposition](docs/specs/PHASE_5_OVERVIEW.md) - ✅ Complete (CLI, LLM Decomposition, Research Pipeline)
 - [Phase 6: Enhanced Discovery](docs/specs/PHASE_6_DISCOVERY_ENHANCEMENT_SPEC.md) - ✅ Complete (Multi-Provider Orchestration)
@@ -258,7 +260,7 @@ output/
 
 ## 🏗️ Project Status
 
-**Current Status:** ✅ **Phase 8.1 Complete** - Corpus Infrastructure for Deep Research Agent + Intelligence Services Consolidation Phase 1 (PR #89 merged 2026-04-13). Full production pipeline with 3,642 tests at 99%+ coverage.
+**Current Status:** ✅ **Phase 8.1 Complete** - Corpus Infrastructure for Deep Research Agent + Intelligence Services Consolidation Phase 1 (Core Services) (PR #89 merged 2026-04-13). Full production pipeline with 3,642 tests at 99.25% coverage.
 
 **Next Phase:** 📋 **Phase 8.2: DRA Agent Loop** (ReAct-style reasoning) or **Phase 9 planning** - Autonomous research agent with trajectory learning.
 
@@ -452,4 +454,4 @@ timeframe:
 
 **Built with ❤️ for research teams who want to stay ahead**
 
-**Status**: Phase 8.1 Complete - Corpus Infrastructure for Deep Research Agent + Intelligence Services Consolidation Phase 1. 3,642 tests, 99%+ coverage 🚀
+**Status**: Phase 8.1 Complete - Corpus Infrastructure for Deep Research Agent + Intelligence Services Consolidation Phase 1 (Core Services). 3,642 tests, 99.25% coverage 🚀

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ ARISP automates the research process by:
 - 🤖 **Extracting** prompts, code, and insights using LLM (Claude/Gemini)
 - 📝 **Synthesizing** Obsidian-ready markdown briefs for engineering teams
 
-**✨ Phase 3.1 Complete:** Concurrent orchestration with async worker pools, intelligent resource limiting, and full integration with intelligence layer - 99% test coverage, 442 tests!
+**✨ Phase 8.1 Complete:** Corpus Infrastructure for Deep Research Agent — hybrid search (FAISS + BM25), paper ingestion pipeline, semantic chunking, and trajectory storage. Plus full Intelligence Services Consolidation (Phase 1), Human Feedback Loop (Phase 7.3), and 3,642 tests at 99%+ coverage!
 
 ## ✨ Key Features
 
@@ -49,10 +49,38 @@ ARISP automates the research process by:
 - **Graceful Degradation**: Individual paper failures don't block pipeline
 - **Full Integration**: Works with cache, dedup, filter, and checkpoint services
 
-### Production (Phase 4)
+### Production (Phase 4) ✅ Complete
 - **Observable**: Structured logging, Prometheus metrics, Grafana dashboards
 - **Resilient**: Retry logic, circuit breakers, checkpoint/resume
 - **Secure**: Security-first design, secrets scanning, input validation
+
+### Global Registry & CLI (Phase 5.x) ✅ Complete
+- **Paper Registry**: Global paper identity with Semantic Scholar, ArXiv, HuggingFace integration
+- **LLM Decomposition**: Break complex queries into targeted search strategies
+- **Research Pipeline**: Multi-source discovery with cross-provider deduplication
+- **CLI Commands**: Full command-line interface for all pipeline operations
+
+### Enhanced Discovery (Phase 6) ✅ Complete
+- **Multi-Provider Orchestration**: Unified discovery across ArXiv, Semantic Scholar, HuggingFace
+- **Provider Abstraction**: Pluggable provider interface with health tracking
+- **Benchmark Mode**: Cross-provider comparison and quality scoring
+
+### Human Feedback Loop (Phase 7.3) ✅ Complete
+- **Preference Learning**: User feedback drives paper relevance scoring
+- **Semantic Similarity**: Embedding-based topic matching for smarter discovery
+- **Feedback Integration**: Phase 7.3 loop wired into the discovery pipeline
+
+### Intelligence Services Consolidation (Phase 7.x) ✅ Complete
+- **VenueRepository**: YAML-based venue quality scoring with LRU caching
+- **QualityIntelligenceService**: Unified quality scoring with recency decay
+- **QueryIntelligenceService**: Provider selection and LLM-powered query expansion
+- **Hybrid Search**: FAISS + BM25 retrieval outperforming dense-only approaches
+
+### Deep Research Agent — Corpus (Phase 8.1) ✅ Complete
+- **Corpus Manager**: Offline indexed corpus from ARISP papers with semantic chunking
+- **Hybrid Retrieval**: FAISS + BM25 hybrid search with <200ms latency targets
+- **Paper Ingestion**: Automated pipeline to index and search over all discovered papers
+- **Trajectory Storage**: Batch trajectory storage for learning from research sessions
 
 ## 🚀 Quick Start
 
@@ -205,14 +233,23 @@ output/
 - [Phase 2.5: PDF Reliability](docs/specs/PHASE_2.5_SPEC.md) - ✅ Complete (Multi-Backend Fallback Chain)
 - [Phase 3: Intelligence Layer](docs/specs/PHASE_3_SPEC.md) - ✅ Complete (Cache, Dedup, Filters, Checkpoint)
 - [Phase 3.1: Concurrent Orchestration](docs/specs/PHASE_3.1_SPEC.md) - ✅ Complete (Async Workers & Resource Limiting)
-- [Phase 3.2: Semantic Scholar Activation](docs/specs/PHASE_3.2_SPEC.md) - 🎯 Ready (Multi-Provider Intelligence)
-- [Phase 4: Hardening](docs/specs/PHASE_4_SPEC.md) - 📋 Planned (Production Readiness)
-- [Phase 8: Deep Research Agent](docs/specs/PHASE_8_DRA_SPEC.md) - 📋 Planned (Autonomous Research Agent)
+- [Phase 3.3: LLM Resilience](docs/specs/PHASE_3.3_LLM_FALLBACK_SPEC.md) - ✅ Complete (Retry, Circuit Breaker, Provider Failover)
+- [Phase 3.4: Multi-Provider Discovery](docs/specs/PHASE_3.4_PDF_PRIORITY_SPEC.md) - ✅ Complete (HuggingFace, Cross-Provider)
+- [Phase 3.5: Global Registry](docs/specs/PHASE_3.5_SPEC.md) - ✅ Complete (Paper Identity & Registry)
+- [Phase 3.6: Delta Briefs](docs/specs/PHASE_3.6_SPEC.md) - ✅ Complete (Topic-Level Change Tracking)
+- [Phase 3.8: Cross-Topic Synthesis](docs/specs/PHASE_3.8_SPEC.md) - ✅ Complete (Multi-Topic Query Synthesis)
+- [Phase 4: Production Hardening](docs/specs/PHASE_4_SPEC.md) - ✅ Complete (Observability, Security, Deployment)
+- [Phase 5.x: CLI & Decomposition](docs/specs/PHASE_5_OVERVIEW.md) - ✅ Complete (CLI, LLM Decomposition, Research Pipeline)
+- [Phase 6: Enhanced Discovery](docs/specs/PHASE_6_DISCOVERY_ENHANCEMENT_SPEC.md) - ✅ Complete (Multi-Provider Orchestration)
+- [Phase 7.1: Feedback Foundation](docs/specs/PHASE_7.1_SPEC.md) - ✅ Complete (Feedback Data Model)
+- [Phase 7.2: Preference Learning](docs/specs/PHASE_7.2_SPEC.md) - ✅ Complete (Embedding-Based Topic Matching)
+- [Phase 7.3: Human Feedback Loop](docs/specs/PHASE_7.3_SPEC.md) - ✅ Complete (Feedback Integration)
+- [Phase 8.1: DRA Corpus Infrastructure](docs/specs/PHASE_8_DRA_SPEC.md) - ✅ Complete (Hybrid Search, Paper Ingestion, Trajectory Storage)
 
 ### Proposals
 - [Proposal 001: Discovery Provider Strategy](docs/proposals/001_DISCOVERY_PROVIDER_STRATEGY.md) - ✅ Approved & Implemented
 - [Proposal 002: PDF Extraction Reliability](docs/proposals/002_PDF_EXTRACTION_RELIABILITY.md) - ✅ Approved & Implemented
-- [Proposal 004: Deep Research Agent (DRA)](docs/proposals/004_OPENRESEARCHER_OFFLINE_TRAJECTORY_SYNTHESIS.md) - 📋 Draft (Autonomous, Self-Improving Research)
+- [Proposal 004: Deep Research Agent (DRA)](docs/proposals/004_OPENRESEARCHER_OFFLINE_TRAJECTORY_SYNTHESIS.md) - 🔄 Phase 8.1 Complete (Corpus Infrastructure); Agent Loop (8.2) in progress
 
 ### Development
 - [CLAUDE.md](CLAUDE.md) - Development guide for Claude Code integration
@@ -221,9 +258,9 @@ output/
 
 ## 🏗️ Project Status
 
-**Current Status:** ✅ **Phase 3.1 Complete** - Concurrent orchestration with async worker pools, resource limiting, and full integration with intelligence layer.
+**Current Status:** ✅ **Phase 8.1 Complete** - Corpus Infrastructure for Deep Research Agent + Intelligence Services Consolidation Phase 1 (PR #89 merged 2026-04-13). Full production pipeline with 3,642 tests at 99%+ coverage.
 
-**Next Phase:** 📋 **Phase 3.2: Semantic Scholar Activation** or **Phase 4: Production Hardening** - Multi-provider intelligence or observability/monitoring.
+**Next Phase:** 📋 **Phase 8.2: DRA Agent Loop** (ReAct-style reasoning) or **Phase 9 planning** - Autonomous research agent with trajectory learning.
 
 📊 **For detailed progress tracking, timelines, and phase-by-phase completion status, see:**
 → **[Phased Delivery Plan](docs/PHASED_DELIVERY_PLAN.md)** (Single Source of Truth)
@@ -415,4 +452,4 @@ timeframe:
 
 **Built with ❤️ for research teams who want to stay ahead**
 
-**Status**: Phase 3.1 Complete - Concurrent orchestration with async workers, resource limiting, and full intelligence integration. 99.1% coverage, 442 tests 🚀
+**Status**: Phase 8.1 Complete - Corpus Infrastructure for Deep Research Agent + Intelligence Services Consolidation Phase 1. 3,642 tests, 99%+ coverage 🚀

--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ output/
 - [Phase 2.5: PDF Reliability](docs/specs/PHASE_2.5_SPEC.md) - ✅ Complete (Multi-Backend Fallback Chain)
 - [Phase 3: Intelligence Layer](docs/specs/PHASE_3_SPEC.md) - ✅ Complete (Cache, Dedup, Filters, Checkpoint)
 - [Phase 3.1: Concurrent Orchestration](docs/specs/PHASE_3.1_SPEC.md) - ✅ Complete (Async Workers & Resource Limiting)
+- [Phase 3.2: Semantic Scholar Activation](docs/specs/PHASE_3.2_SPEC.md) - ⚙️ Superseded → Semantic Scholar activation implemented as part of Phase 6 (Multi-Provider Orchestration)
 - [Phase 3.3: LLM Resilience](docs/specs/PHASE_3.3_LLM_FALLBACK_SPEC.md) - ✅ Complete (Retry, Circuit Breaker, Provider Failover)
 - [Phase 3.4: Quality-First Discovery](docs/specs/PHASE_3.4_PDF_PRIORITY_SPEC.md) - ✅ Complete (Quality Ranking, PDF Availability Tracking)
 - [Phase 3.5: Global Registry](docs/specs/PHASE_3.5_SPEC.md) - ✅ Complete (Paper Identity & Registry)

--- a/docs/PHASED_DELIVERY_PLAN.md
+++ b/docs/PHASED_DELIVERY_PLAN.md
@@ -1,9 +1,9 @@
 # ARISP Phased Delivery Plan
 **Automated Research Ingestion & Synthesis Pipeline**
 
-**Version:** 2.0
-**Date:** 2026-03-11
-**Status:** Phase 6 Cleanup Complete (Deprecated Modules Removed)
+**Version:** 3.0
+**Date:** 2026-04-13
+**Status:** Phase 8.1 Complete — Deep Research Agent Corpus Infrastructure operational. Intelligence Services Consolidation Phase 1 merged (PR #89).
 
 ---
 
@@ -22,27 +22,35 @@ This document outlines a phased delivery plan to build the Automated Research In
 
 ┌──────────┬──────────┬──────────┬──────────┬──────────┬──────────┬──────────┬──────────┐
 │Phase 3.6 │Phase 3.7 │Phase 5.1 │Phase 5.2 │Phase 5.3 │Phase 5.4 │Phase 5.5 │ Phase 6  │
-│✅Complete│✅Complete│✅Complete│✅Complete│✅Complete│(Future)  │(Future)  │🔄 Core   │
-│          │          │          │          │          │          │          │ Complete │
+│✅Complete│✅Complete│✅Complete│✅Complete│✅Complete│✅Complete│✅Complete│✅Complete│
+│          │          │          │          │          │          │          │          │
 │ Delta    │Cross-    │   LLM    │Research  │   CLI    │ Utility  │ Model    │ Enhanced │
 │ Briefs   │Synthesis │ Decompose│ Pipeline │ Commands │ Patterns │Consolid. │ Discovery│
 └──────────┴──────────┴──────────┴──────────┴──────────┴──────────┴──────────┴──────────┘
 
-┌──────────┬──────────┐
-│ Phase 8  │ Phase 4  │
-│📋Planned │📋Planned │
-│          │          │
-│   DRA    │Production│
-│Autonomous│Hardening │
-│ Research │          │
-└──────────┴──────────┘
+┌──────────┬──────────┬──────────┬──────────┬──────────┐
+│ Phase 7.1│ Phase 7.2│ Phase 7.3│ Phase 8.1│ Phase 4  │
+│✅Complete│✅Complete│✅Complete│✅Complete│✅Complete│
+│          │          │          │          │          │
+│ Feedback │Preference│  Human   │   DRA    │Production│
+│Foundation│ Learning │ Feedback │  Corpus  │Hardening │
+└──────────┴──────────┴──────────┴──────────┴──────────┘
+
+┌──────────┐
+│ Phase 8.2│
+│📋Planned │
+│          │
+│   DRA    │
+│ Agent    │
+│   Loop   │
+└──────────┘
 ```
 
 ### Investment & Returns
 
 | Metric | Value |
 |--------|-------|
-| **Development Time** | 3-4 weeks remaining |
+| **Development Time** | Phase 8.1 complete; Phase 8.2 (Agent Loop) in progress |
 | **Team Size** | 2-3 engineers |
 | **Infrastructure Cost** | ~$100/month (LLM + hosting) |
 | **Expected Savings** | 15+ hours/week of manual research |
@@ -254,8 +262,8 @@ Despite retrieving 90+ papers, the synthesis phase covered 0 topics due to poor 
 ---
 
 ### Phase 8: Deep Research Agent (DRA)
-**Status:** 📋 **PLANNED**
-**Duration:** 4-5 weeks
+**Status:** 🔄 **Phase 8.1 Complete** (PR #83 merged 2026-04-05); Phase 8.2+ in progress
+**Duration:** 4-5 weeks total
 **Dependencies:** Phase 3.5 (Global Registry), Phase 5.1 (LLM Service Decomposition), Phase 6 Core (Enhanced Discovery, optional)
 **Goal:** Autonomous, self-improving research agent with iterative reasoning and trajectory learning
 

--- a/docs/PHASED_DELIVERY_PLAN.md
+++ b/docs/PHASED_DELIVERY_PLAN.md
@@ -48,13 +48,13 @@ This document outlines a phased delivery plan to build the Automated Research In
 
 ### Investment & Returns
 
-| Metric | Value |
-|--------|-------|
-| **Development Time** | Phase 8.1 complete; Phase 8.2 (Agent Loop) in progress |
-| **Team Size** | 2-3 engineers |
-| **Infrastructure Cost** | ~$100/month (LLM + hosting) |
-| **Expected Savings** | 15+ hours/week of manual research |
-| **ROI Timeframe** | 2-3 months |
+| Metric | Estimate | Current Status |
+|--------|----------|----------------|
+| **Development Time** | 6-8 weeks total | Phase 8.1 complete; Phase 8.2 in progress |
+| **Team Size** | 2-3 engineers | — |
+| **Infrastructure Cost** | ~$100/month (LLM + hosting) | — |
+| **Expected Savings** | 15+ hours/week of manual research | — |
+| **ROI Timeframe** | 2-3 months | — |
 
 ---
 


### PR DESCRIPTION
## Summary

README was showing **Phase 3.1 Complete** but the codebase is actually at **Phase 8.1+** (PR #83 merged 2026-04-05). This updates all documentation to reflect current reality.

### Changes

**README.md:**
- Status badge: Phase 3.1 → Phase 8.1 (Corpus Infrastructure + Intelligence Consolidation Phase 1)
- Key Features: Added Phase 5.x (Global Registry & CLI), Phase 6 (Enhanced Discovery), Phase 7.x (Human Feedback Loop + Intelligence Services Consolidation), Phase 8.1 (DRA Corpus)
- Phase specs list: Updated all phases through 8.1 as ✅ Complete
- Next Phase: Updated from Phase 3.2 → Phase 8.2 (DRA Agent Loop)
- Proposal 004: Updated from Draft → Phase 8.1 Complete
- Test count: 442 → 3,642 tests

**docs/PHASED_DELIVERY_PLAN.md:**
- Version: 2.0 → 3.0
- Status header: Updated to Phase 8.1 Complete
- Timeline overview diagram: Phase 8.1 and Phase 4 now shown as ✅ Complete
- Investment table: Updated development status

### Why Doc Automation Didn't Catch This

The Documentation Automation spec (Phase A, from PR #61) is still marked **'Phase A In Progress'** — pre-commit hooks and CI drift detection were **not fully operational** when PRs #80, #83, and #89 merged. The doc automation infrastructure was designed to prevent exactly this kind of drift, but it wasn't live yet.

**Action item:** Complete Phase A of the doc automation system before the next major PR to prevent future drift.

### Test Plan
- [x] All 3,642 existing tests still pass (no code changes)
- [x] README renders correctly with updated badges
- [x] Phase spec links verified
- [x] No broken links

---

Reviewed and updated by Joe (Claude Code)