### PR TITLE
fix(discovery): wire settings.enhanced_discovery into DiscoveryPhase mode selection

### DIFF
--- a/.spec-workflow/specs/quality-scoring-consolidation/discovery-orchestration-requirements.md
+++ b/.spec-workflow/specs/quality-scoring-consolidation/discovery-orchestration-requirements.md
@@ -190,10 +190,11 @@ This document extends the Quality Scoring Consolidation specification to address
 
 1. WHEN `DiscoveryPhase.execute()` runs THEN it SHALL call `DiscoveryService.discover()` with appropriate mode based on config
 2. WHEN `multi_source_enabled=True` THEN the phase SHALL use `mode=DEEP`
-3. WHEN `multi_source_enabled=False` AND `enhanced_enabled=True` THEN the phase SHALL use `mode=STANDARD`
-4. WHEN neither is enabled THEN the phase SHALL use `mode=SURFACE`
-5. WHEN discovery completes THEN the phase SHALL use `DiscoveryResult.metrics` directly (no separate stats collection)
-6. WHEN discovery completes THEN the phase SHALL preserve `DiscoveryResult.source_breakdown` for reporting
+3. WHEN `multi_source_enabled=False` AND `settings.enhanced_discovery is not None` THEN the phase SHALL use `mode=STANDARD`
+4. WHEN neither is configured THEN the phase SHALL use `mode=SURFACE`
+5. Precedence: `multi_source_enabled` (DEEP) SHALL take precedence over `enhanced_discovery` (STANDARD) when both are set
+6. WHEN discovery completes THEN the phase SHALL use `DiscoveryResult.metrics` directly (no separate stats collection)
+7. WHEN discovery completes THEN the phase SHALL preserve `DiscoveryResult.source_breakdown` for reporting
 
 ## Non-Functional Requirements
 

--- a/.spec-workflow/specs/quality-scoring-consolidation/tasks.md
+++ b/.spec-workflow/specs/quality-scoring-consolidation/tasks.md
@@ -204,8 +204,9 @@ Tasks are organized by implementation phase as defined in the design document.
 **Acceptance Criteria:**
 - [x] DiscoveryPhase calls `discover()` based on config
 - [x] `multi_source_enabled=True` → mode=DEEP
-- [x] `enhanced_enabled=True` → mode=STANDARD
-- [x] Neither enabled → mode=SURFACE
+- [x] `settings.enhanced_discovery is not None` → mode=STANDARD
+- [x] Neither configured → mode=SURFACE
+- [x] Precedence: multi_source (DEEP) > enhanced_discovery (STANDARD) > SURFACE
 - [x] Use DiscoveryResult.metrics directly (no separate stats)
 - [x] Preserve source_breakdown for reporting
 

--- a/src/orchestration/phases/discovery.py
+++ b/src/orchestration/phases/discovery.py
@@ -219,11 +219,14 @@ class DiscoveryPhase(PipelinePhase[DiscoveryResult]):
                 multi_source=self.multi_source_enabled,
             )
 
-            # Phase 8: Use unified discover() API based on configuration
-            # Determine discovery mode from config flags
+            # Phase 8: Use unified discover() API based on typed config.
+            # Mode selection precedence:
+            #   - Phase 7.2 multi-source (query expansion / citations) → DEEP
+            #   - Phase 6 enhanced_discovery configured → STANDARD
+            #   - Otherwise → SURFACE (fast single-provider default)
             if self.multi_source_enabled:
                 mode = DiscoveryMode.DEEP
-            elif getattr(self.context.config.settings, "enhanced_enabled", False):
+            elif self.context.config.settings.enhanced_discovery is not None:
                 mode = DiscoveryMode.STANDARD
             else:
                 mode = DiscoveryMode.SURFACE

--- a/tests/unit/orchestration/phases/test_discovery.py
+++ b/tests/unit/orchestration/phases/test_discovery.py
@@ -14,6 +14,7 @@ from src.models.config import (
     ResearchTopic,
     TimeframeRecent,
     DiscoveryFilterSettings,
+    EnhancedDiscoveryConfig,
     IncrementalDiscoverySettings,
 )
 from src.models.discovery import (
@@ -30,7 +31,12 @@ from src.services.providers.base import APIError
 
 @pytest.fixture
 def mock_context():
-    """Create mock pipeline context."""
+    """Create mock pipeline context.
+
+    Mirrors a production-default ``GlobalSettings`` shape:
+    no Phase 6 ``enhanced_discovery`` is configured, so DiscoveryPhase
+    selects ``DiscoveryMode.SURFACE`` unless a test overrides it.
+    """
     context = MagicMock(spec=PipelineContext)
     context.config = MagicMock()
     context.config.research_topics = []
@@ -44,6 +50,10 @@ def mock_context():
             enabled=False,
         )
     )
+    # Production default: no Phase 6 enhanced discovery → SURFACE mode.
+    # Explicit None avoids MagicMock's truthy-attribute default masking the
+    # real branch under test.
+    context.config.settings.enhanced_discovery = None
     context.discovery_service = AsyncMock()
     context.catalog_service = MagicMock()
     context.registry_service = None
@@ -228,9 +238,8 @@ class TestDiscoveryPhase:
         mock_context.discovery_service.discover.assert_called_once()
         call_args = mock_context.discovery_service.discover.call_args
         assert call_args[1]["topic"] == "machine learning"
-        # Mode defaults to STANDARD when neither multi_source nor
-        # enhanced_enabled is set
-        assert call_args[1]["mode"] == DiscoveryMode.STANDARD
+        # Default: no multi_source, no enhanced_discovery → SURFACE mode.
+        assert call_args[1]["mode"] == DiscoveryMode.SURFACE
 
     @pytest.mark.asyncio
     async def test_execute_topic_api_error(self, mock_context, sample_topic):
@@ -705,3 +714,86 @@ class TestDiscoveryPhasePhase71Integration:
         assert result.total_papers == 2
         # Paper should still be included, but its date might be None or default
         # Our goal is to hit the 'except ValueError' in _convert_scored_to_metadata()
+
+
+class TestDiscoveryPhaseModeSelection:
+    """Explicit coverage of DiscoveryPhase → DiscoveryMode selection.
+
+    DiscoveryPhase chooses which discover() mode to invoke based on two
+    typed config inputs:
+      - ``multi_source_enabled`` (constructor arg, driven by Phase 7.2
+        query_expansion/citation_exploration config)
+      - ``settings.enhanced_discovery`` (Phase 6 config object; ``None``
+        means "not configured")
+
+    These tests assert each branch deterministically, without relying on
+    MagicMock attribute truthiness.
+    """
+
+    async def _run_and_capture_mode(
+        self, mock_context, sample_topic, sample_scored_papers, **phase_kwargs
+    ) -> DiscoveryMode:
+        """Execute a phase and return the mode passed to discover()."""
+        mock_context.config.research_topics = [sample_topic]
+        mock_context.catalog_service.get_or_create_topic.return_value = MagicMock(
+            topic_slug="machine-learning"
+        )
+        discovery_result = make_discovery_result(sample_scored_papers)
+        mock_context.discovery_service.discover = AsyncMock(
+            return_value=discovery_result
+        )
+
+        phase = DiscoveryPhase(mock_context, **phase_kwargs)
+        await phase.execute()
+
+        mock_context.discovery_service.discover.assert_called_once()
+        return mock_context.discovery_service.discover.call_args[1]["mode"]
+
+    @pytest.mark.asyncio
+    async def test_surface_mode_when_no_features_configured(
+        self, mock_context, sample_topic, sample_scored_papers
+    ):
+        """Default config (no multi_source, no enhanced_discovery) → SURFACE."""
+        # Fixture already sets enhanced_discovery = None.
+        mode = await self._run_and_capture_mode(
+            mock_context, sample_topic, sample_scored_papers
+        )
+        assert mode == DiscoveryMode.SURFACE
+
+    @pytest.mark.asyncio
+    async def test_standard_mode_when_enhanced_discovery_configured(
+        self, mock_context, sample_topic, sample_scored_papers
+    ):
+        """Non-None settings.enhanced_discovery → STANDARD mode."""
+        mock_context.config.settings.enhanced_discovery = EnhancedDiscoveryConfig()
+        mode = await self._run_and_capture_mode(
+            mock_context, sample_topic, sample_scored_papers
+        )
+        assert mode == DiscoveryMode.STANDARD
+
+    @pytest.mark.asyncio
+    async def test_deep_mode_when_multi_source_enabled(
+        self, mock_context, sample_topic, sample_scored_papers
+    ):
+        """multi_source_enabled=True → DEEP mode."""
+        mode = await self._run_and_capture_mode(
+            mock_context,
+            sample_topic,
+            sample_scored_papers,
+            multi_source_enabled=True,
+        )
+        assert mode == DiscoveryMode.DEEP
+
+    @pytest.mark.asyncio
+    async def test_multi_source_takes_precedence_over_enhanced_discovery(
+        self, mock_context, sample_topic, sample_scored_papers
+    ):
+        """When both flags are set, multi_source (DEEP) wins."""
+        mock_context.config.settings.enhanced_discovery = EnhancedDiscoveryConfig()
+        mode = await self._run_and_capture_mode(
+            mock_context,
+            sample_topic,
+            sample_scored_papers,
+            multi_source_enabled=True,
+        )
+        assert mode == DiscoveryMode.DEEP

--- a/tests/unit/pdf_extractors/test_quality_validator.py
+++ b/tests/unit/pdf_extractors/test_quality_validator.py
@@ -42,7 +42,9 @@ def code():
 |--------|-------|
 | Score  | 0.95  |
 
-""" + ("Text content. " * 300)
+""" + (
+        "Text content. " * 300
+    )
 
     score = validator.score_extraction(markdown, Path("dummy.pdf"), page_count=2)
     # With 5+ headers/lists and good density, it should be above 0.65

--- a/tests/unit/services/test_phase_3_4_coverage.py
+++ b/tests/unit/services/test_phase_3_4_coverage.py
@@ -41,11 +41,13 @@ class TestQualityScorerYAMLErrorHandling:
         """Test that ValueError from non-integer scores returns defaults."""
         # Create YAML with non-integer venue score
         invalid_yaml = tmp_path / "invalid_scores.yaml"
-        invalid_yaml.write_text("""
+        invalid_yaml.write_text(
+            """
 venues:
   NeurIPS: "not_a_number"
 default_score: 15
-""")
+"""
+        )
 
         venues, default = load_venue_scores(invalid_yaml)
 
@@ -57,11 +59,13 @@ default_score: 15
         """Test that ValueError from non-integer default_score returns defaults."""
         # Create YAML with non-integer default_score
         invalid_yaml = tmp_path / "invalid_default.yaml"
-        invalid_yaml.write_text("""
+        invalid_yaml.write_text(
+            """
 venues:
   NeurIPS: 30
 default_score: "fifteen"
-""")
+"""
+        )
 
         venues, default = load_venue_scores(invalid_yaml)
 
@@ -74,11 +78,13 @@ default_score: "fifteen"
         # Create YAML with venue score as a list (not an int)
         # This causes TypeError when int() is called on a list
         invalid_yaml = tmp_path / "list_score.yaml"
-        invalid_yaml.write_text("""
+        invalid_yaml.write_text(
+            """
 venues:
   NeurIPS: [30, 25]
 default_score: 15
-""")
+"""
+        )
 
         # int([30, 25]) raises TypeError
         venues, default = load_venue_scores(invalid_yaml)

--- a/tests/unit/test_orchestration/test_research_pipeline.py
+++ b/tests/unit/test_orchestration/test_research_pipeline.py
@@ -311,6 +311,152 @@ class TestResearchPipelinePhase72:
         assert phase.aggregation_config == aggregation_config
 
 
+class TestResearchPipelineDiscoveryModeWiring:
+    """End-to-end wiring from pipeline config → DiscoveryPhase → discover() mode.
+
+    The unit tests in ``tests/unit/orchestration/phases/test_discovery.py``
+    exercise the mode-selection ladder in isolation. These tests close the
+    integration gap by verifying that a pipeline built from a real
+    ``ResearchConfig`` actually passes the expected ``mode`` kwarg all the
+    way through to ``DiscoveryService.discover()``.
+    """
+
+    def _make_context_with_settings(self, settings_overrides):
+        """Construct a minimal context with configurable settings."""
+        from src.models.discovery import DiscoveryMode  # noqa: F401
+
+        mock_context = MagicMock()
+        # Apply all Phase 7.2 defaults to None unless overridden.
+        mock_context.config.settings.query_expansion = settings_overrides.get(
+            "query_expansion"
+        )
+        mock_context.config.settings.citation_exploration = settings_overrides.get(
+            "citation_exploration"
+        )
+        mock_context.config.settings.aggregation = settings_overrides.get("aggregation")
+        mock_context.config.settings.enhanced_discovery = settings_overrides.get(
+            "enhanced_discovery"
+        )
+        # Disable filters / incremental for deterministic mode assertion.
+        mock_context.config.settings.discovery_filter_settings = MagicMock(
+            enabled=False, register_at_discovery=False
+        )
+        mock_context.config.settings.incremental_discovery_settings = MagicMock(
+            enabled=False
+        )
+        mock_context.config.research_topics = []
+        mock_context.errors = []
+        mock_context.catalog_service = MagicMock()
+        mock_context.discovery_service = AsyncMock()
+        mock_context.registry_service = None
+        mock_context.add_error = MagicMock()
+        mock_context.add_discovered_papers = MagicMock()
+        return mock_context
+
+    @pytest.mark.asyncio
+    async def test_pipeline_with_enhanced_discovery_triggers_standard_mode(self):
+        """Config sets `enhanced_discovery` → pipeline → phase → discover(STANDARD)."""
+        from src.models.config import (
+            EnhancedDiscoveryConfig,
+            ResearchTopic,
+            TimeframeRecent,
+        )
+        from src.models.discovery import (
+            DiscoveryResult as DiscoveryAPIResult,
+            DiscoveryMetrics,
+            DiscoveryMode,
+        )
+
+        pipeline = ResearchPipeline()
+        mock_context = self._make_context_with_settings(
+            {"enhanced_discovery": EnhancedDiscoveryConfig()}
+        )
+        mock_context.config.research_topics = [
+            ResearchTopic(
+                query="quantum computing", timeframe=TimeframeRecent(value="7d")
+            )
+        ]
+        mock_context.catalog_service.get_or_create_topic.return_value = MagicMock(
+            topic_slug="quantum-computing"
+        )
+        mock_context.discovery_service.discover = AsyncMock(
+            return_value=DiscoveryAPIResult(
+                papers=[],
+                metrics=DiscoveryMetrics(
+                    papers_retrieved=0,
+                    papers_after_dedup=0,
+                    papers_after_quality_filter=0,
+                    papers_after_relevance_filter=0,
+                    providers_queried=[],
+                    avg_relevance_score=0.0,
+                    avg_quality_score=0.0,
+                    pipeline_duration_ms=1,
+                ),
+                queries_used=[],
+                source_breakdown={},
+                mode=DiscoveryMode.STANDARD,
+            )
+        )
+        pipeline._context = mock_context
+
+        # Pipeline builds phase from context; phase reads enhanced_discovery.
+        phase = pipeline._create_discovery_phase()
+        assert phase.multi_source_enabled is False
+        await phase.execute()
+
+        mock_context.discovery_service.discover.assert_called_once()
+        call_mode = mock_context.discovery_service.discover.call_args[1]["mode"]
+        assert call_mode == DiscoveryMode.STANDARD
+
+    @pytest.mark.asyncio
+    async def test_pipeline_without_enhanced_discovery_triggers_surface_mode(self):
+        """No config → pipeline → phase → discover(SURFACE)."""
+        from src.models.config import ResearchTopic, TimeframeRecent
+        from src.models.discovery import (
+            DiscoveryResult as DiscoveryAPIResult,
+            DiscoveryMetrics,
+            DiscoveryMode,
+        )
+
+        pipeline = ResearchPipeline()
+        mock_context = self._make_context_with_settings({})  # all None
+        mock_context.config.research_topics = [
+            ResearchTopic(
+                query="quantum computing", timeframe=TimeframeRecent(value="7d")
+            )
+        ]
+        mock_context.catalog_service.get_or_create_topic.return_value = MagicMock(
+            topic_slug="quantum-computing"
+        )
+        mock_context.discovery_service.discover = AsyncMock(
+            return_value=DiscoveryAPIResult(
+                papers=[],
+                metrics=DiscoveryMetrics(
+                    papers_retrieved=0,
+                    papers_after_dedup=0,
+                    papers_after_quality_filter=0,
+                    papers_after_relevance_filter=0,
+                    providers_queried=[],
+                    avg_relevance_score=0.0,
+                    avg_quality_score=0.0,
+                    pipeline_duration_ms=1,
+                ),
+                queries_used=[],
+                source_breakdown={},
+                mode=DiscoveryMode.SURFACE,
+            )
+        )
+        pipeline._context = mock_context
+
+        phase = pipeline._create_discovery_phase()
+        assert phase.multi_source_enabled is False
+        await phase.execute()
+
+        mock_context.discovery_service.discover.assert_called_once()
+        call_mode = mock_context.discovery_service.discover.call_args[1]["mode"]
+        assert call_mode == DiscoveryMode.SURFACE
+
+
 class TestResearchPipelineProcessTopic:
     """Tests for _process_topic method."""
 


### PR DESCRIPTION
## Summary

Fixes an unreachable branch in `DiscoveryPhase` that prevented users from ever selecting `DiscoveryMode.STANDARD` via configuration.

### Root Cause

[`src/orchestration/phases/discovery.py:226`](../blob/main/src/orchestration/phases/discovery.py#L226) read a non-existent `enhanced_enabled` attribute:

```python
elif getattr(self.context.config.settings, "enhanced_enabled", False):
    mode = DiscoveryMode.STANDARD
```

- `GlobalSettings` (Pydantic model) has **no** `enhanced_enabled` field.
- `ResearchConfig.model_config = ConfigDict(extra="forbid")` — users cannot add it via YAML; Pydantic would reject it.
- The `getattr(..., False)` always returns `False` in production.
- **Effect:** `DiscoveryPhase` could only reach `DEEP` (via Phase 7.2 multi-source) or `SURFACE` (default). `STANDARD` mode was dead code.

A typed Pydantic field `settings.enhanced_discovery: Optional[EnhancedDiscoveryConfig]` already exists at `src/models/config/settings.py:73` for exactly this purpose, but `DiscoveryPhase` wasn't reading it.

## Changes

### `src/orchestration/phases/discovery.py` (+6 −3)
Replace the orphaned `getattr` with a check on the existing typed field:

```python
if self.multi_source_enabled:
    mode = DiscoveryMode.DEEP
elif self.context.config.settings.enhanced_discovery is not None:
    mode = DiscoveryMode.STANDARD
else:
    mode = DiscoveryMode.SURFACE
```

### `tests/unit/orchestration/phases/test_discovery.py` (+96 −4)
- **Fixture hardening:** `mock_context.config.settings.enhanced_discovery = None` explicitly. The old fixture relied on `MagicMock` returning truthy attribute access, which masked the branch under test.
- **Assertion correction:** `test_execute_single_topic_success` previously asserted `STANDARD` as the default mode — this only passed due to the mock's truthy behavior. Corrected to `SURFACE`, which matches the real production default.
- **New `TestDiscoveryPhaseModeSelection` class** with 4 deterministic tests:
  - `test_surface_mode_when_no_features_configured` → SURFACE
  - `test_standard_mode_when_enhanced_discovery_configured` → STANDARD
  - `test_deep_mode_when_multi_source_enabled` → DEEP
  - `test_multi_source_takes_precedence_over_enhanced_discovery` → DEEP wins

### Prep commit (separate): `style(tests): apply black to pre-existing drifted test files`
Two unrelated test files drifted from black on main. CI runs `black --check src/` only, but local `./verify.sh` runs on `src/ tests/` — so the drift blocks the stricter local gate. Format-only, zero behavior change.

## Scope Exclusions

Deliberately **not** included:
- No changes to `QualityScorer` / `QualityFilterService` (already deprecated at the correct boundary in `DiscoveryService`; class-level deprecation would add noise, not safety — see closed PR #92 thread).
- No new CLI flag. Users already reach this via YAML (`settings.enhanced_discovery: { ... }`).
- No changes to `DiscoveryService.discover()` internals — already correct.

## Test Plan

- [x] `./verify.sh` passes locally: **3812 tests, 99.01% coverage, all checks green**
- [x] Black: clean (`src/` + `tests/`)
- [x] Flake8: clean
- [x] Mypy: clean
- [x] Pragma audit: passed
- [x] New mode-selection tests verify each branch with typed config state (no MagicMock truthiness dependency)

## Related

- Spec: `.spec-workflow/specs/quality-scoring-consolidation/discovery-orchestration-requirements.md` (REQ: `enhanced_enabled=True → STANDARD`)
- Supersedes relevant narrow slice of closed PR #92 (the rest of #92 was already in main via #89/#93)