### PR TITLE
feat(phase-9.2): Citation Graph Week 1 — Semantic Scholar client + models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,9 @@ addopts = [
     "--strict-config",
     "--verbose",
 ]
+# Tests use explicit @pytest.mark.asyncio markers; pin to strict so a
+# missing marker fails fast rather than silently skipping coroutine tests.
+asyncio_mode = "strict"
 
 [tool.coverage.run]
 source = ["src"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,8 @@
 [pytest]
 testpaths = tests
+# Tests use explicit @pytest.mark.asyncio markers; pin to strict so a
+# missing marker fails fast rather than silently skipping coroutine tests.
+asyncio_mode = strict
 filterwarnings =
     ignore::FutureWarning:google.api_core.*:
     ignore::FutureWarning:google.generativeai.*:

--- a/src/services/intelligence/citation/__init__.py
+++ b/src/services/intelligence/citation/__init__.py
@@ -1,0 +1,53 @@
+"""Milestone 9.2: Citation Graph Intelligence (Week 1 surface).
+
+This package builds and persists citation graphs from external APIs
+(Semantic Scholar primary, OpenAlex fallback) using the Phase 9
+``GraphStore`` for storage. Week 1 delivers depth=1 graph construction;
+BFS crawler, coupling analyzer, influence scorer, and recommender are
+deferred to follow-up PRs (Weeks 2-3).
+
+Public surface (Week 1 PR — descoped):
+
+- :class:`CitationNode` / :class:`CitationEdge` — domain models that
+  layer over the shared ``GraphNode`` / ``GraphEdge`` kernel.
+- :class:`CitationDirection` — small enum for traversal direction.
+- :class:`SemanticScholarCitationClient` — primary citation source.
+
+Deferred to Week 1.5 follow-up PR (small, focused):
+- ``OpenAlexCitationClient`` (fallback with polite-pool email)
+- ``CitationGraphBuilder`` (composes clients + persists via
+  ``GraphStore.add_nodes_batch`` / ``add_edges_batch``)
+
+Architecture choice (recorded for downstream milestones):
+We deliberately built **dedicated citation clients alongside** the
+existing ``SemanticScholarProvider`` / ``OpenAlexProvider`` in
+``src/services/providers/`` rather than extending those. The existing
+providers implement the ``DiscoveryProvider`` ABC for keyword-based
+paper search and have request shapes, response parsers, and retry
+semantics that don't transfer cleanly to the
+``/paper/{id}/citations|references`` and ``/works/{id}`` endpoints.
+Wrapping them would require either widening the ABC or layering an
+adapter on top — both add coupling without saving meaningful code.
+"""
+
+from src.services.intelligence.citation.models import (
+    CitationDirection,
+    CitationEdge,
+    CitationNode,
+    make_citation_edge_id,
+    make_paper_node_id,
+)
+from src.services.intelligence.citation.semantic_scholar_client import (
+    SemanticScholarCitationClient,
+)
+
+__all__ = [
+    # Models
+    "CitationDirection",
+    "CitationEdge",
+    "CitationNode",
+    "make_citation_edge_id",
+    "make_paper_node_id",
+    # Clients
+    "SemanticScholarCitationClient",
+]

--- a/src/services/intelligence/citation/models.py
+++ b/src/services/intelligence/citation/models.py
@@ -25,6 +25,7 @@ Design notes:
 
 from __future__ import annotations
 
+import hashlib
 import re
 from datetime import datetime, timezone
 from enum import Enum
@@ -82,13 +83,24 @@ def make_citation_edge_id(citing_id: str, cited_id: str) -> str:
     Deterministic edge ids let bulk inserts be idempotent within a
     single transaction (a duplicate raises a constraint error before
     any partial write — see ``add_edges_batch``).
+
+    Implementation note: the citing/cited node ids both contain ``:``
+    separators (e.g. ``paper:s2:abc``). Concatenating them with another
+    ``:`` would let two distinct pairs collide on the resulting edge
+    id (``a:b:c + d:e:f`` and ``a:b + c:d:e:f`` both yield
+    ``a:b:c:d:e:f``), which would silently merge unrelated edges in
+    ``add_edges_batch``. We hash the pair with SHA-256 to get a
+    collision-free, deterministic, length-bounded id. Only the first
+    32 hex chars (128 bits) are kept to stay within the storage
+    layer's ``edge_id`` length budget; collisions remain
+    cryptographically negligible at our scale (~10^9 edges).
     """
     # The two node ids are already validated, but we still scrub here
     # to defend against future callers passing raw external ids.
-    return (
-        f"edge:cites:"
-        f"{_normalize_id_segment(citing_id)}:{_normalize_id_segment(cited_id)}"
-    )
+    citing = _normalize_id_segment(citing_id)
+    cited = _normalize_id_segment(cited_id)
+    digest = hashlib.sha256(f"{citing}|{cited}".encode("utf-8")).hexdigest()[:32]
+    return f"edge:cites:{digest}"
 
 
 class CitationDirection(str, Enum):

--- a/src/services/intelligence/citation/models.py
+++ b/src/services/intelligence/citation/models.py
@@ -1,0 +1,329 @@
+"""Domain models for the citation graph (Milestone 9.2).
+
+These models layer over the shared ``GraphNode`` / ``GraphEdge`` kernel
+defined in ``src.services.intelligence.models.graph``. They give the
+citation subsystem typed accessors and validation appropriate to the
+domain (years, citation counts, DOIs, S2 ids) without forcing those
+concerns into the kernel — which is reused by knowledge, frontier,
+and monitoring milestones too.
+
+Design notes:
+- Pydantic V2 with ``extra="forbid"`` per project standards (see
+  CLAUDE.md). Conversion helpers (``to_graph_node`` / ``to_graph_edge``)
+  produce kernel objects ready for ``GraphStore.add_nodes_batch`` /
+  ``add_edges_batch``.
+- ``paper_id`` is the canonical identifier used inside the graph. We
+  always emit the ``paper:`` prefix so node ids never collide with
+  other ``NodeType`` (entity, topic, author, venue) — a constraint
+  the storage layer's ``node_id`` regex enforces but does not assert.
+- ``CitationDirection`` is the small enum the graph builder uses to
+  decide which S2/OpenAlex endpoints to hit. The full Week-2
+  ``CrawlConfig`` enum from the spec lives in ``crawler.py`` once it
+  ships; we keep this one minimal so we don't pre-commit to choices
+  the crawler will revisit.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from src.services.intelligence.models import (
+    EdgeType,
+    GraphEdge,
+    GraphNode,
+    NodeType,
+)
+
+# Identifier scrubber: keep only chars allowed by GraphNode.node_id
+# (alphanumeric, colons, periods, hyphens, underscores). Anything else
+# is collapsed to ``_`` so external ids with slashes/spaces still
+# produce valid node ids.
+_ID_SAFE_CHARS = re.compile(r"[^A-Za-z0-9:._-]+")
+
+
+def _normalize_id_segment(value: str) -> str:
+    """Return a node-id-safe segment: scrub disallowed chars, trim.
+
+    Collapses runs of unsafe characters (slash, space, etc.) into a
+    single underscore so the resulting node id matches the kernel's
+    validation regex without losing readability.
+    """
+    cleaned = _ID_SAFE_CHARS.sub("_", value.strip()).strip("_")
+    if not cleaned:
+        raise ValueError("Identifier segment is empty after sanitization")
+    return cleaned
+
+
+def make_paper_node_id(source: str, external_id: str) -> str:
+    """Build a canonical ``paper:<source>:<external_id>`` node id.
+
+    Args:
+        source: Origin of the id (``s2``, ``openalex``, ``arxiv``,
+            ``doi``). Must be a short identifier; sanitized.
+        external_id: The provider-specific id. Sanitized for storage.
+
+    Returns:
+        A node id of the form ``paper:<source>:<external_id>``.
+
+    Raises:
+        ValueError: If either segment is empty after sanitization.
+    """
+    return f"paper:{_normalize_id_segment(source)}:{_normalize_id_segment(external_id)}"
+
+
+def make_citation_edge_id(citing_id: str, cited_id: str) -> str:
+    """Build a deterministic edge id for a CITES relationship.
+
+    Deterministic edge ids let bulk inserts be idempotent within a
+    single transaction (a duplicate raises a constraint error before
+    any partial write — see ``add_edges_batch``).
+    """
+    # The two node ids are already validated, but we still scrub here
+    # to defend against future callers passing raw external ids.
+    return (
+        f"edge:cites:"
+        f"{_normalize_id_segment(citing_id)}:{_normalize_id_segment(cited_id)}"
+    )
+
+
+class CitationDirection(str, Enum):
+    """Direction of citation traversal for the graph builder.
+
+    - ``OUT``: outgoing — the seed paper's *references* (what it cites).
+    - ``IN``: incoming — papers that *cite* the seed.
+    - ``BOTH``: both directions (one round-trip per side).
+    """
+
+    OUT = "out"
+    IN = "in"
+    BOTH = "both"
+
+
+class CitationNode(BaseModel):
+    """A paper in the citation graph (REQ-9.2.1).
+
+    This is the domain model layered over ``GraphNode``. It carries the
+    fields the spec calls out (paper_id, external_ids, title, year,
+    citation_count, reference_count, is_in_corpus, influence_score,
+    fetched_at) and validates them more strictly than a generic
+    properties dict would.
+
+    Construction expectations:
+    - ``paper_id`` is the canonical graph node id. Use
+      :func:`make_paper_node_id` to build one from a provider id.
+    - ``external_ids`` maps short source codes (``s2``, ``doi``,
+      ``arxiv``, ``openalex``) to their provider value. Optional fields
+      are simply omitted; we never store ``None`` values in the graph
+      properties dict.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+        json_schema_extra={
+            "example": {
+                "paper_id": "paper:s2:204e3073870fae3d05bcbc2f6a8e263d9b72e776",
+                "external_ids": {
+                    "s2": "204e3073870fae3d05bcbc2f6a8e263d9b72e776",
+                    "doi": "10.5555/3295222.3295349",
+                    "arxiv": "1706.03762",
+                },
+                "title": "Attention Is All You Need",
+                "year": 2017,
+                "citation_count": 95000,
+                "reference_count": 36,
+                "is_in_corpus": False,
+                "influence_score": None,
+            }
+        },
+    )
+
+    paper_id: str = Field(
+        ...,
+        min_length=1,
+        max_length=512,
+        description="Canonical graph node id (use make_paper_node_id).",
+    )
+    external_ids: dict[str, str] = Field(
+        default_factory=dict,
+        description="Source-to-id map (e.g. {'s2': '...', 'doi': '...'}).",
+    )
+    title: str = Field(
+        ...,
+        min_length=1,
+        max_length=2048,
+        description="Paper title.",
+    )
+    year: int | None = Field(
+        default=None,
+        ge=1800,
+        le=2100,
+        description="Publication year, if known.",
+    )
+    citation_count: int = Field(
+        default=0,
+        ge=0,
+        description="How many papers cite this one (per source).",
+    )
+    reference_count: int = Field(
+        default=0,
+        ge=0,
+        description="How many papers this one references.",
+    )
+    is_in_corpus: bool = Field(
+        default=False,
+        description="True iff we have full text for this paper locally.",
+    )
+    influence_score: float | None = Field(
+        default=None,
+        description="Optional precomputed influence score (e.g. PageRank).",
+    )
+    fetched_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        description="When this record was fetched from the source.",
+    )
+
+    @field_validator("paper_id")
+    @classmethod
+    def _validate_paper_id(cls, v: str) -> str:
+        """Mirror the storage-layer node id regex.
+
+        We re-validate here so callers fail at model construction time
+        with a meaningful error, rather than at the SQLite boundary.
+        """
+        v = v.strip()
+        if not v:
+            raise ValueError("paper_id cannot be empty")
+        if not re.match(r"^[A-Za-z0-9:._-]+$", v):
+            raise ValueError(
+                f"Invalid paper_id format: {v!r}. "
+                "Allowed: alphanumeric, colons, periods, hyphens, underscores."
+            )
+        return v
+
+    @field_validator("external_ids")
+    @classmethod
+    def _validate_external_ids(cls, v: dict[str, str]) -> dict[str, str]:
+        """Reject empty source codes or empty id values.
+
+        We don't try to enumerate the allowed source codes — the spec
+        explicitly anticipates new sources (Crossref, OpenAlex variants)
+        — but every entry must be a non-empty key/value pair so we
+        don't pollute the graph with ``{"": ""}`` placeholders.
+        """
+        for key, value in v.items():
+            if not isinstance(key, str) or not key.strip():
+                raise ValueError("external_ids keys must be non-empty source codes")
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"external_ids[{key!r}] must be a non-empty string")
+        return v
+
+    def to_graph_node(self) -> GraphNode:
+        """Project the domain model onto a kernel ``GraphNode``.
+
+        Properties dict is built explicitly — we omit ``None`` values
+        rather than store JSON nulls — and ``fetched_at`` is serialized
+        to ISO-8601 so the storage layer's JSON dump is stable.
+        """
+        properties: dict[str, Any] = {
+            "title": self.title,
+            "external_ids": dict(self.external_ids),
+            "citation_count": self.citation_count,
+            "reference_count": self.reference_count,
+            "is_in_corpus": self.is_in_corpus,
+            "fetched_at": self.fetched_at.isoformat(),
+        }
+        if self.year is not None:
+            properties["year"] = self.year
+        if self.influence_score is not None:
+            properties["influence_score"] = self.influence_score
+
+        return GraphNode(
+            node_id=self.paper_id,
+            node_type=NodeType.PAPER,
+            properties=properties,
+        )
+
+
+class CitationEdge(BaseModel):
+    """A directed citation relationship (REQ-9.2.1).
+
+    Mirrors the spec's ``CitationEdge``. Edges always point from the
+    citing paper to the cited paper (``CITES`` semantics). The
+    ``is_influential`` flag carries Semantic Scholar's
+    ``isInfluential`` signal verbatim when available; OpenAlex does not
+    provide this and will leave it ``None``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    citing_paper_id: str = Field(
+        ...,
+        min_length=1,
+        max_length=512,
+        description="Source (citing) paper node id.",
+    )
+    cited_paper_id: str = Field(
+        ...,
+        min_length=1,
+        max_length=512,
+        description="Target (cited) paper node id.",
+    )
+    context: str | None = Field(
+        default=None,
+        max_length=4096,
+        description="Snippet around the citation marker, if available.",
+    )
+    section: str | None = Field(
+        default=None,
+        max_length=256,
+        description="Section the citation appears in (e.g. 'Introduction').",
+    )
+    is_influential: bool | None = Field(
+        default=None,
+        description=(
+            "Semantic Scholar 'isInfluential' flag. None when the "
+            "source does not provide it (e.g. OpenAlex)."
+        ),
+    )
+    source: str = Field(
+        default="semantic_scholar",
+        min_length=1,
+        max_length=64,
+        description="Provider that produced this edge (provenance).",
+    )
+
+    @field_validator("citing_paper_id", "cited_paper_id")
+    @classmethod
+    def _validate_ids(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("Citation paper ids cannot be empty")
+        if not re.match(r"^[A-Za-z0-9:._-]+$", v):
+            raise ValueError(
+                f"Invalid citation paper id: {v!r}. "
+                "Allowed: alphanumeric, colons, periods, hyphens, underscores."
+            )
+        return v
+
+    def to_graph_edge(self) -> GraphEdge:
+        """Project the domain edge onto a kernel ``GraphEdge``."""
+        properties: dict[str, Any] = {"source": self.source}
+        if self.context is not None:
+            properties["context"] = self.context
+        if self.section is not None:
+            properties["section"] = self.section
+        if self.is_influential is not None:
+            properties["is_influential"] = self.is_influential
+
+        return GraphEdge(
+            edge_id=make_citation_edge_id(self.citing_paper_id, self.cited_paper_id),
+            edge_type=EdgeType.CITES,
+            source_id=self.citing_paper_id,
+            target_id=self.cited_paper_id,
+            properties=properties,
+        )

--- a/src/services/intelligence/citation/semantic_scholar_client.py
+++ b/src/services/intelligence/citation/semantic_scholar_client.py
@@ -1,0 +1,488 @@
+"""Semantic Scholar citation client (Milestone 9.2 — primary source).
+
+This is **not** the existing ``SemanticScholarProvider`` from
+``src.services.providers.semantic_scholar``; that one implements the
+``DiscoveryProvider`` ABC for keyword paper search. The citation graph
+needs different endpoints (``/paper/{id}/references``,
+``/paper/{id}/citations``), pagination semantics (``offset``/``limit``
+up to S2's 1000 cap), and a 7-day disk cache per spec (Section 11.3).
+We deliberately built alongside rather than retrofitting the search
+provider — see the package docstring for the rationale.
+
+Spec mapping:
+- REQ-9.2.1 (Citation Graph Construction): ``get_references`` and
+  ``get_citations`` produce :class:`CitationNode` / :class:`CitationEdge`
+  pairs ready for the graph builder to persist.
+- SR-9.1 (API Key Management): the API key is read from the
+  ``SEMANTIC_SCHOLAR_API_KEY`` env var by default; never hardcoded.
+- SR-9.2 (Rate Limiting): 100 req / 5min with an API key, 1 req/sec
+  without; both bounds are enforced via :class:`RateLimiter` and the
+  caller can override either value.
+- Cost optimization (Section 11.3): citation lookups are cached on
+  disk for 7 days (TTL configurable for tests).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any, Optional, cast
+
+import aiohttp
+import diskcache
+import structlog
+
+from src.services.intelligence.citation.models import (
+    CitationEdge,
+    CitationNode,
+    make_paper_node_id,
+)
+from src.services.providers.base import APIError, RateLimitError
+from src.utils.rate_limiter import RateLimiter
+
+logger = structlog.get_logger(__name__)
+
+
+# Spec-mandated cache TTL (Section 11.3): citation lookups are cached
+# for 7 days. Tests pass a much shorter TTL via constructor arg.
+_DEFAULT_CITATION_CACHE_TTL_SECONDS = 7 * 24 * 60 * 60
+
+# S2 hard cap on a single page of results.
+_S2_MAX_PAGE_LIMIT = 1000
+
+# Default per-call ceiling. Far below the spec's worst-case crawl-level
+# budget so a single ``get_references`` cannot pull thousands of pages.
+_DEFAULT_MAX_RESULTS = 200
+
+# Fields requested from S2 for both endpoints. Ordered for readability;
+# S2 ignores order. We request both ``citationCount`` and
+# ``influentialCitationCount`` so the Week-2 ``sort_by_influence``
+# helper has the data it needs without a second round-trip.
+_S2_PAPER_FIELDS = ",".join(
+    [
+        "paperId",
+        "externalIds",
+        "title",
+        "year",
+        "citationCount",
+        "influentialCitationCount",
+        "referenceCount",
+    ]
+)
+
+
+class SemanticScholarCitationClient:
+    """Citation-endpoint client for Semantic Scholar.
+
+    Public methods return ``(seed_node, related_nodes, edges)`` tuples
+    where:
+    - ``seed_node`` is a :class:`CitationNode` for the paper queried,
+    - ``related_nodes`` is the list of cited/citing papers (as
+      :class:`CitationNode`),
+    - ``edges`` is the list of :class:`CitationEdge` connecting them
+      (always pointing from citing to cited).
+
+    Caching: each ``(endpoint, paper_id, max_results)`` triple is cached
+    for ``cache_ttl_seconds`` (7 days by default). The cache is on disk
+    via ``diskcache`` so it survives process restarts. Pass
+    ``cache_dir=None`` to disable caching entirely (used in tests that
+    need to assert HTTP behavior on each call).
+    """
+
+    BASE_URL = "https://api.semanticscholar.org/graph/v1"
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        rate_limiter: Optional[RateLimiter] = None,
+        cache_dir: Optional[Path | str] = None,
+        cache_ttl_seconds: int = _DEFAULT_CITATION_CACHE_TTL_SECONDS,
+        request_timeout_seconds: float = 30.0,
+    ) -> None:
+        """Initialize the client.
+
+        Args:
+            api_key: Semantic Scholar API key. If ``None``, falls back
+                to the ``SEMANTIC_SCHOLAR_API_KEY`` env var. Either path
+                is fine — the caller chooses where the secret lives —
+                but the resulting key is *never* logged.
+            rate_limiter: Optional pre-built rate limiter. When
+                ``None``, the client builds one matching S2's published
+                limits: 100 req/5min (~20 req/min) with an API key,
+                12 req/min (1/5s) without. The lower no-key value is
+                deliberately conservative — S2 throttles aggressively
+                on unauthenticated calls.
+            cache_dir: Directory for the disk cache. ``None`` disables
+                caching. Defaults to ``$ARISP_CITATION_CACHE_DIR`` or
+                ``./cache/citation/s2``.
+            cache_ttl_seconds: TTL for cached citation lookups. Default
+                is 7 days per spec Section 11.3; tests pass smaller
+                values to exercise expiration logic.
+            request_timeout_seconds: Per-request HTTP timeout.
+        """
+        self.api_key = (
+            api_key if api_key is not None else os.getenv("SEMANTIC_SCHOLAR_API_KEY")
+        )
+
+        if rate_limiter is None:
+            # 100 req / 5min with an API key = 20 req/min effective.
+            # Without a key S2 enforces ~1 req/sec; we go a touch under
+            # at 12 req/min to leave headroom for retry storms.
+            requests_per_minute = 20 if self.api_key else 12
+            rate_limiter = RateLimiter(
+                requests_per_minute=requests_per_minute,
+                burst_size=5,
+            )
+        self.rate_limiter = rate_limiter
+
+        self.request_timeout_seconds = request_timeout_seconds
+
+        self._cache: Optional[diskcache.Cache]
+        if cache_dir is None and "ARISP_CITATION_CACHE_DIR" in os.environ:
+            cache_dir = os.environ["ARISP_CITATION_CACHE_DIR"]
+
+        if cache_dir is None:
+            self._cache = None
+            self._cache_ttl_seconds = cache_ttl_seconds
+        else:
+            cache_path = Path(cache_dir) / "s2"
+            cache_path.mkdir(parents=True, exist_ok=True)
+            self._cache = diskcache.Cache(str(cache_path), timeout=cache_ttl_seconds)
+            self._cache_ttl_seconds = cache_ttl_seconds
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def get_references(
+        self,
+        paper_id: str,
+        max_results: int = _DEFAULT_MAX_RESULTS,
+    ) -> tuple[CitationNode, list[CitationNode], list[CitationEdge]]:
+        """Fetch papers the seed paper *references* (outgoing edges).
+
+        Args:
+            paper_id: The S2-recognized paper id. Accepts S2 native ids
+                (``204e3073...``), DOI form (``10.18653/v1/...``), or
+                arxiv form (``arxiv:1706.03762``). S2's API resolves
+                all three transparently.
+            max_results: Cap on rows returned. We page in 100-row
+                chunks until either the cap is hit or S2 reports no
+                more results. Defaults to 200; the spec's BFS layer
+                caps at 200 too.
+
+        Returns:
+            ``(seed_node, ref_nodes, edges)`` — see the class docstring.
+        """
+        return await self._fetch_relationships(
+            endpoint="references",
+            paper_id=paper_id,
+            max_results=max_results,
+        )
+
+    async def get_citations(
+        self,
+        paper_id: str,
+        max_results: int = _DEFAULT_MAX_RESULTS,
+    ) -> tuple[CitationNode, list[CitationNode], list[CitationEdge]]:
+        """Fetch papers that *cite* the seed paper (incoming edges).
+
+        Mirror of :meth:`get_references` but for the ``/citations``
+        endpoint. Returned edges still point from citing → cited, so
+        in this case every edge has ``cited_paper_id == seed.paper_id``.
+        """
+        return await self._fetch_relationships(
+            endpoint="citations",
+            paper_id=paper_id,
+            max_results=max_results,
+        )
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    async def _fetch_relationships(
+        self,
+        endpoint: str,
+        paper_id: str,
+        max_results: int,
+    ) -> tuple[CitationNode, list[CitationNode], list[CitationEdge]]:
+        """Common path for ``get_references`` / ``get_citations``."""
+        if not paper_id or not paper_id.strip():
+            raise ValueError("paper_id must be a non-empty string")
+        if max_results < 1:
+            raise ValueError("max_results must be >= 1")
+        if endpoint not in {"references", "citations"}:
+            # Internal callers only — guards against typos in future
+            # wrapper methods.
+            raise ValueError(f"Unsupported endpoint: {endpoint!r}")
+
+        cache_key = self._cache_key(endpoint, paper_id, max_results)
+        cached = self._cache_get(cache_key)
+        if cached is not None:
+            logger.info(
+                "s2_citation_cache_hit",
+                endpoint=endpoint,
+                paper_id=paper_id,
+            )
+            return self._deserialize_payload(cached)
+
+        # Cache miss — fetch the seed metadata and the related list in
+        # parallel. The seed metadata gives us authoritative title /
+        # year / citation_count to attach to the seed node, which the
+        # spec requires (REQ-9.2.1).
+        seed_task = asyncio.create_task(self._fetch_paper(paper_id))
+        rels_task = asyncio.create_task(
+            self._fetch_relationship_pages(endpoint, paper_id, max_results)
+        )
+        seed_payload = await seed_task
+        rel_payloads = await rels_task
+
+        seed_node = self._payload_to_node(seed_payload)
+
+        related_nodes: list[CitationNode] = []
+        edges: list[CitationEdge] = []
+        for entry in rel_payloads:
+            related_payload = entry.get("citingPaper") or entry.get("citedPaper")
+            if not related_payload:
+                # S2 occasionally returns rows where the related paper
+                # body is missing (deleted record). Skip silently —
+                # there's nothing to add to the graph.
+                continue
+
+            try:
+                related_node = self._payload_to_node(related_payload)
+            except (ValueError, KeyError) as exc:
+                logger.warning(
+                    "s2_citation_skip_invalid_node",
+                    endpoint=endpoint,
+                    seed_paper_id=paper_id,
+                    error=str(exc),
+                )
+                continue
+
+            related_nodes.append(related_node)
+
+            if endpoint == "references":
+                citing, cited = seed_node.paper_id, related_node.paper_id
+            else:  # citations: caller is the cited paper
+                citing, cited = related_node.paper_id, seed_node.paper_id
+
+            edges.append(
+                CitationEdge(
+                    citing_paper_id=citing,
+                    cited_paper_id=cited,
+                    context=self._first_context(entry.get("contexts")),
+                    section=self._first_context(entry.get("intents")),
+                    is_influential=entry.get("isInfluential"),
+                    source="semantic_scholar",
+                )
+            )
+
+        result = (seed_node, related_nodes, edges)
+        self._cache_set(cache_key, self._serialize_payload(result))
+        logger.info(
+            "s2_citation_fetched",
+            endpoint=endpoint,
+            paper_id=paper_id,
+            related_count=len(related_nodes),
+        )
+        return result
+
+    async def _fetch_paper(self, paper_id: str) -> dict[str, Any]:
+        """Fetch the seed paper's own metadata."""
+        url = f"{self.BASE_URL}/paper/{paper_id}"
+        params = {"fields": _S2_PAPER_FIELDS}
+        return await self._http_get(url, params=params)
+
+    async def _fetch_relationship_pages(
+        self,
+        endpoint: str,
+        paper_id: str,
+        max_results: int,
+    ) -> list[dict[str, Any]]:
+        """Page through ``/references`` or ``/citations`` until done.
+
+        S2 caps a single page at 1000 rows; we chunk in 100-row pages
+        because that's where the API documentation says response time
+        plateaus, and smaller pages let us bail early once ``max_results``
+        is hit without wasting bandwidth.
+        """
+        url = f"{self.BASE_URL}/paper/{paper_id}/{endpoint}"
+        page_size = min(100, max_results, _S2_MAX_PAGE_LIMIT)
+
+        collected: list[dict[str, Any]] = []
+        offset = 0
+        while len(collected) < max_results:
+            params = {
+                "fields": _S2_PAPER_FIELDS + ",contexts,intents,isInfluential",
+                "limit": str(page_size),
+                "offset": str(offset),
+            }
+            payload = await self._http_get(url, params=params)
+            data = payload.get("data") or []
+            if not data:
+                break
+            collected.extend(data)
+
+            # S2 returns ``next`` only when more pages exist. If it is
+            # absent or zero we have reached the end of the result set.
+            next_offset = payload.get("next")
+            if next_offset is None or next_offset == offset:
+                break
+            offset = int(next_offset)
+
+        return collected[:max_results]
+
+    async def _http_get(
+        self,
+        url: str,
+        params: dict[str, str],
+    ) -> dict[str, Any]:
+        """Issue a single GET to S2 with rate limiting + error handling.
+
+        Distinguishes:
+        - 200: returns the parsed JSON body.
+        - 404: raises ``APIError`` (the seed paper id is unknown — not
+          retryable).
+        - 429: raises ``RateLimitError`` (caller may retry).
+        - 5xx / other: raises ``APIError``.
+        """
+        await self.rate_limiter.acquire("semantic_scholar_citations")
+
+        headers: dict[str, str] = {}
+        if self.api_key:
+            headers["x-api-key"] = self.api_key
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    url,
+                    params=params,
+                    headers=headers,
+                    timeout=aiohttp.ClientTimeout(total=self.request_timeout_seconds),
+                ) as response:
+                    if response.status == 429:
+                        raise RateLimitError(
+                            "Semantic Scholar citation rate limit exceeded"
+                        )
+                    if response.status == 404:
+                        text = await response.text()
+                        raise APIError(
+                            f"Paper not found on Semantic Scholar (404): {text}"
+                        )
+                    if response.status != 200:
+                        text = await response.text()
+                        raise APIError(
+                            f"Semantic Scholar error {response.status}: {text}"
+                        )
+                    body: dict[str, Any] = await response.json()
+                    return body
+        except asyncio.TimeoutError as exc:
+            raise APIError(
+                f"Semantic Scholar request timed out after "
+                f"{self.request_timeout_seconds}s"
+            ) from exc
+
+    # ------------------------------------------------------------------
+    # Payload <-> CitationNode glue
+    # ------------------------------------------------------------------
+
+    def _payload_to_node(self, payload: dict[str, Any]) -> CitationNode:
+        """Convert an S2 paper payload into a :class:`CitationNode`."""
+        s2_id = payload.get("paperId")
+        if not s2_id:
+            raise KeyError("S2 payload missing paperId")
+
+        external_ids: dict[str, str] = {"s2": str(s2_id)}
+        for key, value in (payload.get("externalIds") or {}).items():
+            if value:
+                external_ids[str(key).lower()] = str(value)
+
+        title = payload.get("title") or "Unknown Title"
+
+        return CitationNode(
+            paper_id=make_paper_node_id("s2", str(s2_id)),
+            external_ids=external_ids,
+            title=title,
+            year=payload.get("year"),
+            citation_count=int(payload.get("citationCount") or 0),
+            reference_count=int(payload.get("referenceCount") or 0),
+        )
+
+    @staticmethod
+    def _first_context(value: Any) -> Optional[str]:
+        """Extract a single string from S2's list-of-strings fields.
+
+        S2 returns ``contexts`` and ``intents`` as JSON arrays. The
+        spec's ``CitationEdge`` only allows a single string per field,
+        so we keep the first non-empty entry. If the list is empty or
+        absent we return ``None`` and the edge property is omitted.
+        """
+        if not value:
+            return None
+        if isinstance(value, list):
+            for entry in value:
+                if entry:
+                    return str(entry)
+            return None
+        # Non-list scalar — should not happen but defends against
+        # surprise schema changes upstream.
+        return str(value)
+
+    # ------------------------------------------------------------------
+    # Cache helpers
+    # ------------------------------------------------------------------
+
+    def _cache_key(self, endpoint: str, paper_id: str, max_results: int) -> str:
+        """Derive a stable cache key.
+
+        We hash the inputs so the resulting key is filesystem-safe and
+        bounded in length — paper ids can include slashes (DOIs) which
+        would otherwise break diskcache on some platforms.
+        """
+        raw = f"{endpoint}|{paper_id}|{max_results}"
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+    def _cache_get(self, key: str) -> Optional[bytes]:
+        if self._cache is None:
+            return None
+        value = self._cache.get(key)
+        return cast(Optional[bytes], value)
+
+    def _cache_set(self, key: str, payload: bytes) -> None:
+        if self._cache is None:
+            return
+        self._cache.set(key, payload, expire=self._cache_ttl_seconds)
+
+    @staticmethod
+    def _serialize_payload(
+        result: tuple[CitationNode, list[CitationNode], list[CitationEdge]],
+    ) -> bytes:
+        seed, related, edges = result
+        return json.dumps(
+            {
+                "seed": seed.model_dump(mode="json"),
+                "related": [n.model_dump(mode="json") for n in related],
+                "edges": [e.model_dump(mode="json") for e in edges],
+            }
+        ).encode("utf-8")
+
+    @staticmethod
+    def _deserialize_payload(
+        raw: bytes,
+    ) -> tuple[CitationNode, list[CitationNode], list[CitationEdge]]:
+        data = json.loads(raw.decode("utf-8"))
+        seed = CitationNode.model_validate(data["seed"])
+        related = [CitationNode.model_validate(n) for n in data["related"]]
+        edges = [CitationEdge.model_validate(e) for e in data["edges"]]
+        return seed, related, edges
+
+    def close(self) -> None:
+        """Release any disk cache handle."""
+        if self._cache is not None:
+            self._cache.close()
+            self._cache = None

--- a/tests/unit/services/intelligence/citation/__init__.py
+++ b/tests/unit/services/intelligence/citation/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the citation graph package (Milestone 9.2)."""

--- a/tests/unit/services/intelligence/citation/test_models.py
+++ b/tests/unit/services/intelligence/citation/test_models.py
@@ -1,0 +1,440 @@
+"""Tests for citation domain models (Milestone 9.2 — Week 1)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from src.services.intelligence.citation.models import (
+    CitationDirection,
+    CitationEdge,
+    CitationNode,
+    _normalize_id_segment,
+    make_citation_edge_id,
+    make_paper_node_id,
+)
+from src.services.intelligence.models import EdgeType, NodeType
+
+# ---------------------------------------------------------------------------
+# _normalize_id_segment
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_id_segment_passes_safe_input():
+    assert _normalize_id_segment("abc.123-DEF") == "abc.123-DEF"
+
+
+def test_normalize_id_segment_collapses_unsafe_runs():
+    # slashes and spaces collapse to a single underscore
+    assert _normalize_id_segment("10.18653/v1/2020 paper") == "10.18653_v1_2020_paper"
+
+
+def test_normalize_id_segment_strips_surrounding_whitespace():
+    assert _normalize_id_segment("  abc  ") == "abc"
+
+
+def test_normalize_id_segment_rejects_empty_string():
+    with pytest.raises(ValueError, match="empty after sanitization"):
+        _normalize_id_segment("")
+
+
+def test_normalize_id_segment_rejects_only_unsafe_chars():
+    # All chars get replaced and stripped → empty result
+    with pytest.raises(ValueError, match="empty after sanitization"):
+        _normalize_id_segment("///")
+
+
+# ---------------------------------------------------------------------------
+# make_paper_node_id
+# ---------------------------------------------------------------------------
+
+
+def test_make_paper_node_id_builds_canonical_form():
+    node_id = make_paper_node_id("s2", "204e3073870fae3d05bcbc2f6a8e263d9b72e776")
+    assert node_id == "paper:s2:204e3073870fae3d05bcbc2f6a8e263d9b72e776"
+
+
+def test_make_paper_node_id_sanitizes_doi_with_slashes():
+    node_id = make_paper_node_id("doi", "10.18653/v1/2020.acl-main.1")
+    assert node_id == "paper:doi:10.18653_v1_2020.acl-main.1"
+    # Must satisfy GraphNode.node_id regex
+    import re
+
+    assert re.match(r"^[A-Za-z0-9:._-]+$", node_id)
+
+
+def test_make_paper_node_id_rejects_empty_external_id():
+    with pytest.raises(ValueError):
+        make_paper_node_id("s2", "")
+
+
+def test_make_paper_node_id_rejects_empty_source():
+    with pytest.raises(ValueError):
+        make_paper_node_id("", "abc123")
+
+
+# ---------------------------------------------------------------------------
+# make_citation_edge_id
+# ---------------------------------------------------------------------------
+
+
+def test_make_citation_edge_id_is_deterministic():
+    e1 = make_citation_edge_id("paper:s2:abc", "paper:s2:def")
+    e2 = make_citation_edge_id("paper:s2:abc", "paper:s2:def")
+    assert e1 == e2 == "edge:cites:paper:s2:abc:paper:s2:def"
+
+
+def test_make_citation_edge_id_directional_difference():
+    forward = make_citation_edge_id("paper:s2:abc", "paper:s2:def")
+    reverse = make_citation_edge_id("paper:s2:def", "paper:s2:abc")
+    assert forward != reverse
+
+
+def test_make_citation_edge_id_sanitizes_inputs():
+    edge_id = make_citation_edge_id("paper s2 abc", "paper/def")
+    # Spaces and slashes get scrubbed
+    assert " " not in edge_id
+    assert "/" not in edge_id
+
+
+# ---------------------------------------------------------------------------
+# CitationDirection enum
+# ---------------------------------------------------------------------------
+
+
+def test_citation_direction_values():
+    assert CitationDirection.OUT.value == "out"
+    assert CitationDirection.IN.value == "in"
+    assert CitationDirection.BOTH.value == "both"
+
+
+def test_citation_direction_membership():
+    assert CitationDirection("out") is CitationDirection.OUT
+    assert CitationDirection("in") is CitationDirection.IN
+    assert CitationDirection("both") is CitationDirection.BOTH
+
+
+def test_citation_direction_rejects_unknown_value():
+    with pytest.raises(ValueError):
+        CitationDirection("sideways")
+
+
+# ---------------------------------------------------------------------------
+# CitationNode — happy path & defaults
+# ---------------------------------------------------------------------------
+
+
+def test_citation_node_minimal_construction():
+    node = CitationNode(paper_id="paper:s2:abc123", title="A Paper")
+    assert node.paper_id == "paper:s2:abc123"
+    assert node.title == "A Paper"
+    assert node.year is None
+    assert node.citation_count == 0
+    assert node.reference_count == 0
+    assert node.is_in_corpus is False
+    assert node.influence_score is None
+    assert node.external_ids == {}
+    assert isinstance(node.fetched_at, datetime)
+    assert node.fetched_at.tzinfo == timezone.utc
+
+
+def test_citation_node_full_construction():
+    node = CitationNode(
+        paper_id="paper:s2:abc",
+        external_ids={"s2": "abc", "doi": "10.1/2"},
+        title="Attention Is All You Need",
+        year=2017,
+        citation_count=95000,
+        reference_count=36,
+        is_in_corpus=True,
+        influence_score=0.91,
+    )
+    assert node.year == 2017
+    assert node.influence_score == 0.91
+    assert node.is_in_corpus is True
+    assert node.external_ids["doi"] == "10.1/2"
+
+
+# ---------------------------------------------------------------------------
+# CitationNode — validators
+# ---------------------------------------------------------------------------
+
+
+def test_citation_node_paper_id_strips_whitespace():
+    node = CitationNode(paper_id="  paper:s2:abc  ", title="t")
+    assert node.paper_id == "paper:s2:abc"
+
+
+def test_citation_node_paper_id_rejects_empty_after_strip():
+    with pytest.raises(ValidationError) as exc:
+        CitationNode(paper_id="   ", title="t")
+    assert "cannot be empty" in str(exc.value) or "at least 1 character" in str(
+        exc.value
+    )
+
+
+def test_citation_node_paper_id_rejects_invalid_chars():
+    with pytest.raises(ValidationError, match="Invalid paper_id format"):
+        CitationNode(paper_id="paper:s2:abc/def", title="t")
+
+
+def test_citation_node_paper_id_rejects_min_length_violation():
+    with pytest.raises(ValidationError):
+        CitationNode(paper_id="", title="t")
+
+
+def test_citation_node_title_required():
+    with pytest.raises(ValidationError):
+        CitationNode(paper_id="paper:s2:abc", title="")
+
+
+def test_citation_node_year_lower_bound():
+    with pytest.raises(ValidationError):
+        CitationNode(paper_id="paper:s2:abc", title="t", year=1799)
+
+
+def test_citation_node_year_upper_bound():
+    with pytest.raises(ValidationError):
+        CitationNode(paper_id="paper:s2:abc", title="t", year=2101)
+
+
+def test_citation_node_year_accepts_valid_range():
+    node = CitationNode(paper_id="paper:s2:abc", title="t", year=2017)
+    assert node.year == 2017
+
+
+def test_citation_node_citation_count_negative_rejected():
+    with pytest.raises(ValidationError):
+        CitationNode(paper_id="paper:s2:abc", title="t", citation_count=-1)
+
+
+def test_citation_node_reference_count_negative_rejected():
+    with pytest.raises(ValidationError):
+        CitationNode(paper_id="paper:s2:abc", title="t", reference_count=-1)
+
+
+def test_citation_node_external_ids_rejects_empty_key():
+    with pytest.raises(ValidationError, match="non-empty source codes"):
+        CitationNode(paper_id="paper:s2:abc", title="t", external_ids={"": "value"})
+
+
+def test_citation_node_external_ids_rejects_whitespace_key():
+    with pytest.raises(ValidationError, match="non-empty source codes"):
+        CitationNode(paper_id="paper:s2:abc", title="t", external_ids={"   ": "value"})
+
+
+def test_citation_node_external_ids_rejects_empty_value():
+    with pytest.raises(ValidationError, match="must be a non-empty string"):
+        CitationNode(paper_id="paper:s2:abc", title="t", external_ids={"s2": ""})
+
+
+def test_citation_node_external_ids_rejects_whitespace_value():
+    with pytest.raises(ValidationError, match="must be a non-empty string"):
+        CitationNode(paper_id="paper:s2:abc", title="t", external_ids={"s2": "   "})
+
+
+def test_citation_node_external_ids_rejects_non_string_key():
+    # Pydantic itself coerces here when possible; but ints will raise
+    with pytest.raises(ValidationError):
+        CitationNode.model_validate(
+            {
+                "paper_id": "paper:s2:abc",
+                "title": "t",
+                "external_ids": {123: "value"},
+            }
+        )
+
+
+def test_citation_node_external_ids_rejects_non_string_value():
+    with pytest.raises(ValidationError):
+        CitationNode.model_validate(
+            {
+                "paper_id": "paper:s2:abc",
+                "title": "t",
+                "external_ids": {"s2": 123},
+            }
+        )
+
+
+def test_citation_node_extra_fields_forbidden():
+    with pytest.raises(ValidationError):
+        CitationNode.model_validate(
+            {
+                "paper_id": "paper:s2:abc",
+                "title": "t",
+                "unknown_field": "x",
+            }
+        )
+
+
+# ---------------------------------------------------------------------------
+# CitationNode.to_graph_node
+# ---------------------------------------------------------------------------
+
+
+def test_citation_node_to_graph_node_minimal():
+    node = CitationNode(paper_id="paper:s2:abc", title="My Paper")
+    graph_node = node.to_graph_node()
+    assert graph_node.node_id == "paper:s2:abc"
+    assert graph_node.node_type == NodeType.PAPER
+    props = graph_node.properties
+    assert props["title"] == "My Paper"
+    assert props["citation_count"] == 0
+    assert props["reference_count"] == 0
+    assert props["is_in_corpus"] is False
+    assert props["external_ids"] == {}
+    # year and influence_score must be omitted, not present as None
+    assert "year" not in props
+    assert "influence_score" not in props
+    assert "fetched_at" in props
+    # ISO-8601 string
+    assert isinstance(props["fetched_at"], str)
+    assert "T" in props["fetched_at"]
+
+
+def test_citation_node_to_graph_node_includes_year_and_influence():
+    node = CitationNode(
+        paper_id="paper:s2:abc",
+        title="Paper",
+        year=2020,
+        influence_score=0.5,
+    )
+    props = node.to_graph_node().properties
+    assert props["year"] == 2020
+    assert props["influence_score"] == 0.5
+
+
+def test_citation_node_to_graph_node_external_ids_copied():
+    ext = {"s2": "abc", "doi": "10.1/2"}
+    node = CitationNode(paper_id="paper:s2:abc", title="t", external_ids=ext)
+    props = node.to_graph_node().properties
+    # Defensive: verify it's a copy, mutating the result doesn't leak back
+    props["external_ids"]["new"] = "x"
+    assert "new" not in node.external_ids
+
+
+# ---------------------------------------------------------------------------
+# CitationEdge — happy path & validators
+# ---------------------------------------------------------------------------
+
+
+def test_citation_edge_minimal_construction():
+    edge = CitationEdge(
+        citing_paper_id="paper:s2:a",
+        cited_paper_id="paper:s2:b",
+    )
+    assert edge.citing_paper_id == "paper:s2:a"
+    assert edge.cited_paper_id == "paper:s2:b"
+    assert edge.context is None
+    assert edge.section is None
+    assert edge.is_influential is None
+    assert edge.source == "semantic_scholar"
+
+
+def test_citation_edge_full_construction():
+    edge = CitationEdge(
+        citing_paper_id="paper:s2:a",
+        cited_paper_id="paper:s2:b",
+        context="As shown in [1]...",
+        section="Introduction",
+        is_influential=True,
+        source="openalex",
+    )
+    assert edge.context == "As shown in [1]..."
+    assert edge.section == "Introduction"
+    assert edge.is_influential is True
+    assert edge.source == "openalex"
+
+
+def test_citation_edge_strips_id_whitespace():
+    edge = CitationEdge(
+        citing_paper_id="  paper:s2:a  ",
+        cited_paper_id="paper:s2:b",
+    )
+    assert edge.citing_paper_id == "paper:s2:a"
+
+
+def test_citation_edge_rejects_blank_citing_id():
+    with pytest.raises(ValidationError):
+        CitationEdge(citing_paper_id="   ", cited_paper_id="paper:s2:b")
+
+
+def test_citation_edge_rejects_invalid_citing_id():
+    with pytest.raises(ValidationError, match="Invalid citation paper id"):
+        CitationEdge(citing_paper_id="paper s2 a", cited_paper_id="paper:s2:b")
+
+
+def test_citation_edge_rejects_invalid_cited_id():
+    with pytest.raises(ValidationError, match="Invalid citation paper id"):
+        CitationEdge(citing_paper_id="paper:s2:a", cited_paper_id="paper/b")
+
+
+def test_citation_edge_rejects_blank_source():
+    with pytest.raises(ValidationError):
+        CitationEdge(
+            citing_paper_id="paper:s2:a", cited_paper_id="paper:s2:b", source=""
+        )
+
+
+def test_citation_edge_extra_fields_forbidden():
+    with pytest.raises(ValidationError):
+        CitationEdge.model_validate(
+            {
+                "citing_paper_id": "paper:s2:a",
+                "cited_paper_id": "paper:s2:b",
+                "unknown_field": "x",
+            }
+        )
+
+
+# ---------------------------------------------------------------------------
+# CitationEdge.to_graph_edge
+# ---------------------------------------------------------------------------
+
+
+def test_citation_edge_to_graph_edge_minimal():
+    edge = CitationEdge(
+        citing_paper_id="paper:s2:a",
+        cited_paper_id="paper:s2:b",
+    )
+    g = edge.to_graph_edge()
+    assert g.source_id == "paper:s2:a"
+    assert g.target_id == "paper:s2:b"
+    assert g.edge_type == EdgeType.CITES
+    assert g.edge_id == "edge:cites:paper:s2:a:paper:s2:b"
+    # Only source property when no extras
+    assert g.properties == {"source": "semantic_scholar"}
+
+
+def test_citation_edge_to_graph_edge_full_properties():
+    edge = CitationEdge(
+        citing_paper_id="paper:s2:a",
+        cited_paper_id="paper:s2:b",
+        context="ctx",
+        section="Methods",
+        is_influential=False,
+        source="openalex",
+    )
+    g = edge.to_graph_edge()
+    assert g.properties == {
+        "source": "openalex",
+        "context": "ctx",
+        "section": "Methods",
+        "is_influential": False,
+    }
+
+
+def test_citation_edge_to_graph_edge_omits_none_properties():
+    # context=None and is_influential=None — should not appear in props
+    edge = CitationEdge(
+        citing_paper_id="paper:s2:a",
+        cited_paper_id="paper:s2:b",
+        section="Intro",
+    )
+    g = edge.to_graph_edge()
+    assert "context" not in g.properties
+    assert "is_influential" not in g.properties
+    assert g.properties["section"] == "Intro"
+    assert g.properties["source"] == "semantic_scholar"

--- a/tests/unit/services/intelligence/citation/test_models.py
+++ b/tests/unit/services/intelligence/citation/test_models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from datetime import datetime, timezone
 
 import pytest
@@ -83,7 +84,10 @@ def test_make_paper_node_id_rejects_empty_source():
 def test_make_citation_edge_id_is_deterministic():
     e1 = make_citation_edge_id("paper:s2:abc", "paper:s2:def")
     e2 = make_citation_edge_id("paper:s2:abc", "paper:s2:def")
-    assert e1 == e2 == "edge:cites:paper:s2:abc:paper:s2:def"
+    assert e1 == e2
+    # Format: 'edge:cites:' + 32 lowercase hex chars (SHA-256 truncated)
+    assert e1.startswith("edge:cites:")
+    assert re.fullmatch(r"edge:cites:[0-9a-f]{32}", e1)
 
 
 def test_make_citation_edge_id_directional_difference():
@@ -93,10 +97,32 @@ def test_make_citation_edge_id_directional_difference():
 
 
 def test_make_citation_edge_id_sanitizes_inputs():
-    edge_id = make_citation_edge_id("paper s2 abc", "paper/def")
-    # Spaces and slashes get scrubbed
-    assert " " not in edge_id
-    assert "/" not in edge_id
+    # Scrubbing happens before hashing; the resulting edge_id is hex
+    # (no spaces or slashes possible by construction). The behavioral
+    # check is that two inputs producing identical scrubbed ids hash
+    # to the same edge.
+    e1 = make_citation_edge_id("paper s2 abc", "paper/def")
+    e2 = make_citation_edge_id("paper_s2_abc", "paper_def")
+    assert e1 == e2
+
+
+def test_make_citation_edge_id_no_collision_on_colon_boundary():
+    """Regression: SHA-256 hashing closes the collision window.
+
+    Pre-fix, ``edge:cites:{a}:{b}`` would collide for any two pairs
+    where ``a + ':' + b`` produced the same string after splitting on
+    colons. The classic case:
+
+        ('paper:s2:abc',      'paper:s2:def:ghi')
+        ('paper:s2:abc:paper', 's2:def:ghi')
+
+    Both would yield ``edge:cites:paper:s2:abc:paper:s2:def:ghi``,
+    silently merging unrelated edges in ``add_edges_batch``. This test
+    pins that distinct pairs always produce distinct edge ids.
+    """
+    e1 = make_citation_edge_id("paper:s2:abc", "paper:s2:def:ghi")
+    e2 = make_citation_edge_id("paper:s2:abc:paper", "s2:def:ghi")
+    assert e1 != e2
 
 
 # ---------------------------------------------------------------------------
@@ -403,7 +429,9 @@ def test_citation_edge_to_graph_edge_minimal():
     assert g.source_id == "paper:s2:a"
     assert g.target_id == "paper:s2:b"
     assert g.edge_type == EdgeType.CITES
-    assert g.edge_id == "edge:cites:paper:s2:a:paper:s2:b"
+    # SHA-256 hashed edge_id (collision-safe, see make_citation_edge_id docstring)
+    assert g.edge_id == make_citation_edge_id("paper:s2:a", "paper:s2:b")
+    assert re.fullmatch(r"edge:cites:[0-9a-f]{32}", g.edge_id)
     # Only source property when no extras
     assert g.properties == {"source": "semantic_scholar"}
 

--- a/tests/unit/services/intelligence/citation/test_semantic_scholar_client.py
+++ b/tests/unit/services/intelligence/citation/test_semantic_scholar_client.py
@@ -1,0 +1,756 @@
+"""Tests for SemanticScholarCitationClient (Milestone 9.2 — Week 1).
+
+All HTTP is mocked. No live API calls.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.services.intelligence.citation.models import (
+    CitationEdge,
+    CitationNode,
+    make_paper_node_id,
+)
+from src.services.intelligence.citation.semantic_scholar_client import (
+    SemanticScholarCitationClient,
+)
+from src.services.providers.base import APIError, RateLimitError
+from src.utils.rate_limiter import RateLimiter
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+SEED_PAYLOAD = {
+    "paperId": "seed1",
+    "externalIds": {"DOI": "10.1/seed", "ArXiv": None},
+    "title": "Seed Paper",
+    "year": 2020,
+    "citationCount": 42,
+    "referenceCount": 7,
+}
+
+
+def _ref_entry(paper_id: str = "ref1", **overrides):
+    """Build a single S2 /references row."""
+    body = {
+        "citedPaper": {
+            "paperId": paper_id,
+            "externalIds": {"DOI": "10.1/" + paper_id},
+            "title": f"Ref {paper_id}",
+            "year": 2019,
+            "citationCount": 10,
+            "referenceCount": 3,
+        },
+        "contexts": ["Context one", "Context two"],
+        "intents": ["methodology"],
+        "isInfluential": True,
+    }
+    body.update(overrides)
+    return body
+
+
+def _cite_entry(paper_id: str = "cite1", **overrides):
+    """Build a single S2 /citations row."""
+    body = {
+        "citingPaper": {
+            "paperId": paper_id,
+            "externalIds": {"DOI": "10.1/" + paper_id},
+            "title": f"Cite {paper_id}",
+            "year": 2021,
+            "citationCount": 5,
+            "referenceCount": 12,
+        },
+        "contexts": ["Cite context"],
+        "intents": [],
+        "isInfluential": False,
+    }
+    body.update(overrides)
+    return body
+
+
+@pytest.fixture
+def fast_limiter():
+    """A nearly no-op rate limiter so tests don't sleep."""
+    return RateLimiter(requests_per_minute=600000, burst_size=1000)
+
+
+@pytest.fixture
+def client(fast_limiter):
+    """Default test client: no cache, no env-derived API key."""
+    # Ensure env var doesn't leak into the test
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("SEMANTIC_SCHOLAR_API_KEY", None)
+        os.environ.pop("ARISP_CITATION_CACHE_DIR", None)
+        c = SemanticScholarCitationClient(
+            api_key=None,
+            rate_limiter=fast_limiter,
+            cache_dir=None,
+        )
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# Constructor
+# ---------------------------------------------------------------------------
+
+
+def test_init_uses_env_var_when_api_key_omitted(monkeypatch):
+    monkeypatch.setenv("SEMANTIC_SCHOLAR_API_KEY", "from-env")
+    monkeypatch.delenv("ARISP_CITATION_CACHE_DIR", raising=False)
+    c = SemanticScholarCitationClient()
+    assert c.api_key == "from-env"
+
+
+def test_init_explicit_api_key_overrides_env(monkeypatch):
+    monkeypatch.setenv("SEMANTIC_SCHOLAR_API_KEY", "from-env")
+    c = SemanticScholarCitationClient(api_key="explicit")
+    assert c.api_key == "explicit"
+
+
+def test_init_no_api_key_when_env_unset(monkeypatch):
+    monkeypatch.delenv("SEMANTIC_SCHOLAR_API_KEY", raising=False)
+    c = SemanticScholarCitationClient(api_key=None)
+    assert c.api_key is None
+
+
+def test_init_default_rate_limiter_with_api_key(monkeypatch):
+    monkeypatch.delenv("SEMANTIC_SCHOLAR_API_KEY", raising=False)
+    c = SemanticScholarCitationClient(api_key="x")
+    # 20 req/min with API key → rate = 20/60
+    assert c.rate_limiter.rate == pytest.approx(20 / 60.0)
+
+
+def test_init_default_rate_limiter_without_api_key(monkeypatch):
+    monkeypatch.delenv("SEMANTIC_SCHOLAR_API_KEY", raising=False)
+    c = SemanticScholarCitationClient(api_key=None)
+    # 12 req/min without API key → rate = 12/60
+    assert c.rate_limiter.rate == pytest.approx(12 / 60.0)
+
+
+def test_init_uses_provided_rate_limiter(fast_limiter):
+    c = SemanticScholarCitationClient(api_key="x", rate_limiter=fast_limiter)
+    assert c.rate_limiter is fast_limiter
+
+
+def test_init_no_cache_when_cache_dir_none_and_no_env(monkeypatch):
+    monkeypatch.delenv("ARISP_CITATION_CACHE_DIR", raising=False)
+    c = SemanticScholarCitationClient(cache_dir=None)
+    assert c._cache is None
+
+
+def test_init_uses_cache_dir_from_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("ARISP_CITATION_CACHE_DIR", str(tmp_path))
+    c = SemanticScholarCitationClient(cache_dir=None)
+    assert c._cache is not None
+    assert (tmp_path / "s2").exists()
+    c.close()
+
+
+def test_init_cache_dir_explicit_path(tmp_path):
+    c = SemanticScholarCitationClient(cache_dir=tmp_path)
+    assert c._cache is not None
+    assert (tmp_path / "s2").exists()
+    c.close()
+
+
+def test_init_cache_dir_explicit_str(tmp_path):
+    c = SemanticScholarCitationClient(cache_dir=str(tmp_path))
+    assert c._cache is not None
+    c.close()
+
+
+def test_close_releases_cache_handle(tmp_path):
+    c = SemanticScholarCitationClient(cache_dir=tmp_path)
+    assert c._cache is not None
+    c.close()
+    assert c._cache is None
+
+
+def test_close_is_safe_when_no_cache(client):
+    # Should not raise even though _cache is None
+    client.close()
+    assert client._cache is None
+
+
+# ---------------------------------------------------------------------------
+# Input validation in _fetch_relationships
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_references_rejects_empty_paper_id(client):
+    with pytest.raises(ValueError, match="non-empty"):
+        await client.get_references("")
+
+
+@pytest.mark.asyncio
+async def test_get_references_rejects_whitespace_paper_id(client):
+    with pytest.raises(ValueError, match="non-empty"):
+        await client.get_references("   ")
+
+
+@pytest.mark.asyncio
+async def test_get_references_rejects_zero_max_results(client):
+    with pytest.raises(ValueError, match="max_results must be"):
+        await client.get_references("abc", max_results=0)
+
+
+@pytest.mark.asyncio
+async def test_internal_fetch_rejects_unknown_endpoint(client):
+    with pytest.raises(ValueError, match="Unsupported endpoint"):
+        await client._fetch_relationships(
+            endpoint="bogus", paper_id="abc", max_results=5
+        )
+
+
+# ---------------------------------------------------------------------------
+# Happy-path: get_references
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_references_happy_path(client):
+    # First call → seed metadata. Second → page 1. Third → page 2 (empty stop).
+    calls: list[str] = []
+
+    async def fake_http_get(url, params):
+        calls.append(url)
+        if url.endswith("/paper/seed1"):
+            return SEED_PAYLOAD
+        if url.endswith("/paper/seed1/references"):
+            offset = int(params["offset"])
+            if offset == 0:
+                return {"data": [_ref_entry("ref1"), _ref_entry("ref2")], "next": 2}
+            return {"data": []}
+        raise AssertionError(f"unexpected url {url}")
+
+    with patch.object(client, "_http_get", side_effect=fake_http_get):
+        seed, related, edges = await client.get_references("seed1", max_results=10)
+
+    assert seed.paper_id == make_paper_node_id("s2", "seed1")
+    assert seed.title == "Seed Paper"
+    assert seed.year == 2020
+    assert seed.citation_count == 42
+    assert seed.reference_count == 7
+    assert seed.external_ids["s2"] == "seed1"
+    assert seed.external_ids["doi"] == "10.1/seed"
+    # ArXiv was None → skipped
+    assert "arxiv" not in seed.external_ids
+
+    assert len(related) == 2
+    assert {n.title for n in related} == {"Ref ref1", "Ref ref2"}
+
+    # Edges point seed → ref (citing → cited), source set
+    assert len(edges) == 2
+    for e in edges:
+        assert e.citing_paper_id == seed.paper_id
+        assert e.source == "semantic_scholar"
+        assert e.is_influential is True
+        assert e.context == "Context one"
+        assert e.section == "methodology"
+
+
+# ---------------------------------------------------------------------------
+# Happy-path: get_citations
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_citations_happy_path(client):
+    async def fake_http_get(url, params):
+        if url.endswith("/paper/seed1"):
+            return SEED_PAYLOAD
+        if url.endswith("/paper/seed1/citations"):
+            return {"data": [_cite_entry("cite1")]}
+        raise AssertionError(f"unexpected url {url}")
+
+    with patch.object(client, "_http_get", side_effect=fake_http_get):
+        seed, related, edges = await client.get_citations("seed1", max_results=10)
+
+    assert len(related) == 1
+    edge = edges[0]
+    # For citations, related → seed
+    assert edge.citing_paper_id == related[0].paper_id
+    assert edge.cited_paper_id == seed.paper_id
+    assert edge.is_influential is False
+    # intents was [] → section None
+    assert edge.section is None
+    assert edge.context == "Cite context"
+
+
+# ---------------------------------------------------------------------------
+# Pagination edge cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pagination_stops_at_max_results(client):
+    # Page returns 100 entries; max_results=3 → trims to 3
+    async def fake_http_get(url, params):
+        if url.endswith("/paper/seed1"):
+            return SEED_PAYLOAD
+        return {"data": [_ref_entry(f"ref{i}") for i in range(100)], "next": 100}
+
+    with patch.object(client, "_http_get", side_effect=fake_http_get):
+        _, related, edges = await client.get_references("seed1", max_results=3)
+
+    assert len(related) == 3
+    assert len(edges) == 3
+
+
+@pytest.mark.asyncio
+async def test_pagination_stops_when_data_empty(client):
+    async def fake_http_get(url, params):
+        if url.endswith("/paper/seed1"):
+            return SEED_PAYLOAD
+        return {"data": [], "next": 50}  # next is ignored when data empty
+
+    with patch.object(client, "_http_get", side_effect=fake_http_get):
+        _, related, _ = await client.get_references("seed1", max_results=10)
+
+    assert related == []
+
+
+@pytest.mark.asyncio
+async def test_pagination_stops_when_next_missing(client):
+    page_calls = {"n": 0}
+
+    async def fake_http_get(url, params):
+        if url.endswith("/paper/seed1"):
+            return SEED_PAYLOAD
+        page_calls["n"] += 1
+        # Single page, no `next`
+        return {"data": [_ref_entry("only")]}
+
+    with patch.object(client, "_http_get", side_effect=fake_http_get):
+        _, related, _ = await client.get_references("seed1", max_results=10)
+
+    assert len(related) == 1
+    assert page_calls["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_pagination_stops_when_next_equals_offset(client):
+    async def fake_http_get(url, params):
+        if url.endswith("/paper/seed1"):
+            return SEED_PAYLOAD
+        offset = int(params["offset"])
+        return {"data": [_ref_entry("only")], "next": offset}
+
+    with patch.object(client, "_http_get", side_effect=fake_http_get):
+        _, related, _ = await client.get_references("seed1", max_results=10)
+
+    assert len(related) == 1
+
+
+@pytest.mark.asyncio
+async def test_pagination_advances_through_multiple_pages(client):
+    async def fake_http_get(url, params):
+        if url.endswith("/paper/seed1"):
+            return SEED_PAYLOAD
+        offset = int(params["offset"])
+        if offset == 0:
+            return {"data": [_ref_entry(f"r{i}") for i in range(5)], "next": 5}
+        if offset == 5:
+            return {"data": [_ref_entry(f"r{i}") for i in range(5, 8)]}
+        raise AssertionError(f"unexpected offset {offset}")
+
+    with patch.object(client, "_http_get", side_effect=fake_http_get):
+        _, related, _ = await client.get_references("seed1", max_results=10)
+
+    assert len(related) == 8
+
+
+# ---------------------------------------------------------------------------
+# Malformed responses
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_skips_entries_with_missing_related_payload(client):
+    async def fake_http_get(url, params):
+        if url.endswith("/paper/seed1"):
+            return SEED_PAYLOAD
+        return {
+            "data": [
+                {"contexts": [], "intents": []},  # no citingPaper / citedPaper
+                _ref_entry("ref-good"),
+            ]
+        }
+
+    with patch.object(client, "_http_get", side_effect=fake_http_get):
+        _, related, edges = await client.get_references("seed1", max_results=10)
+
+    assert len(related) == 1
+    assert related[0].title == "Ref ref-good"
+    assert len(edges) == 1
+
+
+@pytest.mark.asyncio
+async def test_skips_entries_with_invalid_payload_node(client):
+    async def fake_http_get(url, params):
+        if url.endswith("/paper/seed1"):
+            return SEED_PAYLOAD
+        return {
+            "data": [
+                # Missing paperId → KeyError → skipped
+                {"citedPaper": {"title": "no id"}, "contexts": [], "intents": []},
+                _ref_entry("ref-good"),
+            ]
+        }
+
+    with patch.object(client, "_http_get", side_effect=fake_http_get):
+        _, related, edges = await client.get_references("seed1", max_results=10)
+
+    assert len(related) == 1
+    assert len(edges) == 1
+
+
+@pytest.mark.asyncio
+async def test_seed_payload_missing_paper_id_raises(client):
+    async def fake_http_get(url, params):
+        if url.endswith("/paper/seed1"):
+            return {"title": "no id"}  # missing paperId
+        return {"data": []}
+
+    with patch.object(client, "_http_get", side_effect=fake_http_get):
+        with pytest.raises(KeyError, match="missing paperId"):
+            await client.get_references("seed1", max_results=5)
+
+
+@pytest.mark.asyncio
+async def test_payload_with_missing_optional_fields(client):
+    """citationCount / referenceCount / title / year all absent."""
+
+    async def fake_http_get(url, params):
+        if url.endswith("/paper/seed1"):
+            return {"paperId": "seed1"}  # only required field
+        return {"data": []}
+
+    with patch.object(client, "_http_get", side_effect=fake_http_get):
+        seed, related, edges = await client.get_references("seed1", max_results=5)
+
+    assert seed.title == "Unknown Title"
+    assert seed.year is None
+    assert seed.citation_count == 0
+    assert seed.reference_count == 0
+    assert seed.external_ids == {"s2": "seed1"}
+    assert related == []
+    assert edges == []
+
+
+@pytest.mark.asyncio
+async def test_external_ids_filters_falsy_values(client):
+    async def fake_http_get(url, params):
+        if url.endswith("/paper/seed1"):
+            return {
+                "paperId": "seed1",
+                "externalIds": {"DOI": "10.1/x", "ArXiv": "", "PubMed": None},
+            }
+        return {"data": []}
+
+    with patch.object(client, "_http_get", side_effect=fake_http_get):
+        seed, _, _ = await client.get_references("seed1", max_results=5)
+
+    assert seed.external_ids == {"s2": "seed1", "doi": "10.1/x"}
+
+
+# ---------------------------------------------------------------------------
+# _first_context helper (covers all branches)
+# ---------------------------------------------------------------------------
+
+
+def test_first_context_returns_none_for_none():
+    assert SemanticScholarCitationClient._first_context(None) is None
+
+
+def test_first_context_returns_none_for_empty_list():
+    assert SemanticScholarCitationClient._first_context([]) is None
+
+
+def test_first_context_returns_first_entry():
+    assert SemanticScholarCitationClient._first_context(["a", "b", "c"]) == "a"
+
+
+def test_first_context_skips_falsy_entries():
+    assert (
+        SemanticScholarCitationClient._first_context([None, "", "first-real"])
+        == "first-real"
+    )
+
+
+def test_first_context_returns_none_when_all_falsy():
+    assert SemanticScholarCitationClient._first_context(["", None, ""]) is None
+
+
+def test_first_context_handles_scalar_input():
+    # Non-list scalar — defensive branch
+    assert SemanticScholarCitationClient._first_context("scalar") == "scalar"
+
+
+# ---------------------------------------------------------------------------
+# Caching behavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_returns_deserialized_payload(tmp_path, fast_limiter):
+    c = SemanticScholarCitationClient(
+        api_key="x", rate_limiter=fast_limiter, cache_dir=tmp_path
+    )
+
+    seed = CitationNode(paper_id=make_paper_node_id("s2", "seed1"), title="Cached")
+    related = [CitationNode(paper_id=make_paper_node_id("s2", "ref1"), title="R")]
+    edges = [
+        CitationEdge(
+            citing_paper_id=seed.paper_id,
+            cited_paper_id=related[0].paper_id,
+        )
+    ]
+
+    # Pre-populate cache
+    key = c._cache_key("references", "seed1", 5)
+    c._cache_set(key, c._serialize_payload((seed, related, edges)))
+
+    # _http_get must NOT be called
+    with patch.object(c, "_http_get", side_effect=AssertionError("HTTP called!")):
+        s, r, e = await c.get_references("seed1", max_results=5)
+
+    assert s.title == "Cached"
+    assert r[0].title == "R"
+    assert len(e) == 1
+    c.close()
+
+
+@pytest.mark.asyncio
+async def test_cache_miss_then_populated_on_success(tmp_path, fast_limiter):
+    c = SemanticScholarCitationClient(
+        api_key=None, rate_limiter=fast_limiter, cache_dir=tmp_path
+    )
+
+    async def fake_http_get(url, params):
+        if url.endswith("/paper/seed1"):
+            return SEED_PAYLOAD
+        return {"data": [_ref_entry("ref1")]}
+
+    with patch.object(c, "_http_get", side_effect=fake_http_get):
+        await c.get_references("seed1", max_results=5)
+
+    key = c._cache_key("references", "seed1", 5)
+    cached_bytes = c._cache_get(key)
+    assert cached_bytes is not None
+    assert b"Seed Paper" in cached_bytes
+    c.close()
+
+
+def test_cache_get_returns_none_when_no_cache(client):
+    assert client._cache_get("any-key") is None
+
+
+def test_cache_set_no_op_when_no_cache(client):
+    # Must not raise when there is no cache backing
+    client._cache_set("k", b"v")
+    assert client._cache_get("k") is None
+
+
+def test_cache_key_is_stable_and_deterministic(client):
+    k1 = client._cache_key("references", "abc", 10)
+    k2 = client._cache_key("references", "abc", 10)
+    k3 = client._cache_key("references", "abc", 11)
+    assert k1 == k2
+    assert k1 != k3
+    # SHA-256 hex → 64 chars
+    assert len(k1) == 64
+
+
+def test_serialize_then_deserialize_roundtrip():
+    seed = CitationNode(paper_id="paper:s2:abc", title="X")
+    related = [CitationNode(paper_id="paper:s2:def", title="Y")]
+    edges = [
+        CitationEdge(citing_paper_id="paper:s2:abc", cited_paper_id="paper:s2:def")
+    ]
+
+    raw = SemanticScholarCitationClient._serialize_payload((seed, related, edges))
+    s, r, e = SemanticScholarCitationClient._deserialize_payload(raw)
+
+    assert s.paper_id == seed.paper_id
+    assert r[0].paper_id == related[0].paper_id
+    assert e[0].cited_paper_id == "paper:s2:def"
+
+
+# ---------------------------------------------------------------------------
+# _http_get — actually exercise the aiohttp path
+# ---------------------------------------------------------------------------
+
+
+def _mock_aiohttp_response(status, json_body=None, text_body="oops"):
+    """Build an async-context-manager-compatible mocked response."""
+    resp = MagicMock()
+    resp.status = status
+    resp.json = AsyncMock(return_value=json_body)
+    resp.text = AsyncMock(return_value=text_body)
+
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=resp)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+def _patch_session(response_cm):
+    session = MagicMock()
+    session.get = MagicMock(return_value=response_cm)
+    session_cm = MagicMock()
+    session_cm.__aenter__ = AsyncMock(return_value=session)
+    session_cm.__aexit__ = AsyncMock(return_value=False)
+    return patch("aiohttp.ClientSession", return_value=session_cm), session
+
+
+@pytest.mark.asyncio
+async def test_http_get_returns_json_on_200(client):
+    cm = _mock_aiohttp_response(200, json_body={"hello": "world"})
+    p, _ = _patch_session(cm)
+    with p:
+        body = await client._http_get("http://x", {"a": "b"})
+    assert body == {"hello": "world"}
+
+
+@pytest.mark.asyncio
+async def test_http_get_includes_api_key_header_when_present(fast_limiter):
+    c = SemanticScholarCitationClient(
+        api_key="secret", rate_limiter=fast_limiter, cache_dir=None
+    )
+    cm = _mock_aiohttp_response(200, json_body={})
+    p, session = _patch_session(cm)
+    with p:
+        await c._http_get("http://x", {})
+    _, kwargs = session.get.call_args
+    assert kwargs["headers"] == {"x-api-key": "secret"}
+
+
+@pytest.mark.asyncio
+async def test_http_get_omits_header_when_no_api_key(client):
+    cm = _mock_aiohttp_response(200, json_body={})
+    p, session = _patch_session(cm)
+    with p:
+        await client._http_get("http://x", {})
+    _, kwargs = session.get.call_args
+    assert kwargs["headers"] == {}
+
+
+@pytest.mark.asyncio
+async def test_http_get_raises_rate_limit_on_429(client):
+    cm = _mock_aiohttp_response(429, text_body="slow down")
+    p, _ = _patch_session(cm)
+    with p:
+        with pytest.raises(RateLimitError, match="rate limit exceeded"):
+            await client._http_get("http://x", {})
+
+
+@pytest.mark.asyncio
+async def test_http_get_raises_api_error_on_404(client):
+    cm = _mock_aiohttp_response(404, text_body="not here")
+    p, _ = _patch_session(cm)
+    with p:
+        with pytest.raises(APIError, match="not found"):
+            await client._http_get("http://x", {})
+
+
+@pytest.mark.asyncio
+async def test_http_get_raises_api_error_on_500(client):
+    cm = _mock_aiohttp_response(500, text_body="server explosion")
+    p, _ = _patch_session(cm)
+    with p:
+        with pytest.raises(APIError, match="error 500"):
+            await client._http_get("http://x", {})
+
+
+@pytest.mark.asyncio
+async def test_http_get_wraps_timeout_as_api_error(client):
+    session_cm = MagicMock()
+    session = MagicMock()
+    session.get = MagicMock(side_effect=asyncio.TimeoutError())
+    session_cm.__aenter__ = AsyncMock(return_value=session)
+    session_cm.__aexit__ = AsyncMock(return_value=False)
+    with patch("aiohttp.ClientSession", return_value=session_cm):
+        with pytest.raises(APIError, match="timed out"):
+            await client._http_get("http://x", {})
+
+
+# ---------------------------------------------------------------------------
+# Retry-on-transient-failure: caller-side, by re-invoking after a transient
+# RateLimitError / APIError. The client itself does not auto-retry; we verify
+# both that the error is raised AND that a subsequent retry succeeds with
+# fresh mock state. This mirrors how the future graph_builder will behave.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_transient_failure_then_retry_success(client):
+    state = {"attempt": 0}
+
+    async def flaky_http_get(url, params):
+        if url.endswith("/paper/seed1"):
+            state["attempt"] += 1
+            if state["attempt"] == 1:
+                raise RateLimitError("temporary")
+            return SEED_PAYLOAD
+        return {"data": []}
+
+    with patch.object(client, "_http_get", side_effect=flaky_http_get):
+        # First attempt bubbles RateLimitError up
+        with pytest.raises(RateLimitError):
+            await client.get_references("seed1", max_results=5)
+
+        # Caller retries → succeeds
+        seed, related, _ = await client.get_references("seed1", max_results=5)
+
+    assert seed.title == "Seed Paper"
+    assert related == []
+
+
+# ---------------------------------------------------------------------------
+# Class constants
+# ---------------------------------------------------------------------------
+
+
+def test_base_url_is_s2_v1():
+    assert (
+        SemanticScholarCitationClient.BASE_URL
+        == "https://api.semanticscholar.org/graph/v1"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cache integration via end-to-end public API (covers cache hit log path)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_second_call_hits_cache_no_http(tmp_path, fast_limiter):
+    c = SemanticScholarCitationClient(
+        api_key=None, rate_limiter=fast_limiter, cache_dir=tmp_path
+    )
+
+    call_count = {"n": 0}
+
+    async def fake_http_get(url, params):
+        call_count["n"] += 1
+        if url.endswith("/paper/seed1"):
+            return SEED_PAYLOAD
+        return {"data": [_ref_entry("ref1")]}
+
+    with patch.object(c, "_http_get", side_effect=fake_http_get):
+        await c.get_references("seed1", max_results=5)
+        first_call_count = call_count["n"]
+        # Second call should be served from cache
+        await c.get_references("seed1", max_results=5)
+
+    assert call_count["n"] == first_call_count
+    c.close()


### PR DESCRIPTION
## Summary
First slice of Milestone 9.2 (Citation Graph). Ships the Semantic Scholar client and citation domain models layered over the Phase 9 GraphStore primitives. **Descoped** from the original Week 1 plan after a tooling timeout — see "Deferred" below.

**This PR delivers:**
- `semantic_scholar_client.py` — references/citations endpoints with paginated fetch, S2-published rate limiting (20 req/min with key, 12/min without), 7-day diskcache (per spec Section 11.3), and structured error handling (`RateLimitError` on 429, `APIError` on 404 / 5xx / timeout).
- `models.py` — Pydantic V2 `CitationNode`, `CitationEdge`, `CitationDirection`, plus `make_paper_node_id` / `make_citation_edge_id` helpers. Layered over the shared `GraphNode` / `GraphEdge` kernel via `to_graph_node()` / `to_graph_edge()` rather than redefining them.
- Comprehensive tests (98 new), all HTTP mocked — no live API calls.

**Architecture choice (recorded in package docstring):**
We deliberately built dedicated citation clients alongside the existing `SemanticScholarProvider` in `src/services/providers/` rather than extending it. The existing provider implements the `DiscoveryProvider` ABC for keyword paper search; the citation graph needs different endpoints (`/paper/{id}/references|citations`), pagination semantics (offset/limit), and a 7-day on-disk cache that don't transfer cleanly. Wrapping the existing provider would require widening the ABC or layering an adapter — both add coupling without saving meaningful code.

**Deferred to Week 1.5 follow-up PR (small, focused):**
- `openalex_client.py` (OpenAlex fallback with polite-pool email)
- `graph_builder.py` (compose S2/OpenAlex clients + persist via `add_nodes_batch` / `add_edges_batch`)

**Deferred to Weeks 2-3 PRs (per execution plan):**
- `crawler.py` (BFS depth>1)
- `coupling_analyzer.py` (Jaccard)
- `influence_scorer.py` (uses existing `GraphAlgorithms.pagerank` from PR #105)
- `recommender.py`
- CLI commands

## Verification
- `./verify.sh` passes
- 4361 tests pass (was 4263 on main; +98)
- Coverage 99.22% project-wide (≥99% requirement met)
- Citation module coverage **100%** (252 stmts, 80 branches, 0 missing)
- Black / Flake8 / Mypy clean
- Zero new pragmas added
- No live API calls in tests (all `aiohttp` / `_http_get` mocked)

## Test plan
- [ ] Reviewer: confirm no live API calls in tests
- [ ] Reviewer: confirm S2 rate limit matches spec (~20 req/min with key, ~12 req/min without — see rationale comment in `__init__`)
- [ ] Reviewer: confirm `CitationNode` / `CitationEdge` compose `GraphNode` / `GraphEdge` rather than redefining (see `to_graph_node` / `to_graph_edge`)
- [ ] Reviewer: confirm rationale for not extending `src/services/providers/semantic_scholar.py` (documented in `__init__.py` package docstring)
- [ ] Reviewer: confirm API key never logged and only sourced from `SEMANTIC_SCHOLAR_API_KEY` env var or constructor

## Refs
- Spec: `docs/specs/PHASE_9_RESEARCH_INTELLIGENCE_SPEC.md` (Section 5 / REQ-9.2.x, SR-9.1, SR-9.2, Section 11.3)
- Spec addendum (in flight): PR #106
- Foundation: PR #105