### PR TITLE
feat(phase-8.5): DRA daily integration for corpus refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Python 3.14](https://img.shields.io/badge/python-3.14-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Security: High](https://img.shields.io/badge/security-high-green.svg)](docs/security/)
-[![Test Coverage: 99.25%](https://img.shields.io/badge/coverage-99.25%25-brightgreen.svg)](tests/)
+[![Test Coverage: 99.16%](https://img.shields.io/badge/coverage-99.16%25-brightgreen.svg)](tests/)
 
 ## 🎯 Overview
 
@@ -15,7 +15,7 @@ ARISP automates the research process by:
 - 🤖 **Extracting** prompts, code, and insights using LLM (Claude/Gemini)
 - 📝 **Synthesizing** Obsidian-ready markdown briefs for engineering teams
 
-**✨ Phase 8.1 Complete:** Corpus Infrastructure for Deep Research Agent — paper ingestion pipeline, semantic chunking, and trajectory storage. Plus Intelligence Services Consolidation Phase 1 (Core Services), Human Feedback Loop (Phase 7.3), and 3,642 tests at 99.25% coverage!
+**✨ Phase 8 Complete:** Deep Research Agent (DRA) — autonomous multi-turn research with corpus infrastructure, browser primitives, ReAct agent loop, trajectory learning, and CLI integration. Plus Intelligence Services Consolidation, Human Feedback Loop (Phase 7.3), and 3,980 tests at 99.16% coverage!
 
 ## ✨ Key Features
 
@@ -77,11 +77,30 @@ ARISP automates the research process by:
 - **QueryIntelligenceService**: Provider selection and LLM-powered query expansion
 - **Hybrid Search Service**: FAISS + BM25 retrieval infrastructure (applied by DRA in Phase 8.1)
 
-### Deep Research Agent — Corpus (Phase 8.1) ✅ Complete
+### Deep Research Agent (Phase 8) ✅ Complete
+*Autonomous multi-turn research agent with trajectory-based learning*
+
+**Phase 8.1: Corpus Infrastructure** ✅
 - **Corpus Manager**: Offline indexed corpus from ARISP papers with semantic chunking
-- **Hybrid Retrieval**: Applies Phase 7.x's FAISS + BM25 service to DRA corpus (<200ms latency)
+- **Hybrid Retrieval**: FAISS + BM25 service for DRA corpus (<200ms latency)
 - **Paper Ingestion**: Automated pipeline to index and search over all discovered papers
-- **Trajectory Storage**: Batch trajectory storage for learning from research sessions
+
+**Phase 8.2: Browser Primitives & Agent Loop** ✅
+- **Browser Primitives**: `search()`, `open()`, `find()` for corpus navigation
+- **ReAct Agent Loop**: Reasoning + Acting pattern with configurable turn limits
+- **System Prompts**: Research protocol and contextual learning tips
+- **CLI Commands**: `arisp research` for interactive deep research sessions
+
+**Phase 8.3: Trajectory Collection & Learning** ✅
+- **Trajectory Recording**: Full turn-by-turn session capture
+- **Pattern Analysis**: Extract successful query patterns and strategies
+- **Quality Filtering**: Score and filter trajectories for learning
+- **CLI Commands**: `arisp trajectories list/analyze/export/stats/clear`
+
+**Phase 8.4: Integration & Validation** ✅
+- **End-to-End Testing**: Full research session integration tests
+- **User Documentation**: [DRA User Guide](docs/user_guides/DRA_USER_GUIDE.md)
+- **Export Formats**: ShareGPT JSONL, JSON, CSV for trajectory export
 
 ## 🚀 Quick Start
 
@@ -247,12 +266,13 @@ output/
 - [Phase 7.1: Feedback Foundation](docs/specs/PHASE_7.1_SPEC.md) - ✅ Complete (Feedback Data Model)
 - [Phase 7.2: Preference Learning](docs/specs/PHASE_7.2_SPEC.md) - ✅ Complete (Embedding-Based Topic Matching)
 - [Phase 7.3: Human Feedback Loop](docs/specs/PHASE_7.3_SPEC.md) - ✅ Complete (Feedback Integration)
-- [Phase 8.1: DRA Corpus Infrastructure](docs/specs/PHASE_8_DRA_SPEC.md) - ✅ Complete (Hybrid Search, Paper Ingestion, Trajectory Storage)
+- [Phase 8: Deep Research Agent](docs/specs/PHASE_8_DRA_SPEC.md) - ✅ Complete (Corpus, Browser, Agent Loop, Trajectory Learning)
+- [Phase 9: Research Intelligence Layer](docs/specs/PHASE_9_RESEARCH_INTELLIGENCE_SPEC.md) - 📋 Planning (Monitoring, Citation Graph, Knowledge Graph, Frontier Detection)
 
 ### Proposals
 - [Proposal 001: Discovery Provider Strategy](docs/proposals/001_DISCOVERY_PROVIDER_STRATEGY.md) - ✅ Approved & Implemented
 - [Proposal 002: PDF Extraction Reliability](docs/proposals/002_PDF_EXTRACTION_RELIABILITY.md) - ✅ Approved & Implemented
-- [Proposal 004: Deep Research Agent (DRA)](docs/proposals/004_OPENRESEARCHER_OFFLINE_TRAJECTORY_SYNTHESIS.md) - 🔄 Phase 8.1 Complete (Corpus Infrastructure); Agent Loop (8.2) in progress
+- [Proposal 004: Deep Research Agent (DRA)](docs/proposals/004_OPENRESEARCHER_OFFLINE_TRAJECTORY_SYNTHESIS.md) - ✅ Complete (Phase 8: Corpus, Browser, Agent, Trajectory Learning)
 
 ### Development
 - [CLAUDE.md](CLAUDE.md) - Development guide for Claude Code integration
@@ -261,9 +281,9 @@ output/
 
 ## 🏗️ Project Status
 
-**Current Status:** ✅ **Phase 8.1 Complete** - Corpus Infrastructure for Deep Research Agent + Intelligence Services Consolidation Phase 1 (Core Services) (PR #89 merged 2026-04-13). Full production pipeline with 3,642 tests at 99.25% coverage.
+**Current Status:** ✅ **Phase 8 Complete** - Deep Research Agent with corpus infrastructure, browser primitives, ReAct agent loop, trajectory learning, and CLI integration (PR #101). Full production pipeline with 3,980 tests at 99.16% coverage.
 
-**Next Phase:** 📋 **Phase 8.2: DRA Agent Loop** (ReAct-style reasoning) or **Phase 9 planning** - Autonomous research agent with trajectory learning.
+**Next Phase:** 📋 **Phase 9: Research Intelligence Layer** - Proactive paper monitoring, citation graph intelligence, knowledge graph synthesis, and research frontier detection. See [Phase 9 Spec](docs/specs/PHASE_9_RESEARCH_INTELLIGENCE_SPEC.md).
 
 📊 **For detailed progress tracking, timelines, and phase-by-phase completion status, see:**
 → **[Phased Delivery Plan](docs/PHASED_DELIVERY_PLAN.md)** (Single Source of Truth)
@@ -296,7 +316,7 @@ output/
 ## 📊 Performance & Quality
 
 ### Current Metrics
-- ✅ **Test Coverage**: 99.25% (2181 automated tests, 100% pass rate)
+- ✅ **Test Coverage**: 99.16% (3,980 automated tests, 100% pass rate)
 - ✅ **Security**: 22/22 requirements met across all layers
 - ✅ **Quality Gates**: Automated enforcement (Flake8, Black, Mypy, Pytest)
 - ✅ **Configuration Validation**: <1s
@@ -421,6 +441,14 @@ python -m src.cli catalog show
 # Run tests
 pytest tests/ --cov=src --cov-report=term
 
+# Deep Research Agent commands
+python -m src.cli research "What are the latest advances in attention mechanisms?"
+python -m src.cli corpus build          # Build corpus from registry
+python -m src.cli corpus stats          # View corpus statistics
+python -m src.cli trajectories list     # List research trajectories
+python -m src.cli trajectories analyze  # Analyze trajectory patterns
+python -m src.cli trajectories export   # Export to ShareGPT JSONL
+
 # Run security checks
 python -m pip_audit -r requirements.txt
 pre-commit run --all-files
@@ -455,4 +483,4 @@ timeframe:
 
 **Built with ❤️ for research teams who want to stay ahead**
 
-**Status**: Phase 8.1 Complete - Corpus Infrastructure for Deep Research Agent + Intelligence Services Consolidation Phase 1 (Core Services). 3,642 tests, 99.25% coverage 🚀
+**Status**: Phase 8 Complete - Deep Research Agent with autonomous multi-turn research, trajectory learning, and CLI integration. 3,980 tests, 99.16% coverage 🚀

--- a/src/models/config/settings.py
+++ b/src/models/config/settings.py
@@ -25,6 +25,31 @@ from src.models.concurrency import ConcurrencyConfig
 from src.models.notification import NotificationSettings
 
 
+class DRADailySettings(BaseModel):
+    """DRA integration settings for daily runs (Phase 8.5).
+
+    Controls whether and how the Deep Research Agent integrates
+    with the daily research pipeline.
+    """
+
+    enable_corpus_refresh: bool = Field(
+        True,
+        description="Refresh DRA corpus after daily pipeline completes",
+    )
+    corpus_data_dir: str = Field(
+        "./data/dra",
+        description="Directory for DRA corpus storage",
+    )
+    registry_path: str = Field(
+        "./data/registry",
+        description="Path to global paper registry",
+    )
+    force_reindex: bool = Field(
+        False,
+        description="Force re-indexing of all papers (not just new ones)",
+    )
+
+
 class GlobalSettings(BaseModel):
     """Global pipeline settings"""
 
@@ -104,6 +129,11 @@ class GlobalSettings(BaseModel):
     arxiv_default_categories: List[str] = Field(
         default_factory=lambda: ["cs.CL", "cs.LG", "cs.AI"],
         description="Default ArXiv categories for structured queries (Phase 7 Fix I1)",
+    )
+    # Phase 8.5: DRA Daily Integration
+    dra_daily: Optional[DRADailySettings] = Field(
+        default=None,
+        description="DRA integration settings for daily runs (Phase 8.5)",
     )
 
 

--- a/src/scheduling/jobs.py
+++ b/src/scheduling/jobs.py
@@ -12,6 +12,7 @@ Usage:
     await job.run()
 """
 
+import asyncio
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
 from pathlib import Path
@@ -357,9 +358,12 @@ class DailyResearchJob(BaseJob):
             )
 
             # Initialize corpus manager and ingest
+            # Use asyncio.to_thread to offload blocking ML/IO operations
+            # to a background thread, preventing event loop stalls
             corpus_config = CorpusConfig(corpus_dir=str(corpus_data_dir))
             corpus_manager = CorpusManager(config=corpus_config)
-            papers_ingested = corpus_manager.ingest_from_registry(
+            papers_ingested = await asyncio.to_thread(
+                corpus_manager.ingest_from_registry,
                 registry_path=registry_path,
                 force=dra_settings.force_reindex,
             )
@@ -647,7 +651,10 @@ class DRACorpusRefreshJob(BaseJob):
             )
 
             # Ingest papers from registry
-            papers_ingested = corpus_manager.ingest_from_registry(
+            # Use asyncio.to_thread to offload blocking ML/IO operations
+            # to a background thread, preventing event loop stalls
+            papers_ingested = await asyncio.to_thread(
+                corpus_manager.ingest_from_registry,
                 registry_path=self.registry_path,
                 force=self.force_reindex,
             )

--- a/src/scheduling/jobs.py
+++ b/src/scheduling/jobs.py
@@ -135,16 +135,19 @@ class DailyResearchJob(BaseJob):
         self,
         config_path: Optional[Path] = None,
         enable_phase2: bool = True,
+        enable_dra_refresh: bool = True,
     ):
         """Initialize daily research job.
 
         Args:
             config_path: Path to research config (default: config/research_config.yaml)
             enable_phase2: Enable Phase 2 PDF/LLM extraction (default: True)
+            enable_dra_refresh: Enable DRA corpus refresh after pipeline (Phase 8.5)
         """
         super().__init__("daily_research")
         self.config_path = config_path or Path("config/research_config.yaml")
         self.enable_phase2 = enable_phase2
+        self.enable_dra_refresh = enable_dra_refresh
 
     async def run(self) -> Dict[str, Any]:
         """Run the complete research pipeline.
@@ -195,7 +198,13 @@ class DailyResearchJob(BaseJob):
         # Phase 3.7 + 3.8: Send notifications with deduplication (fail-safe)
         await self._send_notifications(result, config, pipeline)
 
-        return result.to_dict()
+        # Phase 8.5: DRA corpus refresh (fail-safe)
+        dra_result = await self._refresh_dra_corpus(config)
+
+        # Include DRA result in response
+        result_dict = result.to_dict()
+        result_dict["dra_corpus_refresh"] = dra_result
+        return result_dict
 
     async def _send_notifications(
         self,
@@ -287,6 +296,95 @@ class DailyResearchJob(BaseJob):
                 error=str(e),
                 exc_info=True,
             )
+
+    async def _refresh_dra_corpus(self, config: Any) -> Dict[str, Any]:
+        """Refresh DRA corpus after pipeline completion (Phase 8.5).
+
+        DRA corpus refresh is fail-safe - errors are logged but never raised.
+
+        Args:
+            config: ResearchConfig with DRA settings.
+
+        Returns:
+            Dictionary with refresh results or skip reason.
+        """
+        result: Dict[str, Any] = {
+            "status": "skipped",
+            "papers_ingested": 0,
+            "error": None,
+        }
+
+        # Check if DRA refresh is enabled
+        if not self.enable_dra_refresh:
+            result["error"] = "DRA refresh disabled via constructor"
+            logger.debug("dra_corpus_refresh_disabled", reason="constructor_flag")
+            return result
+
+        # Check config-level DRA settings
+        dra_settings = getattr(config.settings, "dra_daily", None)
+        if dra_settings is None:
+            result["error"] = "No dra_daily settings in config"
+            logger.debug("dra_corpus_refresh_skipped", reason="no_config")
+            return result
+
+        if not dra_settings.enable_corpus_refresh:
+            result["error"] = "Corpus refresh disabled in config"
+            logger.debug("dra_corpus_refresh_disabled", reason="config_flag")
+            return result
+
+        try:
+            from src.models.dra import CorpusConfig
+            from src.services.dra.corpus_manager import CorpusManager
+
+            corpus_data_dir = Path(dra_settings.corpus_data_dir)
+            registry_path = Path(dra_settings.registry_path)
+
+            # Check if registry exists
+            if not registry_path.exists():
+                result["error"] = f"Registry not found: {registry_path}"
+                logger.warning(
+                    "dra_corpus_refresh_skipped",
+                    reason="registry_not_found",
+                    path=str(registry_path),
+                )
+                return result
+
+            logger.info(
+                "dra_corpus_refresh_starting",
+                corpus_dir=str(corpus_data_dir),
+                registry_path=str(registry_path),
+                force_reindex=dra_settings.force_reindex,
+            )
+
+            # Initialize corpus manager and ingest
+            corpus_config = CorpusConfig(corpus_dir=str(corpus_data_dir))
+            corpus_manager = CorpusManager(config=corpus_config)
+            papers_ingested = corpus_manager.ingest_from_registry(
+                registry_path=registry_path,
+                force=dra_settings.force_reindex,
+            )
+
+            result["status"] = "success"
+            result["papers_ingested"] = papers_ingested
+            result["corpus_size"] = corpus_manager.stats.total_chunks
+
+            logger.info(
+                "dra_corpus_refresh_completed",
+                papers_ingested=papers_ingested,
+                corpus_size=result.get("corpus_size", 0),
+            )
+
+        except Exception as e:
+            # DRA refresh should never break the pipeline
+            result["status"] = "error"
+            result["error"] = str(e)
+            logger.error(
+                "dra_corpus_refresh_failed",
+                error=str(e),
+                exc_info=True,
+            )
+
+        return result
 
 
 class CacheCleanupJob(BaseJob):
@@ -478,5 +576,98 @@ class HealthCheckJob(BaseJob):
             )
         else:
             logger.info("health_check_passed", status=report.status.value)
+
+        return result
+
+
+class DRACorpusRefreshJob(BaseJob):
+    """DRA corpus refresh job (Phase 8.5).
+
+    Refreshes the Deep Research Agent corpus by ingesting new papers
+    from the global registry after daily pipeline runs.
+    """
+
+    def __init__(
+        self,
+        corpus_data_dir: Optional[Path] = None,
+        registry_path: Optional[Path] = None,
+        force_reindex: bool = False,
+    ):
+        """Initialize DRA corpus refresh job.
+
+        Args:
+            corpus_data_dir: Directory for DRA corpus storage
+            registry_path: Path to global paper registry
+            force_reindex: Force re-indexing of all papers
+        """
+        super().__init__("dra_corpus_refresh")
+        self.corpus_data_dir = corpus_data_dir or Path("./data/dra")
+        self.registry_path = registry_path or Path("./data/registry")
+        self.force_reindex = force_reindex
+
+    async def run(self) -> Dict[str, Any]:
+        """Refresh DRA corpus from registry.
+
+        Ingests new papers discovered since last refresh into the
+        searchable corpus for Deep Research Agent queries.
+
+        Returns:
+            Dictionary with refresh results
+        """
+        from src.models.dra import CorpusConfig
+        from src.services.dra.corpus_manager import CorpusManager
+
+        result: Dict[str, Any] = {
+            "papers_ingested": 0,
+            "corpus_size": 0,
+            "status": "success",
+            "error": None,
+        }
+
+        # Check if registry exists
+        if not self.registry_path.exists():
+            logger.warning(
+                "dra_corpus_refresh_skipped",
+                reason="registry_not_found",
+                path=str(self.registry_path),
+            )
+            result["status"] = "skipped"
+            result["error"] = "Registry directory not found"
+            return result
+
+        try:
+            # Initialize corpus manager with config
+            config = CorpusConfig(corpus_dir=str(self.corpus_data_dir))
+            corpus_manager = CorpusManager(config=config)
+
+            logger.info(
+                "dra_corpus_refresh_starting",
+                registry_path=str(self.registry_path),
+                force_reindex=self.force_reindex,
+            )
+
+            # Ingest papers from registry
+            papers_ingested = corpus_manager.ingest_from_registry(
+                registry_path=self.registry_path,
+                force=self.force_reindex,
+            )
+
+            result["papers_ingested"] = papers_ingested
+            result["corpus_size"] = corpus_manager.stats.total_chunks
+
+            logger.info(
+                "dra_corpus_refresh_completed",
+                papers_ingested=papers_ingested,
+                corpus_size=result["corpus_size"],
+            )
+
+        except Exception as e:
+            result["status"] = "error"
+            result["error"] = str(e)
+            logger.error(
+                "dra_corpus_refresh_failed",
+                error=str(e),
+                exc_info=True,
+            )
 
         return result

--- a/tests/unit/test_scheduling/test_jobs.py
+++ b/tests/unit/test_scheduling/test_jobs.py
@@ -12,6 +12,7 @@ from src.scheduling.jobs import (
     CacheCleanupJob,
     CostReportJob,
     HealthCheckJob,
+    DRACorpusRefreshJob,
 )
 
 
@@ -608,3 +609,287 @@ class TestHealthCheckJob:
 
             # Status should be degraded
             assert result["status"] == "degraded"
+
+
+class TestDRACorpusRefreshJob:
+    """Tests for DRACorpusRefreshJob (Phase 8.5)."""
+
+    def test_init_with_defaults(self):
+        """Should initialize with default values."""
+        job = DRACorpusRefreshJob()
+
+        assert job.name == "dra_corpus_refresh"
+        assert job.corpus_data_dir == Path("./data/dra")
+        assert job.registry_path == Path("./data/registry")
+        assert job.force_reindex is False
+
+    def test_init_with_custom_values(self):
+        """Should initialize with custom values."""
+        job = DRACorpusRefreshJob(
+            corpus_data_dir=Path("/custom/corpus"),
+            registry_path=Path("/custom/registry"),
+            force_reindex=True,
+        )
+
+        assert job.corpus_data_dir == Path("/custom/corpus")
+        assert job.registry_path == Path("/custom/registry")
+        assert job.force_reindex is True
+
+    @pytest.mark.asyncio
+    async def test_run_registry_not_found(self):
+        """Should return skipped status when registry not found."""
+        job = DRACorpusRefreshJob(
+            registry_path=Path("/nonexistent/registry"),
+        )
+
+        result = await job.run()
+
+        assert result["status"] == "skipped"
+        assert "not found" in result["error"]
+        assert result["papers_ingested"] == 0
+
+    @pytest.mark.asyncio
+    async def test_run_success(self):
+        """Should successfully refresh corpus from registry."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            registry_path = Path(tmpdir) / "registry"
+            registry_path.mkdir()
+            corpus_dir = Path(tmpdir) / "corpus"
+
+            job = DRACorpusRefreshJob(
+                corpus_data_dir=corpus_dir,
+                registry_path=registry_path,
+            )
+
+            # Mock CorpusManager at source
+            with patch(
+                "src.services.dra.corpus_manager.CorpusManager"
+            ) as mock_corpus_manager_class:
+                mock_manager = MagicMock()
+                mock_manager.ingest_from_registry.return_value = 5
+                mock_manager.stats.total_chunks = 100
+                mock_corpus_manager_class.return_value = mock_manager
+
+                result = await job.run()
+
+            assert result["status"] == "success"
+            assert result["papers_ingested"] == 5
+            assert result["corpus_size"] == 100
+            assert result["error"] is None
+
+    @pytest.mark.asyncio
+    async def test_run_handles_corpus_manager_error(self):
+        """Should handle errors from CorpusManager gracefully."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            registry_path = Path(tmpdir) / "registry"
+            registry_path.mkdir()
+            corpus_dir = Path(tmpdir) / "corpus"
+
+            job = DRACorpusRefreshJob(
+                corpus_data_dir=corpus_dir,
+                registry_path=registry_path,
+            )
+
+            # Mock CorpusManager to raise error
+            with patch(
+                "src.services.dra.corpus_manager.CorpusManager"
+            ) as mock_corpus_manager_class:
+                mock_corpus_manager_class.side_effect = RuntimeError("Corpus error")
+
+                result = await job.run()
+
+            assert result["status"] == "error"
+            assert "Corpus error" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_run_with_force_reindex(self):
+        """Should pass force_reindex to corpus manager."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            registry_path = Path(tmpdir) / "registry"
+            registry_path.mkdir()
+            corpus_dir = Path(tmpdir) / "corpus"
+
+            job = DRACorpusRefreshJob(
+                corpus_data_dir=corpus_dir,
+                registry_path=registry_path,
+                force_reindex=True,
+            )
+
+            with patch(
+                "src.services.dra.corpus_manager.CorpusManager"
+            ) as mock_corpus_manager_class:
+                mock_manager = MagicMock()
+                mock_manager.ingest_from_registry.return_value = 3
+                mock_manager.stats.total_chunks = 50
+                mock_corpus_manager_class.return_value = mock_manager
+
+                await job.run()
+
+                # Verify force=True was passed
+                mock_manager.ingest_from_registry.assert_called_once_with(
+                    registry_path=registry_path,
+                    force=True,
+                )
+
+
+class TestDailyResearchJobDRAIntegration:
+    """Tests for DailyResearchJob DRA integration (Phase 8.5)."""
+
+    def test_init_with_dra_refresh_enabled(self):
+        """Should initialize with DRA refresh enabled by default."""
+        job = DailyResearchJob()
+
+        assert job.enable_dra_refresh is True
+
+    def test_init_with_dra_refresh_disabled(self):
+        """Should allow disabling DRA refresh."""
+        job = DailyResearchJob(enable_dra_refresh=False)
+
+        assert job.enable_dra_refresh is False
+
+    @pytest.mark.asyncio
+    async def test_refresh_dra_corpus_disabled_via_constructor(self):
+        """Should skip DRA refresh when disabled via constructor."""
+        job = DailyResearchJob(enable_dra_refresh=False)
+
+        mock_config = MagicMock()
+        mock_config.settings.dra_daily = MagicMock()
+
+        result = await job._refresh_dra_corpus(mock_config)
+
+        assert result["status"] == "skipped"
+        assert "constructor" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_refresh_dra_corpus_no_config(self):
+        """Should skip DRA refresh when no dra_daily config."""
+        job = DailyResearchJob()
+
+        mock_config = MagicMock()
+        mock_config.settings.dra_daily = None
+
+        result = await job._refresh_dra_corpus(mock_config)
+
+        assert result["status"] == "skipped"
+        assert "No dra_daily settings" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_refresh_dra_corpus_disabled_in_config(self):
+        """Should skip DRA refresh when disabled in config."""
+        job = DailyResearchJob()
+
+        mock_config = MagicMock()
+        mock_config.settings.dra_daily.enable_corpus_refresh = False
+
+        result = await job._refresh_dra_corpus(mock_config)
+
+        assert result["status"] == "skipped"
+        assert "disabled in config" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_refresh_dra_corpus_registry_not_found(self):
+        """Should skip DRA refresh when registry not found."""
+        job = DailyResearchJob()
+
+        mock_config = MagicMock()
+        mock_config.settings.dra_daily.enable_corpus_refresh = True
+        mock_config.settings.dra_daily.corpus_data_dir = "/tmp/corpus"
+        mock_config.settings.dra_daily.registry_path = "/nonexistent/registry"
+        mock_config.settings.dra_daily.force_reindex = False
+
+        result = await job._refresh_dra_corpus(mock_config)
+
+        assert result["status"] == "skipped"
+        assert "Registry not found" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_refresh_dra_corpus_success(self):
+        """Should successfully refresh DRA corpus."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            registry_path = Path(tmpdir) / "registry"
+            registry_path.mkdir()
+            corpus_dir = Path(tmpdir) / "corpus"
+
+            job = DailyResearchJob()
+
+            mock_config = MagicMock()
+            mock_config.settings.dra_daily.enable_corpus_refresh = True
+            mock_config.settings.dra_daily.corpus_data_dir = str(corpus_dir)
+            mock_config.settings.dra_daily.registry_path = str(registry_path)
+            mock_config.settings.dra_daily.force_reindex = False
+
+            with patch(
+                "src.services.dra.corpus_manager.CorpusManager"
+            ) as mock_corpus_manager_class:
+                mock_manager = MagicMock()
+                mock_manager.ingest_from_registry.return_value = 10
+                mock_manager.stats.total_chunks = 200
+                mock_corpus_manager_class.return_value = mock_manager
+
+                result = await job._refresh_dra_corpus(mock_config)
+
+            assert result["status"] == "success"
+            assert result["papers_ingested"] == 10
+            assert result["corpus_size"] == 200
+
+    @pytest.mark.asyncio
+    async def test_refresh_dra_corpus_handles_error(self):
+        """Should handle errors gracefully without raising."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            registry_path = Path(tmpdir) / "registry"
+            registry_path.mkdir()
+            corpus_dir = Path(tmpdir) / "corpus"
+
+            job = DailyResearchJob()
+
+            mock_config = MagicMock()
+            mock_config.settings.dra_daily.enable_corpus_refresh = True
+            mock_config.settings.dra_daily.corpus_data_dir = str(corpus_dir)
+            mock_config.settings.dra_daily.registry_path = str(registry_path)
+            mock_config.settings.dra_daily.force_reindex = False
+
+            with patch(
+                "src.services.dra.corpus_manager.CorpusManager"
+            ) as mock_corpus_manager_class:
+                mock_corpus_manager_class.side_effect = RuntimeError("DRA error")
+
+                result = await job._refresh_dra_corpus(mock_config)
+
+            assert result["status"] == "error"
+            assert "DRA error" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_run_includes_dra_result(self):
+        """Should include DRA corpus refresh result in run output."""
+        from src.orchestration import PipelineResult
+        from src.models.notification import NotificationSettings
+
+        job = DailyResearchJob(enable_dra_refresh=False)
+
+        mock_config = MagicMock()
+        mock_config.settings.notification_settings = NotificationSettings()
+        mock_config.settings.dra_daily = None
+
+        with (
+            patch(
+                "src.services.config_manager.ConfigManager"
+            ) as mock_config_manager_class,
+            patch("src.orchestration.ResearchPipeline") as mock_pipeline_class,
+        ):
+            mock_config_manager = MagicMock()
+            mock_config_manager.load_config.return_value = mock_config
+            mock_config_manager_class.return_value = mock_config_manager
+
+            mock_result = PipelineResult()
+            mock_result.topics_processed = 1
+            mock_result.output_files = []
+            mock_result.errors = []
+
+            mock_pipeline = MagicMock()
+            mock_pipeline.run = AsyncMock(return_value=mock_result)
+            mock_pipeline_class.return_value = mock_pipeline
+
+            result = await job.run()
+
+        assert "dra_corpus_refresh" in result
+        assert result["dra_corpus_refresh"]["status"] == "skipped"

--- a/tests/unit/test_scheduling/test_jobs.py
+++ b/tests/unit/test_scheduling/test_jobs.py
@@ -661,10 +661,16 @@ class TestDRACorpusRefreshJob:
                 registry_path=registry_path,
             )
 
-            # Mock CorpusManager at source
-            with patch(
-                "src.services.dra.corpus_manager.CorpusManager"
-            ) as mock_corpus_manager_class:
+            # Mock CorpusManager at source and asyncio.to_thread
+            with (
+                patch(
+                    "src.services.dra.corpus_manager.CorpusManager"
+                ) as mock_corpus_manager_class,
+                patch(
+                    "src.scheduling.jobs.asyncio.to_thread",
+                    side_effect=lambda func, *args, **kwargs: func(*args, **kwargs),
+                ),
+            ):
                 mock_manager = MagicMock()
                 mock_manager.ingest_from_registry.return_value = 5
                 mock_manager.stats.total_chunks = 100
@@ -690,10 +696,16 @@ class TestDRACorpusRefreshJob:
                 registry_path=registry_path,
             )
 
-            # Mock CorpusManager to raise error
-            with patch(
-                "src.services.dra.corpus_manager.CorpusManager"
-            ) as mock_corpus_manager_class:
+            # Mock CorpusManager to raise error and asyncio.to_thread
+            with (
+                patch(
+                    "src.services.dra.corpus_manager.CorpusManager"
+                ) as mock_corpus_manager_class,
+                patch(
+                    "src.scheduling.jobs.asyncio.to_thread",
+                    side_effect=lambda func, *args, **kwargs: func(*args, **kwargs),
+                ),
+            ):
                 mock_corpus_manager_class.side_effect = RuntimeError("Corpus error")
 
                 result = await job.run()
@@ -715,9 +727,15 @@ class TestDRACorpusRefreshJob:
                 force_reindex=True,
             )
 
-            with patch(
-                "src.services.dra.corpus_manager.CorpusManager"
-            ) as mock_corpus_manager_class:
+            with (
+                patch(
+                    "src.services.dra.corpus_manager.CorpusManager"
+                ) as mock_corpus_manager_class,
+                patch(
+                    "src.scheduling.jobs.asyncio.to_thread",
+                    side_effect=lambda func, *args, **kwargs: func(*args, **kwargs),
+                ),
+            ):
                 mock_manager = MagicMock()
                 mock_manager.ingest_from_registry.return_value = 3
                 mock_manager.stats.total_chunks = 50
@@ -818,9 +836,15 @@ class TestDailyResearchJobDRAIntegration:
             mock_config.settings.dra_daily.registry_path = str(registry_path)
             mock_config.settings.dra_daily.force_reindex = False
 
-            with patch(
-                "src.services.dra.corpus_manager.CorpusManager"
-            ) as mock_corpus_manager_class:
+            with (
+                patch(
+                    "src.services.dra.corpus_manager.CorpusManager"
+                ) as mock_corpus_manager_class,
+                patch(
+                    "src.scheduling.jobs.asyncio.to_thread",
+                    side_effect=lambda func, *args, **kwargs: func(*args, **kwargs),
+                ),
+            ):
                 mock_manager = MagicMock()
                 mock_manager.ingest_from_registry.return_value = 10
                 mock_manager.stats.total_chunks = 200
@@ -848,9 +872,15 @@ class TestDailyResearchJobDRAIntegration:
             mock_config.settings.dra_daily.registry_path = str(registry_path)
             mock_config.settings.dra_daily.force_reindex = False
 
-            with patch(
-                "src.services.dra.corpus_manager.CorpusManager"
-            ) as mock_corpus_manager_class:
+            with (
+                patch(
+                    "src.services.dra.corpus_manager.CorpusManager"
+                ) as mock_corpus_manager_class,
+                patch(
+                    "src.scheduling.jobs.asyncio.to_thread",
+                    side_effect=lambda func, *args, **kwargs: func(*args, **kwargs),
+                ),
+            ):
                 mock_corpus_manager_class.side_effect = RuntimeError("DRA error")
 
                 result = await job._refresh_dra_corpus(mock_config)


### PR DESCRIPTION
## Summary

Implements Phase 8.5: DRA Daily Integration for automatic corpus refresh after daily research pipeline runs.

**Changes:**
- Add `DRADailySettings` config model for corpus refresh configuration
- Add `DRACorpusRefreshJob` standalone job for scheduled corpus updates
- Update `DailyResearchJob` with `_refresh_dra_corpus()` fail-safe method
- Add 15 comprehensive tests covering all DRA integration scenarios
- Update README.md for Phase 8 completion (closes #72)

**Key Features:**
- **Automatic corpus refresh**: DRA corpus updates automatically after daily discovery
- **Fail-safe design**: Errors logged but never block main pipeline
- **Configurable**: Enable/disable via config, customizable paths and force-reindex option
- **Standalone job**: `DRACorpusRefreshJob` can also run independently

## Test Plan

- [x] Unit tests for `DRACorpusRefreshJob` initialization and execution (6 tests)
- [x] Unit tests for `DailyResearchJob._refresh_dra_corpus()` (9 tests)
- [x] Verify fail-safe error handling (errors logged, not raised)
- [x] Verify config-level and constructor-level disable options
- [x] Full test suite: 3,995 tests passing
- [x] Coverage: 99.13% (exceeds 99% requirement)
- [x] `./verify.sh` passes all checks (Black, Flake8, Mypy, Pytest)

## Code Review Notes

- Fixed HIGH severity variable shadowing issue (`config` → `corpus_config`)
- Removed redundant `Path` import
- Uses existing `CorpusManager` API with proper `CorpusConfig` initialization