### PR TITLE
feat(phase-9.1): Monitoring Week 1 — subscription manager + ArXiv monitor

### DIFF
--- a/src/services/intelligence/monitoring/__init__.py
+++ b/src/services/intelligence/monitoring/__init__.py
@@ -1,0 +1,54 @@
+"""Proactive paper monitoring (Milestone 9.1).
+
+This package implements ARISP's push-based monitoring system. It allows
+users to register research subscriptions and have new papers from
+external sources (currently ArXiv only — see open-questions.md) flow
+automatically into the registry for downstream processing.
+
+Public surface (Week 1 deliverables):
+
+- ``ResearchSubscription``, ``MonitoringRun``, ``MonitoringRunStatus``,
+  ``MonitoringPaperRecord``: Pydantic V2 strict models describing the
+  monitoring data plane.
+- ``SubscriptionManager``: CRUD over the existing ``subscriptions``
+  SQLite table with limit enforcement (50/user, 100 keywords/sub).
+- ``ArxivMonitor``: ArXiv-only polling that composes the existing
+  ``ArxivProvider`` and the global ``PaperRegistry`` for deduplication.
+
+Deferred to Week 2:
+
+- ``RelevanceScorer`` (LLM-based scoring with Gemini Flash)
+- ``DigestGenerator`` (file-based digests at ``./output/digests/``)
+- CLI commands (``arisp monitor add/list/check/digest``)
+- ``MonitoringCheckJob(BaseJob)`` APScheduler integration
+
+The data model keeps explicit slots for the deferred pieces (e.g.
+``MonitoringRun.scheduled_job_id``, ``MonitoringPaperRecord.relevance_score``)
+so the Week 2 PR can plug in without a migration.
+"""
+
+from src.services.intelligence.monitoring.arxiv_monitor import (
+    ArxivMonitor,
+    ArxivMonitorResult,
+)
+from src.services.intelligence.monitoring.models import (
+    MonitoringPaperRecord,
+    MonitoringRun,
+    MonitoringRunStatus,
+    ResearchSubscription,
+    SubscriptionStatus,
+)
+from src.services.intelligence.monitoring.subscription_manager import (
+    SubscriptionManager,
+)
+
+__all__ = [
+    "ArxivMonitor",
+    "ArxivMonitorResult",
+    "MonitoringPaperRecord",
+    "MonitoringRun",
+    "MonitoringRunStatus",
+    "ResearchSubscription",
+    "SubscriptionManager",
+    "SubscriptionStatus",
+]

--- a/src/services/intelligence/monitoring/arxiv_monitor.py
+++ b/src/services/intelligence/monitoring/arxiv_monitor.py
@@ -1,0 +1,304 @@
+"""ArXiv-only monitor (REQ-9.1.2).
+
+Composes the existing ``ArxivProvider`` (rate limit + structured query
++ feedparser parsing) with the global ``PaperRegistry`` to produce a
+deduplicated stream of *new* papers per subscription.
+
+Design notes:
+
+- We do **not** open a second HTTP client. ``ArxivProvider`` already
+  knows how to rate-limit (3 req/sec via its ``RateLimiter``), retry
+  with exponential backoff (``tenacity``), and parse the Atom feed.
+  Composing it gives us all of that for free.
+- We build a ``ResearchTopic`` on the fly from the subscription's query
+  and ``poll_interval_hours`` window. ``poll_interval_hours`` is treated
+  as the look-back window (a 6h subscription polls the last 6h of
+  papers); this is conservative — a paper showing up twice within the
+  same window is filtered by registry dedup, not by us.
+- Per-cycle paper cap is enforced after fetching to keep the
+  ArxivProvider call site clean. The cap is a security/SR control, not
+  a functional one — see ``MAX_PAPERS_PER_CYCLE`` in ``models``.
+- Failures from the provider are caught and surfaced as a ``FAILED``
+  ``MonitoringRun`` with an ``error`` field. We never re-raise, because
+  the scheduler in Week 2 will iterate over many subscriptions and one
+  upstream outage must not stop the cycle for the others.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+import structlog
+from pydantic import BaseModel, ConfigDict
+
+from src.models.config.core import (
+    ResearchTopic,
+    TimeframeRecent,
+    TimeframeType,
+)
+from src.models.paper import PaperMetadata
+from src.models.registry import RegistryEntry
+from src.services.intelligence.models.monitoring import PaperSource
+from src.services.intelligence.monitoring.models import (
+    MAX_PAPERS_PER_CYCLE,
+    MonitoringPaperRecord,
+    MonitoringRun,
+    MonitoringRunStatus,
+    ResearchSubscription,
+)
+from src.services.providers.arxiv import ArxivProvider
+from src.services.registry import RegistryService
+
+logger = structlog.get_logger()
+
+
+# Default lookback window when a poll interval is too long to express
+# as a TimeframeRecent (>720h cap). ``ArxivProvider`` validates the
+# string at construction time so we cap to the provider's known max.
+_MAX_POLL_HOURS = 720
+# How many papers to ask ArXiv for per call. We pull the per-cycle cap
+# so a single subscription can saturate the cycle if necessary.
+_DEFAULT_MAX_PAPERS = MAX_PAPERS_PER_CYCLE
+
+
+class ArxivMonitorResult(BaseModel):
+    """Convenience aggregate of a monitoring cycle's outcome."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    run: MonitoringRun
+    new_papers: list[PaperMetadata]
+    deduplicated_papers: list[PaperMetadata]
+
+
+class ArxivMonitor:
+    """Polls ArXiv for new papers matching a subscription.
+
+    Args:
+        provider: ArxivProvider instance (rate limiter is the
+            provider's responsibility). Tests inject a mocked one.
+        registry: RegistryService used both for deduplication and as
+            the registration sink for new papers.
+        topic_slug_prefix: Prefix used when affiliating monitored papers
+            in the registry — defaults to ``"monitor"`` so monitor-sourced
+            papers cluster under one folder convention.
+        max_papers_per_cycle: Hard cap on papers processed per call
+            (defaults to the SR limit, currently 1000).
+    """
+
+    def __init__(
+        self,
+        provider: ArxivProvider,
+        registry: RegistryService,
+        topic_slug_prefix: str = "monitor",
+        max_papers_per_cycle: int = _DEFAULT_MAX_PAPERS,
+    ):
+        if max_papers_per_cycle <= 0:
+            raise ValueError("max_papers_per_cycle must be positive")
+        if max_papers_per_cycle > MAX_PAPERS_PER_CYCLE:
+            raise ValueError(
+                f"max_papers_per_cycle cannot exceed {MAX_PAPERS_PER_CYCLE}"
+            )
+        self._provider = provider
+        self._registry = registry
+        self._topic_slug_prefix = topic_slug_prefix
+        self._max_papers_per_cycle = max_papers_per_cycle
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    async def check(self, subscription: ResearchSubscription) -> ArxivMonitorResult:
+        """Run one monitoring cycle for ``subscription``.
+
+        Behavior:
+
+        1. Skip immediately if the subscription is not active or its
+           sources don't include ArXiv.
+        2. Build a ``ResearchTopic`` from ``query`` + ``poll_interval_hours``.
+        3. Call ``ArxivProvider.search``; bound the result to
+           ``max_papers_per_cycle``.
+        4. For each paper, resolve identity against the registry. New
+           papers are registered (``discovery_only=True``); known papers
+           are skipped.
+        5. Return an ``ArxivMonitorResult`` with the run record and the
+           split paper lists.
+
+        This method never raises on provider/registry failure — instead
+        it returns a ``FAILED`` (or ``PARTIAL``) ``MonitoringRun`` so
+        the scheduler keeps cycling through other subscriptions.
+        """
+        run = MonitoringRun(
+            subscription_id=subscription.subscription_id,
+            source=PaperSource.ARXIV,
+        )
+
+        if not self._monitor_eligible(subscription):
+            run.status = MonitoringRunStatus.SUCCESS
+            run.finished_at = datetime.now(timezone.utc)
+            logger.info(
+                "monitor_skipped",
+                subscription_id=subscription.subscription_id,
+                reason="paused_or_no_arxiv",
+            )
+            return ArxivMonitorResult(run=run, new_papers=[], deduplicated_papers=[])
+
+        topic = self._build_topic(subscription)
+
+        try:
+            fetched = await self._provider.search(topic)
+        except Exception as exc:
+            # Provider may surface APIError / RateLimitError /
+            # APIParameterError. We capture the message and let the
+            # scheduler keep iterating.
+            run.status = MonitoringRunStatus.FAILED
+            run.error = f"arxiv_provider_error: {exc}"
+            run.finished_at = datetime.now(timezone.utc)
+            logger.warning(
+                "monitor_provider_error",
+                subscription_id=subscription.subscription_id,
+                error=str(exc),
+            )
+            return ArxivMonitorResult(run=run, new_papers=[], deduplicated_papers=[])
+
+        # Bound the result. ArxivProvider already honors topic.max_papers,
+        # but the cap is a security guarantee enforced here as well.
+        if len(fetched) > self._max_papers_per_cycle:
+            fetched = fetched[: self._max_papers_per_cycle]
+
+        run.papers_seen = len(fetched)
+
+        new_papers: list[PaperMetadata] = []
+        deduped: list[PaperMetadata] = []
+        partial_failure = False
+
+        topic_slug = self._topic_slug(subscription)
+
+        for paper in fetched:
+            try:
+                match = self._registry.resolve_identity(paper)
+            except Exception as exc:
+                # Identity resolution shouldn't fail in practice, but
+                # be defensive — one bad row mustn't kill the cycle.
+                partial_failure = True
+                logger.warning(
+                    "monitor_identity_resolution_error",
+                    subscription_id=subscription.subscription_id,
+                    paper_id=paper.paper_id,
+                    error=str(exc),
+                )
+                continue
+
+            if match.matched:
+                deduped.append(paper)
+                run.papers.append(self._to_record(paper, is_new=False))
+                continue
+
+            try:
+                self._register_new_paper(paper, topic_slug)
+            except Exception as exc:
+                # Failure to persist is recorded but doesn't abort the
+                # cycle. The scheduler will retry on the next interval.
+                partial_failure = True
+                logger.warning(
+                    "monitor_registry_write_error",
+                    subscription_id=subscription.subscription_id,
+                    paper_id=paper.paper_id,
+                    error=str(exc),
+                )
+                continue
+
+            new_papers.append(paper)
+            run.papers.append(self._to_record(paper, is_new=True))
+
+        run.papers_new = len(new_papers)
+        run.papers_deduplicated = len(deduped)
+        run.finished_at = datetime.now(timezone.utc)
+        run.status = (
+            MonitoringRunStatus.PARTIAL
+            if partial_failure
+            else MonitoringRunStatus.SUCCESS
+        )
+        if partial_failure and run.error is None:
+            run.error = "one_or_more_papers_failed"
+
+        logger.info(
+            "monitor_cycle_complete",
+            subscription_id=subscription.subscription_id,
+            seen=run.papers_seen,
+            new=run.papers_new,
+            deduplicated=run.papers_deduplicated,
+            status=run.status.value,
+        )
+        return ArxivMonitorResult(
+            run=run,
+            new_papers=new_papers,
+            deduplicated_papers=deduped,
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _monitor_eligible(subscription: ResearchSubscription) -> bool:
+        """Return True if the monitor should poll for this subscription."""
+        if subscription.status.value != "active":
+            return False
+        if PaperSource.ARXIV not in subscription.sources:
+            return False
+        return True
+
+    @staticmethod
+    def _build_topic(subscription: ResearchSubscription) -> ResearchTopic:
+        """Map a subscription to a ``ResearchTopic`` for the provider.
+
+        ArxivProvider's ``TimeframeRecent`` value pattern is ``\\d+[hd]``,
+        with a 720h cap (~30 days) enforced by the model's
+        ``validate_recent_format``. We clamp ``poll_interval_hours`` to
+        that ceiling to avoid a validation error mid-cycle.
+        """
+        hours = min(subscription.poll_interval_hours, _MAX_POLL_HOURS)
+        timeframe = TimeframeRecent(
+            type=TimeframeType.RECENT,
+            value=f"{hours}h",
+        )
+        return ResearchTopic(
+            query=subscription.query,
+            timeframe=timeframe,
+        )
+
+    def _topic_slug(self, subscription: ResearchSubscription) -> str:
+        """Derive a topic slug for registry affiliation."""
+        # Subscription IDs already match the registry's allowed
+        # character class, so we just prefix them. Keep it short to fit
+        # in any downstream filename use cases.
+        return f"{self._topic_slug_prefix}-{subscription.subscription_id}"
+
+    def _register_new_paper(
+        self, paper: PaperMetadata, topic_slug: str
+    ) -> RegistryEntry:
+        """Register a new paper at discovery-time.
+
+        ``discovery_only=True`` keeps extraction state empty — Week 2's
+        relevance scorer / ingestion path will fill it in if the paper
+        scores above threshold.
+        """
+        return self._registry.register_paper(
+            paper=paper,
+            topic_slug=topic_slug,
+            discovery_only=True,
+        )
+
+    @staticmethod
+    def _to_record(paper: PaperMetadata, is_new: bool) -> MonitoringPaperRecord:
+        published: Optional[datetime] = paper.publication_date
+        # PaperMetadata uses HttpUrl; MonitoringPaperRecord stores plain
+        # strings (it's a serialization-friendly DTO). Cast via str().
+        return MonitoringPaperRecord(
+            paper_id=paper.paper_id,
+            title=paper.title,
+            url=str(paper.url) if paper.url else None,
+            pdf_url=str(paper.open_access_pdf) if paper.open_access_pdf else None,
+            published_at=published,
+            is_new=is_new,
+        )

--- a/src/services/intelligence/monitoring/models.py
+++ b/src/services/intelligence/monitoring/models.py
@@ -1,0 +1,348 @@
+"""Pydantic V2 strict models for the monitoring milestone (REQ-9.1.1).
+
+These models describe the persistent data plane:
+
+- ``ResearchSubscription``: a user's standing query, persisted in the
+  ``subscriptions`` SQLite table created by Milestone 9.0's migrations.
+- ``MonitoringRun`` / ``MonitoringRunStatus``: an audit record for a
+  single execution of the monitor (subscription + cycle).
+- ``MonitoringPaperRecord``: per-paper outcome of a monitoring cycle
+  (matched / deduped / scored placeholder for Week 2).
+
+All models use ``ConfigDict(extra="forbid")`` for Pydantic V2 strictness.
+``@field_validator(..., mode=...)`` is decorated with ``@classmethod`` per
+project convention and Pydantic V2's requirement.
+
+Subscription limits (REQ-9.1, decided in ``.omc/plans/open-questions.md``):
+
+- 50 subscriptions per ``user_id``
+- 100 keywords per subscription
+- 1000 papers checked per monitoring cycle
+
+These limits are enforced at write time by ``SubscriptionManager``;
+``MAX_KEYWORDS_PER_SUBSCRIPTION`` is also enforced at model-validation
+time so a malformed in-memory construction fails fast without touching
+the database.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from src.services.intelligence.models.monitoring import (
+    PaperSource,
+    SubscriptionLimitError,
+)
+
+# Limits from open-questions.md decision (2026-04-24). Kept on the model
+# so the ``SubscriptionManager`` and any future REST/CLI surface use a
+# single source of truth.
+MAX_KEYWORDS_PER_SUBSCRIPTION = 100
+MAX_EXCLUDE_KEYWORDS_PER_SUBSCRIPTION = 100
+MAX_PAPERS_PER_CYCLE = 1000
+
+# Subscription name pattern: same character class as the rest of the
+# Phase 9 surface (matches ``ENTITY_NAME_PATTERN`` extended with
+# underscore so existing user_id slugs keep working).
+_NAME_PATTERN = re.compile(r"^[A-Za-z0-9 ._\-()]+$")
+_USER_ID_PATTERN = re.compile(r"^[A-Za-z0-9._\-]+$")
+_KEYWORD_PATTERN = re.compile(r"^[A-Za-z0-9 ._\-+:/()]+$")
+
+
+class SubscriptionStatus(str, Enum):
+    """Lifecycle state of a research subscription.
+
+    ``ACTIVE`` subscriptions are picked up by the monitor on every cycle.
+    ``PAUSED`` ones are persisted but skipped — useful when a user wants
+    to keep the configuration around without it generating digests.
+    """
+
+    ACTIVE = "active"
+    PAUSED = "paused"
+
+
+class MonitoringRunStatus(str, Enum):
+    """Final status of a single ``MonitoringRun``.
+
+    ``PARTIAL`` covers the case where some papers were processed before
+    a failure (e.g. ArXiv returned valid papers, then the registry write
+    failed). The ``error`` field on the run captures the cause.
+    """
+
+    SUCCESS = "success"
+    PARTIAL = "partial"
+    FAILED = "failed"
+
+
+class ResearchSubscription(BaseModel):
+    """A user-managed standing query (REQ-9.1.1).
+
+    Persisted to the ``subscriptions`` table as JSON in the ``config``
+    column. The ``subscription_id``, ``user_id``, ``name``, and lifecycle
+    columns are stored as first-class columns so the monitor can filter
+    without parsing JSON for every row.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+        json_schema_extra={
+            "example": {
+                "subscription_id": "sub-7c1f4e3a",
+                "user_id": "default",
+                "name": "PEFT Research",
+                "query": "LoRA OR QLoRA OR adapter tuning",
+                "keywords": ["parameter-efficient", "fine-tuning"],
+                "exclude_keywords": ["survey"],
+                "min_relevance_score": 0.7,
+                "sources": ["arxiv"],
+                "poll_interval_hours": 6,
+                "status": "active",
+            }
+        },
+    )
+
+    subscription_id: str = Field(
+        default_factory=lambda: f"sub-{uuid.uuid4().hex[:12]}",
+        min_length=1,
+        max_length=64,
+        description="Unique subscription identifier (system-generated).",
+    )
+    user_id: str = Field(
+        default="default",
+        min_length=1,
+        max_length=64,
+        description="Owner identifier (Phase 10+ multi-user).",
+    )
+    name: str = Field(
+        ...,
+        min_length=1,
+        max_length=100,
+        description="Human-readable subscription name.",
+    )
+    query: str = Field(
+        ...,
+        min_length=1,
+        max_length=512,
+        description="Base search query passed through to the provider.",
+    )
+    keywords: list[str] = Field(
+        default_factory=list,
+        description="Additional keywords to bias scoring/filtering.",
+    )
+    exclude_keywords: list[str] = Field(
+        default_factory=list,
+        description="Keywords whose presence excludes a paper.",
+    )
+    min_relevance_score: float = Field(
+        default=0.7,
+        ge=0.0,
+        le=1.0,
+        description="Threshold below which papers are discarded in Week 2.",
+    )
+    sources: list[PaperSource] = Field(
+        default_factory=lambda: [PaperSource.ARXIV],
+        min_length=1,
+        description="Sources to poll. MVP enforces ArXiv-only.",
+    )
+    poll_interval_hours: int = Field(
+        default=6,
+        ge=1,
+        le=24 * 7,
+        description="Frequency of monitoring cycles (1h .. 168h).",
+    )
+    filters: dict[str, str] = Field(
+        default_factory=dict,
+        description="Optional provider-specific filters (e.g. arxiv categories).",
+    )
+    status: SubscriptionStatus = Field(
+        default=SubscriptionStatus.ACTIVE,
+        description="Lifecycle state.",
+    )
+    last_checked_at: Optional[datetime] = Field(
+        default=None,
+        description="UTC timestamp of the most recent successful cycle.",
+    )
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        description="Subscription creation timestamp.",
+    )
+    updated_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        description="Last mutation timestamp.",
+    )
+
+    @field_validator("subscription_id", "user_id")
+    @classmethod
+    def _validate_identifier(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("Identifier cannot be empty")
+        if not _USER_ID_PATTERN.match(v):
+            raise ValueError(
+                f"Invalid identifier format: {v!r}. "
+                "Allowed: alphanumeric, periods, underscores, hyphens."
+            )
+        return v
+
+    @field_validator("name")
+    @classmethod
+    def _validate_name(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("Subscription name cannot be empty")
+        if not _NAME_PATTERN.match(v):
+            raise ValueError(
+                f"Invalid subscription name: {v!r}. "
+                "Allowed: alphanumeric, spaces, dot, underscore, hyphen, parens."
+            )
+        return v
+
+    @field_validator("query")
+    @classmethod
+    def _validate_query(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("Subscription query cannot be empty")
+        return v
+
+    @field_validator("keywords", "exclude_keywords")
+    @classmethod
+    def _validate_keywords(cls, v: list[str]) -> list[str]:
+        if len(v) > MAX_KEYWORDS_PER_SUBSCRIPTION:
+            # Raise the project-wide subscription limit error rather than a
+            # generic ValueError so callers can render a uniform message.
+            raise SubscriptionLimitError(
+                "keywords per subscription",
+                len(v),
+                MAX_KEYWORDS_PER_SUBSCRIPTION,
+            )
+        cleaned: list[str] = []
+        seen: set[str] = set()
+        for kw in v:
+            kw_stripped = kw.strip()
+            if not kw_stripped:
+                raise ValueError("Keywords cannot be empty strings")
+            if not _KEYWORD_PATTERN.match(kw_stripped):
+                raise ValueError(
+                    f"Invalid keyword: {kw_stripped!r}. "
+                    "Allowed: alphanumeric, spaces, ._-+:/()"
+                )
+            lowered = kw_stripped.lower()
+            if lowered in seen:
+                # Skip duplicates rather than raising to make the model
+                # ergonomic when callers concat keyword lists.
+                continue
+            seen.add(lowered)
+            cleaned.append(kw_stripped)
+        return cleaned
+
+    @field_validator("sources")
+    @classmethod
+    def _validate_sources_arxiv_only(cls, v: list[PaperSource]) -> list[PaperSource]:
+        # MVP scope: open-questions.md decision (2026-04-22) — only ArXiv has
+        # an RSS/Atom feed efficient enough for monitoring. Future polling
+        # support is gated behind the resolution of that question.
+        if not v:
+            raise ValueError("At least one source is required")
+        non_arxiv = [s for s in v if s is not PaperSource.ARXIV]
+        if non_arxiv:
+            raise ValueError(
+                "Only PaperSource.ARXIV is supported in the MVP "
+                f"(got: {[s.value for s in non_arxiv]}). "
+                "Other sources will be added in a follow-up release."
+            )
+        # Always normalize to a single ArXiv entry.
+        return [PaperSource.ARXIV]
+
+
+class MonitoringPaperRecord(BaseModel):
+    """Per-paper outcome of a monitoring cycle.
+
+    Used by the digest generator (Week 2) and by anyone who wants a
+    structured audit trail of "what did the monitor see this run?".
+
+    ``relevance_score`` and ``relevance_reasoning`` are populated by the
+    Week 2 ``RelevanceScorer``; for Week 1 they remain ``None``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    paper_id: str = Field(
+        ...,
+        min_length=1,
+        max_length=128,
+        description="Provider paper id (e.g. ArXiv id 2301.12345).",
+    )
+    title: str = Field(..., min_length=1, max_length=1024)
+    url: Optional[str] = Field(default=None, max_length=1024)
+    pdf_url: Optional[str] = Field(default=None, max_length=1024)
+    published_at: Optional[datetime] = Field(default=None)
+    is_new: bool = Field(
+        ...,
+        description=(
+            "True if the paper was unknown to the global PaperRegistry "
+            "before this cycle (i.e., not deduplicated)."
+        ),
+    )
+    relevance_score: Optional[float] = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description="Filled in by the Week 2 RelevanceScorer.",
+    )
+    relevance_reasoning: Optional[str] = Field(
+        default=None,
+        max_length=1000,
+        description="Filled in by the Week 2 RelevanceScorer.",
+    )
+
+
+class MonitoringRun(BaseModel):
+    """Audit record for one execution of the monitor.
+
+    Created at the start of a cycle, finalized at the end with the
+    outcome and ``papers``. Persistence is the caller's responsibility
+    (Week 1 keeps these in-memory; Week 2's scheduler will write them).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    run_id: str = Field(
+        default_factory=lambda: f"run-{uuid.uuid4().hex[:12]}",
+        min_length=1,
+        max_length=64,
+    )
+    subscription_id: str = Field(..., min_length=1, max_length=64)
+    source: PaperSource = Field(default=PaperSource.ARXIV)
+    started_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+    )
+    finished_at: Optional[datetime] = Field(default=None)
+    status: MonitoringRunStatus = Field(default=MonitoringRunStatus.SUCCESS)
+    papers_seen: int = Field(default=0, ge=0)
+    papers_new: int = Field(default=0, ge=0)
+    papers_deduplicated: int = Field(default=0, ge=0)
+    error: Optional[str] = Field(default=None, max_length=2000)
+    papers: list[MonitoringPaperRecord] = Field(default_factory=list)
+    # Reserved for Week 2 APScheduler integration so a run can be
+    # correlated back to the job that triggered it.
+    scheduled_job_id: Optional[str] = Field(default=None, max_length=128)
+
+    @field_validator("papers")
+    @classmethod
+    def _validate_papers_within_cycle_limit(
+        cls, v: list[MonitoringPaperRecord]
+    ) -> list[MonitoringPaperRecord]:
+        if len(v) > MAX_PAPERS_PER_CYCLE:
+            raise SubscriptionLimitError(
+                "papers per cycle",
+                len(v),
+                MAX_PAPERS_PER_CYCLE,
+            )
+        return v

--- a/src/services/intelligence/monitoring/subscription_manager.py
+++ b/src/services/intelligence/monitoring/subscription_manager.py
@@ -17,20 +17,36 @@ The model fields beyond what's column-promoted (query, keywords,
 sources, etc.) live inside the ``config`` JSON blob — same pattern the
 graph store uses for ``properties``.
 
-We open one ``sqlite3.Connection`` per call; the table is single-user-
-low-contention so the WAL/busy_timeout pragmas inherited from the
-intelligence-graph PRAGMAs are sufficient. We do NOT use
-``BEGIN IMMEDIATE`` because every mutation is single-row and the
-contention surface is bounded (Phase 10+ multi-user will revisit).
+Concurrency model
+-----------------
+``_connect()`` is a context manager that opens a fresh
+``sqlite3.Connection`` per logical operation, applies the standard
+intelligence-graph PRAGMAs (``foreign_keys=ON``, ``journal_mode=WAL``,
+``synchronous=NORMAL``, ``busy_timeout=5000``), and **closes the
+connection on exit** (sqlite3's own ``__exit__`` only commits/rolls
+back — it does not close, which leaks file descriptors under a
+long-running scheduler).
+
+Mutations that combine a read with a write (most notably
+``add_subscription``, which checks the per-user cap before INSERT)
+issue ``BEGIN IMMEDIATE`` at the start of the transaction so the
+read+write pair is serialized against concurrent writers. Without
+this, two concurrent ``add_subscription`` calls could both observe
+``count==MAX-1`` and both insert, breaking the cap. ``BEGIN IMMEDIATE``
+acquires the SQLite write lock up-front; the second writer blocks for
+up to ``busy_timeout`` and then either succeeds or raises
+``OperationalError("database is locked")`` (which our retry policy
+upstream is responsible for translating into a user-visible error).
 """
 
 from __future__ import annotations
 
 import json
 import sqlite3
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional
+from typing import Iterator, Optional
 
 import structlog
 
@@ -92,7 +108,15 @@ class SubscriptionManager:
             )
         self._initialized = True
 
-    def _connect(self) -> sqlite3.Connection:
+    @contextmanager
+    def _connect(self) -> Iterator[sqlite3.Connection]:
+        """Open + auto-close a SQLite connection with the standard PRAGMAs.
+
+        SQLite's ``Connection.__exit__`` commits / rolls back but does
+        NOT close. Wrapping with ``contextlib.contextmanager`` and an
+        explicit ``finally: conn.close()`` keeps file-descriptor usage
+        bounded under a long-running scheduler.
+        """
         if not self._initialized:
             raise RuntimeError(
                 "SubscriptionManager not initialized. Call initialize() first."
@@ -103,7 +127,10 @@ class SubscriptionManager:
         conn.execute("PRAGMA synchronous = NORMAL")
         conn.execute("PRAGMA busy_timeout = 5000")
         conn.row_factory = sqlite3.Row
-        return conn
+        try:
+            yield conn
+        finally:
+            conn.close()
 
     # ------------------------------------------------------------------
     # Serialization
@@ -174,6 +201,11 @@ class SubscriptionManager:
             )
 
         with self._connect() as conn:
+            # Acquire write lock UP FRONT so the count check + INSERT
+            # are atomic against concurrent writers. Without this, two
+            # callers can both observe count==MAX-1 and both insert,
+            # silently breaking the per-user cap.
+            conn.execute("BEGIN IMMEDIATE")
             current = self._count_user_subscriptions(conn, subscription.user_id)
             if current >= self.MAX_SUBSCRIPTIONS_PER_USER:
                 raise SubscriptionLimitError(

--- a/src/services/intelligence/monitoring/subscription_manager.py
+++ b/src/services/intelligence/monitoring/subscription_manager.py
@@ -1,0 +1,399 @@
+"""Subscription CRUD over the existing intelligence-graph SQLite store.
+
+The ``subscriptions`` table is created by the Week 0 migration
+(``src/storage/intelligence_graph/migrations.py:MIGRATION_V1_INITIAL``).
+Schema:
+
+    subscription_id TEXT PRIMARY KEY
+    user_id         TEXT NOT NULL DEFAULT 'default'
+    name            TEXT NOT NULL
+    config          TEXT NOT NULL  -- JSON-encoded ResearchSubscription
+    last_checked    TEXT
+    is_active       INTEGER NOT NULL DEFAULT 1
+    created_at      TEXT NOT NULL
+    updated_at      TEXT NOT NULL
+
+The model fields beyond what's column-promoted (query, keywords,
+sources, etc.) live inside the ``config`` JSON blob — same pattern the
+graph store uses for ``properties``.
+
+We open one ``sqlite3.Connection`` per call; the table is single-user-
+low-contention so the WAL/busy_timeout pragmas inherited from the
+intelligence-graph PRAGMAs are sufficient. We do NOT use
+``BEGIN IMMEDIATE`` because every mutation is single-row and the
+contention surface is bounded (Phase 10+ multi-user will revisit).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+import structlog
+
+from src.services.intelligence.models.monitoring import SubscriptionLimitError
+from src.services.intelligence.monitoring.models import (
+    MAX_KEYWORDS_PER_SUBSCRIPTION,
+    ResearchSubscription,
+    SubscriptionStatus,
+)
+from src.storage.intelligence_graph.migrations import MigrationManager
+from src.storage.intelligence_graph.path_utils import sanitize_storage_path
+
+logger = structlog.get_logger()
+
+
+class SubscriptionManager:
+    """CRUD facade for ``ResearchSubscription`` records.
+
+    Limits enforced (open-questions.md, 2026-04-24):
+
+    - Max ``MAX_SUBSCRIPTIONS_PER_USER`` subscriptions per ``user_id``
+    - Max ``MAX_KEYWORDS_PER_SUBSCRIPTION`` keywords per subscription
+      (also enforced inside ``ResearchSubscription``)
+
+    Both limits raise :class:`SubscriptionLimitError` *before* writing.
+    """
+
+    MAX_SUBSCRIPTIONS_PER_USER = 50
+    MAX_KEYWORDS_PER_SUBSCRIPTION = MAX_KEYWORDS_PER_SUBSCRIPTION
+
+    def __init__(self, db_path: Path | str):
+        """Initialize the manager.
+
+        Args:
+            db_path: SQLite database path. Must lie under one of the
+                approved storage roots (``data/``, ``cache/``, or the
+                system temp directory) — enforced by
+                :func:`sanitize_storage_path`.
+        """
+        self.db_path = sanitize_storage_path(db_path)
+        self._migrations = MigrationManager(self.db_path)
+        self._initialized = False
+
+    # ------------------------------------------------------------------
+    # Bookkeeping
+    # ------------------------------------------------------------------
+    def initialize(self) -> None:
+        """Apply pending schema migrations.
+
+        Idempotent — safe to call multiple times. Must be called before
+        any CRUD operation.
+        """
+        applied = self._migrations.migrate()
+        if applied > 0:
+            logger.info(
+                "subscription_manager_migrations_applied",
+                count=applied,
+                db_path=str(self.db_path),
+            )
+        self._initialized = True
+
+    def _connect(self) -> sqlite3.Connection:
+        if not self._initialized:
+            raise RuntimeError(
+                "SubscriptionManager not initialized. Call initialize() first."
+            )
+        conn = sqlite3.connect(str(self.db_path))
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute("PRAGMA journal_mode = WAL")
+        conn.execute("PRAGMA synchronous = NORMAL")
+        conn.execute("PRAGMA busy_timeout = 5000")
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    # ------------------------------------------------------------------
+    # Serialization
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _serialize(sub: ResearchSubscription) -> str:
+        """Serialize the non-column fields into the ``config`` blob."""
+        payload = sub.model_dump(mode="json")
+        # Drop fields that are persisted as columns to avoid duplication
+        # and accidental skew between row and blob.
+        for col in (
+            "subscription_id",
+            "user_id",
+            "name",
+            "status",
+            "last_checked_at",
+            "created_at",
+            "updated_at",
+        ):
+            payload.pop(col, None)
+        return json.dumps(payload, default=str, sort_keys=True)
+
+    @staticmethod
+    def _deserialize(row: sqlite3.Row) -> ResearchSubscription:
+        config = json.loads(row["config"])
+        # Re-stitch the column-promoted fields back into the dict so we
+        # round-trip via the model validator.
+        is_active = bool(row["is_active"])
+        last_checked = row["last_checked"]
+        return ResearchSubscription(
+            subscription_id=row["subscription_id"],
+            user_id=row["user_id"],
+            name=row["name"],
+            status=(
+                SubscriptionStatus.ACTIVE if is_active else SubscriptionStatus.PAUSED
+            ),
+            last_checked_at=(
+                datetime.fromisoformat(last_checked) if last_checked else None
+            ),
+            created_at=datetime.fromisoformat(row["created_at"]),
+            updated_at=datetime.fromisoformat(row["updated_at"]),
+            **config,
+        )
+
+    # ------------------------------------------------------------------
+    # CRUD
+    # ------------------------------------------------------------------
+    def add_subscription(self, subscription: ResearchSubscription) -> str:
+        """Persist a new subscription.
+
+        Returns:
+            The ``subscription_id``.
+
+        Raises:
+            SubscriptionLimitError: If the user is at the per-user cap or
+                the subscription has too many keywords.
+            ValueError: If a subscription with the same id already
+                exists.
+        """
+        # Defensive double-check on keywords. The model validator already
+        # enforces this, but we keep the explicit guard so failures
+        # before INSERT are uniform with the per-user cap below.
+        if len(subscription.keywords) > self.MAX_KEYWORDS_PER_SUBSCRIPTION:
+            raise SubscriptionLimitError(
+                "keywords per subscription",
+                len(subscription.keywords),
+                self.MAX_KEYWORDS_PER_SUBSCRIPTION,
+            )
+
+        with self._connect() as conn:
+            current = self._count_user_subscriptions(conn, subscription.user_id)
+            if current >= self.MAX_SUBSCRIPTIONS_PER_USER:
+                raise SubscriptionLimitError(
+                    "subscriptions per user",
+                    current,
+                    self.MAX_SUBSCRIPTIONS_PER_USER,
+                )
+
+            cursor = conn.execute(
+                "SELECT 1 FROM subscriptions WHERE subscription_id = ?",
+                (subscription.subscription_id,),
+            )
+            if cursor.fetchone() is not None:
+                raise ValueError(
+                    f"Subscription already exists: {subscription.subscription_id!r}"
+                )
+
+            now = datetime.now(timezone.utc)
+            # Honor caller-provided timestamps if they were set
+            # explicitly; otherwise stamp ``now`` on both.
+            created_at = subscription.created_at or now
+            updated_at = now
+            conn.execute(
+                """
+                INSERT INTO subscriptions (
+                    subscription_id, user_id, name, config,
+                    last_checked, is_active, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    subscription.subscription_id,
+                    subscription.user_id,
+                    subscription.name,
+                    self._serialize(subscription),
+                    (
+                        subscription.last_checked_at.isoformat()
+                        if subscription.last_checked_at
+                        else None
+                    ),
+                    1 if subscription.status is SubscriptionStatus.ACTIVE else 0,
+                    created_at.isoformat(),
+                    updated_at.isoformat(),
+                ),
+            )
+            conn.commit()
+
+        logger.info(
+            "subscription_added",
+            subscription_id=subscription.subscription_id,
+            user_id=subscription.user_id,
+            name=subscription.name,
+        )
+        return subscription.subscription_id
+
+    def get_subscription(self, subscription_id: str) -> Optional[ResearchSubscription]:
+        """Fetch one subscription, or ``None`` if not found."""
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                SELECT subscription_id, user_id, name, config,
+                       last_checked, is_active, created_at, updated_at
+                FROM subscriptions WHERE subscription_id = ?
+                """,
+                (subscription_id,),
+            )
+            row = cursor.fetchone()
+        if row is None:
+            return None
+        return self._deserialize(row)
+
+    def list_subscriptions(
+        self,
+        user_id: Optional[str] = None,
+        active_only: bool = False,
+    ) -> list[ResearchSubscription]:
+        """List subscriptions, optionally filtered by user/active flag."""
+        clauses: list[str] = []
+        params: list[object] = []
+        if user_id is not None:
+            clauses.append("user_id = ?")
+            params.append(user_id)
+        if active_only:
+            clauses.append("is_active = 1")
+        where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+        with self._connect() as conn:
+            cursor = conn.execute(
+                f"""
+                SELECT subscription_id, user_id, name, config,
+                       last_checked, is_active, created_at, updated_at
+                FROM subscriptions
+                {where}
+                ORDER BY created_at ASC
+                """,
+                tuple(params),
+            )
+            return [self._deserialize(r) for r in cursor.fetchall()]
+
+    def update_subscription(self, subscription: ResearchSubscription) -> None:
+        """Replace an existing subscription's mutable fields.
+
+        Raises:
+            KeyError: If no row matches ``subscription.subscription_id``.
+            SubscriptionLimitError: If keyword count exceeds the cap.
+        """
+        if len(subscription.keywords) > self.MAX_KEYWORDS_PER_SUBSCRIPTION:
+            raise SubscriptionLimitError(
+                "keywords per subscription",
+                len(subscription.keywords),
+                self.MAX_KEYWORDS_PER_SUBSCRIPTION,
+            )
+        now = datetime.now(timezone.utc)
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE subscriptions SET
+                    name = ?, config = ?, last_checked = ?,
+                    is_active = ?, updated_at = ?
+                WHERE subscription_id = ?
+                """,
+                (
+                    subscription.name,
+                    self._serialize(subscription),
+                    (
+                        subscription.last_checked_at.isoformat()
+                        if subscription.last_checked_at
+                        else None
+                    ),
+                    1 if subscription.status is SubscriptionStatus.ACTIVE else 0,
+                    now.isoformat(),
+                    subscription.subscription_id,
+                ),
+            )
+            if cursor.rowcount == 0:
+                raise KeyError(
+                    f"Subscription not found: {subscription.subscription_id!r}"
+                )
+            conn.commit()
+        logger.info(
+            "subscription_updated", subscription_id=subscription.subscription_id
+        )
+
+    def delete_subscription(self, subscription_id: str) -> bool:
+        """Delete one subscription. Returns True if a row was removed."""
+        with self._connect() as conn:
+            cursor = conn.execute(
+                "DELETE FROM subscriptions WHERE subscription_id = ?",
+                (subscription_id,),
+            )
+            removed = cursor.rowcount > 0
+            conn.commit()
+        if removed:
+            logger.info("subscription_deleted", subscription_id=subscription_id)
+        return removed
+
+    def set_status(self, subscription_id: str, status: SubscriptionStatus) -> None:
+        """Pause or resume a subscription without rewriting its config.
+
+        Raises:
+            KeyError: If no row matches ``subscription_id``.
+        """
+        now = datetime.now(timezone.utc)
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE subscriptions
+                SET is_active = ?, updated_at = ?
+                WHERE subscription_id = ?
+                """,
+                (
+                    1 if status is SubscriptionStatus.ACTIVE else 0,
+                    now.isoformat(),
+                    subscription_id,
+                ),
+            )
+            if cursor.rowcount == 0:
+                raise KeyError(f"Subscription not found: {subscription_id!r}")
+            conn.commit()
+        logger.info(
+            "subscription_status_changed",
+            subscription_id=subscription_id,
+            status=status.value,
+        )
+
+    def mark_checked(
+        self, subscription_id: str, when: Optional[datetime] = None
+    ) -> None:
+        """Record a successful monitoring cycle's timestamp.
+
+        ``when`` defaults to "now" in UTC. Tests pass an explicit
+        timestamp so cycle behavior is deterministic.
+
+        Raises:
+            KeyError: If no row matches ``subscription_id``.
+        """
+        timestamp = when or datetime.now(timezone.utc)
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE subscriptions
+                SET last_checked = ?, updated_at = ?
+                WHERE subscription_id = ?
+                """,
+                (
+                    timestamp.isoformat(),
+                    timestamp.isoformat(),
+                    subscription_id,
+                ),
+            )
+            if cursor.rowcount == 0:
+                raise KeyError(f"Subscription not found: {subscription_id!r}")
+            conn.commit()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _count_user_subscriptions(conn: sqlite3.Connection, user_id: str) -> int:
+        cursor = conn.execute(
+            "SELECT COUNT(*) AS c FROM subscriptions WHERE user_id = ?",
+            (user_id,),
+        )
+        row = cursor.fetchone()
+        return int(row["c"]) if row else 0

--- a/tests/unit/services/intelligence/monitoring/test_arxiv_monitor.py
+++ b/tests/unit/services/intelligence/monitoring/test_arxiv_monitor.py
@@ -1,0 +1,454 @@
+"""Tests for ``ArxivMonitor`` (Milestone 9.1).
+
+All ArXiv HTTP traffic is mocked at the ``ArxivProvider.search`` boundary —
+no live network calls are made.
+
+Covers:
+- Constructor validation (max_papers_per_cycle bounds)
+- Skip behavior for paused / non-arxiv subscriptions
+- Topic construction from subscription (poll_interval clamping)
+- Topic-slug derivation
+- Provider-error path (search raises) → FAILED run
+- Per-cycle paper cap (post-fetch truncation)
+- Dedup via registry: matched papers go to ``deduplicated_papers``
+- New papers registered via ``register_paper(discovery_only=True)``
+- Identity-resolution failure → PARTIAL run
+- Registry-write failure → PARTIAL run
+- Empty result set → SUCCESS run with zero counts
+- ``_to_record`` URL stringification
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.models.config.core import ResearchTopic, TimeframeRecent, TimeframeType
+from src.models.paper import Author, PaperMetadata
+from src.models.registry import IdentityMatch, RegistryEntry
+from src.services.intelligence.monitoring.arxiv_monitor import (
+    ArxivMonitor,
+    ArxivMonitorResult,
+)
+from src.services.intelligence.monitoring.models import (
+    MAX_PAPERS_PER_CYCLE,
+    MonitoringRunStatus,
+    ResearchSubscription,
+    SubscriptionStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_paper(
+    *,
+    paper_id: str = "2301.12345",
+    title: str = "A Paper",
+    url: str = "https://arxiv.org/abs/2301.12345",
+    pdf: str | None = "https://arxiv.org/pdf/2301.12345",
+    pub_date: datetime | None = None,
+) -> PaperMetadata:
+    return PaperMetadata(
+        paper_id=paper_id,
+        title=title,
+        abstract="abstract",
+        url=url,  # type: ignore[arg-type]
+        open_access_pdf=pdf,  # type: ignore[arg-type]
+        authors=[Author(name="Alice")],
+        year=2024,
+        publication_date=pub_date or datetime(2024, 1, 1, tzinfo=timezone.utc),
+        venue="ArXiv",
+    )
+
+
+def _make_subscription(
+    *,
+    subscription_id: str = "sub-test",
+    poll_interval_hours: int = 6,
+    status: SubscriptionStatus = SubscriptionStatus.ACTIVE,
+) -> ResearchSubscription:
+    return ResearchSubscription(
+        subscription_id=subscription_id,
+        user_id="alice",
+        name="Sub",
+        query="tree of thoughts",
+        poll_interval_hours=poll_interval_hours,
+        status=status,
+    )
+
+
+def _make_provider(papers: list[PaperMetadata] | None = None) -> MagicMock:
+    """Build a mocked ArxivProvider whose ``search`` returns ``papers``."""
+    provider = MagicMock()
+    provider.search = AsyncMock(return_value=papers or [])
+    return provider
+
+
+def _make_registry(
+    *,
+    matches: dict[str, IdentityMatch] | None = None,
+    raise_on_resolve: Exception | None = None,
+    raise_on_register: Exception | None = None,
+) -> MagicMock:
+    """Build a mocked RegistryService.
+
+    ``matches`` maps a paper_id to the IdentityMatch returned by
+    ``resolve_identity``. Default is "no match" (new paper).
+    """
+    matches = matches or {}
+    registry = MagicMock()
+
+    def resolve(paper: PaperMetadata) -> IdentityMatch:
+        if raise_on_resolve is not None:
+            raise raise_on_resolve
+        return matches.get(paper.paper_id, IdentityMatch(matched=False))
+
+    def register(**kwargs: Any) -> RegistryEntry:
+        if raise_on_register is not None:
+            raise raise_on_register
+        return RegistryEntry(
+            title_normalized=kwargs["paper"].title.lower(),
+            extraction_target_hash="sha256:test",
+        )
+
+    registry.resolve_identity = MagicMock(side_effect=resolve)
+    registry.register_paper = MagicMock(side_effect=register)
+    return registry
+
+
+# ---------------------------------------------------------------------------
+# Constructor validation
+# ---------------------------------------------------------------------------
+
+
+class TestArxivMonitorInit:
+    def test_init_default_cap(self) -> None:
+        monitor = ArxivMonitor(_make_provider(), _make_registry())
+        assert monitor._max_papers_per_cycle == MAX_PAPERS_PER_CYCLE
+
+    def test_init_custom_cap(self) -> None:
+        monitor = ArxivMonitor(
+            _make_provider(), _make_registry(), max_papers_per_cycle=10
+        )
+        assert monitor._max_papers_per_cycle == 10
+
+    def test_init_zero_cap_rejected(self) -> None:
+        with pytest.raises(ValueError, match="must be positive"):
+            ArxivMonitor(_make_provider(), _make_registry(), max_papers_per_cycle=0)
+
+    def test_init_negative_cap_rejected(self) -> None:
+        with pytest.raises(ValueError, match="must be positive"):
+            ArxivMonitor(_make_provider(), _make_registry(), max_papers_per_cycle=-1)
+
+    def test_init_above_global_cap_rejected(self) -> None:
+        with pytest.raises(ValueError, match="cannot exceed"):
+            ArxivMonitor(
+                _make_provider(),
+                _make_registry(),
+                max_papers_per_cycle=MAX_PAPERS_PER_CYCLE + 1,
+            )
+
+    def test_init_custom_topic_slug_prefix(self) -> None:
+        monitor = ArxivMonitor(
+            _make_provider(), _make_registry(), topic_slug_prefix="custom"
+        )
+        sub = _make_subscription(subscription_id="sub-x")
+        assert monitor._topic_slug(sub) == "custom-sub-x"
+
+
+# ---------------------------------------------------------------------------
+# Skip / eligibility
+# ---------------------------------------------------------------------------
+
+
+class TestEligibility:
+    @pytest.mark.asyncio
+    async def test_paused_subscription_skipped(self) -> None:
+        provider = _make_provider()
+        registry = _make_registry()
+        monitor = ArxivMonitor(provider, registry)
+        sub = _make_subscription(status=SubscriptionStatus.PAUSED)
+        result = await monitor.check(sub)
+
+        assert isinstance(result, ArxivMonitorResult)
+        assert result.run.status is MonitoringRunStatus.SUCCESS
+        assert result.run.papers_seen == 0
+        assert result.new_papers == []
+        assert result.deduplicated_papers == []
+        # Provider must not have been called.
+        provider.search.assert_not_awaited()
+
+    def test_eligibility_checks_arxiv_in_sources(self) -> None:
+        # The model normalizes sources to ArXiv, but we exercise the
+        # static helper directly with an empty sources list to cover
+        # the "no arxiv" branch.
+        sub = _make_subscription()
+        sub.sources = []  # bypass validator after construction
+        assert ArxivMonitor._monitor_eligible(sub) is False
+
+    def test_eligibility_paused(self) -> None:
+        sub = _make_subscription(status=SubscriptionStatus.PAUSED)
+        assert ArxivMonitor._monitor_eligible(sub) is False
+
+    def test_eligibility_active(self) -> None:
+        sub = _make_subscription()
+        assert ArxivMonitor._monitor_eligible(sub) is True
+
+
+# ---------------------------------------------------------------------------
+# Topic construction
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTopic:
+    def test_build_topic_uses_poll_interval(self) -> None:
+        sub = _make_subscription(poll_interval_hours=12)
+        topic = ArxivMonitor._build_topic(sub)
+        assert isinstance(topic, ResearchTopic)
+        assert topic.query == sub.query
+        assert isinstance(topic.timeframe, TimeframeRecent)
+        assert topic.timeframe.type == TimeframeType.RECENT
+        assert topic.timeframe.value == "12h"
+
+    def test_build_topic_clamps_to_max(self) -> None:
+        # ResearchSubscription caps poll_interval_hours at 24*7=168, well
+        # below the provider's 720h ceiling. To exercise the clamp
+        # branch we mutate the field directly post-construction.
+        sub = _make_subscription()
+        sub.poll_interval_hours = 1000  # bypass validator
+        topic = ArxivMonitor._build_topic(sub)
+        assert isinstance(topic.timeframe, TimeframeRecent)
+        # Clamped to 720h.
+        assert topic.timeframe.value == "720h"
+
+
+# ---------------------------------------------------------------------------
+# Provider error path
+# ---------------------------------------------------------------------------
+
+
+class TestProviderError:
+    @pytest.mark.asyncio
+    async def test_provider_raises_returns_failed_run(self) -> None:
+        provider = _make_provider()
+        provider.search = AsyncMock(side_effect=RuntimeError("boom"))
+        registry = _make_registry()
+        monitor = ArxivMonitor(provider, registry)
+
+        result = await monitor.check(_make_subscription())
+
+        assert result.run.status is MonitoringRunStatus.FAILED
+        assert result.run.error is not None
+        assert "arxiv_provider_error" in result.run.error
+        assert "boom" in result.run.error
+        assert result.run.finished_at is not None
+        assert result.new_papers == []
+        assert result.deduplicated_papers == []
+        # Registry must not have been touched.
+        registry.resolve_identity.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestPollHappyPath:
+    @pytest.mark.asyncio
+    async def test_empty_result_returns_success_run(self) -> None:
+        monitor = ArxivMonitor(_make_provider([]), _make_registry())
+        result = await monitor.check(_make_subscription())
+
+        assert result.run.status is MonitoringRunStatus.SUCCESS
+        assert result.run.papers_seen == 0
+        assert result.run.papers_new == 0
+        assert result.run.papers_deduplicated == 0
+        assert result.new_papers == []
+        assert result.deduplicated_papers == []
+
+    @pytest.mark.asyncio
+    async def test_all_new_papers_registered(self) -> None:
+        papers = [
+            _make_paper(paper_id="2301.0001"),
+            _make_paper(paper_id="2301.0002"),
+        ]
+        registry = _make_registry()  # default: no matches
+        monitor = ArxivMonitor(_make_provider(papers), registry)
+
+        result = await monitor.check(_make_subscription())
+
+        assert result.run.status is MonitoringRunStatus.SUCCESS
+        assert result.run.papers_seen == 2
+        assert result.run.papers_new == 2
+        assert result.run.papers_deduplicated == 0
+        assert [p.paper_id for p in result.new_papers] == [
+            "2301.0001",
+            "2301.0002",
+        ]
+        assert registry.register_paper.call_count == 2
+        # Verify discovery_only=True was passed.
+        for call in registry.register_paper.call_args_list:
+            assert call.kwargs["discovery_only"] is True
+
+    @pytest.mark.asyncio
+    async def test_dedup_against_registry(self) -> None:
+        papers = [
+            _make_paper(paper_id="2301.0001"),
+            _make_paper(paper_id="2301.0002"),
+        ]
+        # Mark the second as already-known.
+        registry = _make_registry(
+            matches={"2301.0002": IdentityMatch(matched=True, match_method="arxiv")}
+        )
+        monitor = ArxivMonitor(_make_provider(papers), registry)
+
+        result = await monitor.check(_make_subscription())
+
+        assert result.run.papers_seen == 2
+        assert result.run.papers_new == 1
+        assert result.run.papers_deduplicated == 1
+        assert [p.paper_id for p in result.new_papers] == ["2301.0001"]
+        assert [p.paper_id for p in result.deduplicated_papers] == ["2301.0002"]
+        # Only the new paper hits register_paper.
+        assert registry.register_paper.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_topic_slug_passed_to_registry(self) -> None:
+        papers = [_make_paper()]
+        registry = _make_registry()
+        monitor = ArxivMonitor(_make_provider(papers), registry)
+        sub = _make_subscription(subscription_id="sub-abc")
+
+        await monitor.check(sub)
+
+        registry.register_paper.assert_called_once()
+        kwargs = registry.register_paper.call_args.kwargs
+        assert kwargs["topic_slug"] == "monitor-sub-abc"
+
+
+# ---------------------------------------------------------------------------
+# Per-cycle paper cap
+# ---------------------------------------------------------------------------
+
+
+class TestPerCycleCap:
+    @pytest.mark.asyncio
+    async def test_cap_truncates_results(self) -> None:
+        papers = [_make_paper(paper_id=f"2301.{i:04d}") for i in range(5)]
+        monitor = ArxivMonitor(
+            _make_provider(papers),
+            _make_registry(),
+            max_papers_per_cycle=3,
+        )
+        result = await monitor.check(_make_subscription())
+
+        # Only the first 3 are processed.
+        assert result.run.papers_seen == 3
+        assert result.run.papers_new == 3
+        assert [p.paper_id for p in result.new_papers] == [
+            "2301.0000",
+            "2301.0001",
+            "2301.0002",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Partial-failure paths
+# ---------------------------------------------------------------------------
+
+
+class TestPartialFailures:
+    @pytest.mark.asyncio
+    async def test_identity_resolution_error_yields_partial(self) -> None:
+        papers = [_make_paper(paper_id="2301.0001")]
+        registry = _make_registry(raise_on_resolve=RuntimeError("bad row"))
+        monitor = ArxivMonitor(_make_provider(papers), registry)
+
+        result = await monitor.check(_make_subscription())
+
+        assert result.run.status is MonitoringRunStatus.PARTIAL
+        assert result.run.error == "one_or_more_papers_failed"
+        assert result.run.papers_seen == 1
+        assert result.run.papers_new == 0
+        assert result.run.papers_deduplicated == 0
+        # No paper added to records (the loop ``continue``d before
+        # appending).
+        assert result.run.papers == []
+
+    @pytest.mark.asyncio
+    async def test_register_failure_yields_partial(self) -> None:
+        papers = [_make_paper(paper_id="2301.0001")]
+        registry = _make_registry(raise_on_register=RuntimeError("disk full"))
+        monitor = ArxivMonitor(_make_provider(papers), registry)
+
+        result = await monitor.check(_make_subscription())
+
+        assert result.run.status is MonitoringRunStatus.PARTIAL
+        assert result.run.error == "one_or_more_papers_failed"
+        assert result.run.papers_seen == 1
+        assert result.run.papers_new == 0
+        assert result.new_papers == []
+
+    @pytest.mark.asyncio
+    async def test_partial_with_some_success(self) -> None:
+        # First paper succeeds, second blows up on register.
+        papers = [
+            _make_paper(paper_id="2301.0001"),
+            _make_paper(paper_id="2301.0002"),
+        ]
+        registry = MagicMock()
+        registry.resolve_identity = MagicMock(return_value=IdentityMatch(matched=False))
+        call_count = {"n": 0}
+
+        def register_side_effect(**kwargs: Any) -> RegistryEntry:
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return RegistryEntry(
+                    title_normalized=kwargs["paper"].title.lower(),
+                    extraction_target_hash="sha256:test",
+                )
+            raise RuntimeError("disk full")
+
+        registry.register_paper = MagicMock(side_effect=register_side_effect)
+        monitor = ArxivMonitor(_make_provider(papers), registry)
+
+        result = await monitor.check(_make_subscription())
+
+        assert result.run.status is MonitoringRunStatus.PARTIAL
+        assert result.run.papers_seen == 2
+        assert result.run.papers_new == 1
+        # Only the first paper was added to the records list.
+        assert [r.paper_id for r in result.run.papers] == ["2301.0001"]
+
+
+# ---------------------------------------------------------------------------
+# Record conversion
+# ---------------------------------------------------------------------------
+
+
+class TestToRecord:
+    def test_to_record_with_urls(self) -> None:
+        paper = _make_paper(
+            paper_id="2301.0001",
+            url="https://arxiv.org/abs/2301.0001",
+            pdf="https://arxiv.org/pdf/2301.0001",
+        )
+        rec = ArxivMonitor._to_record(paper, is_new=True)
+        # HttpUrl is stringified into a plain str for the DTO.
+        assert isinstance(rec.url, str)
+        assert rec.url.startswith("https://arxiv.org/abs/")
+        assert isinstance(rec.pdf_url, str)
+        assert rec.pdf_url.startswith("https://arxiv.org/pdf/")
+        assert rec.is_new is True
+        assert rec.published_at is not None
+
+    def test_to_record_without_pdf(self) -> None:
+        paper = _make_paper(pdf=None)
+        rec = ArxivMonitor._to_record(paper, is_new=False)
+        assert rec.pdf_url is None
+        assert rec.is_new is False

--- a/tests/unit/services/intelligence/monitoring/test_models.py
+++ b/tests/unit/services/intelligence/monitoring/test_models.py
@@ -1,0 +1,366 @@
+"""Tests for monitoring Pydantic V2 models (Milestone 9.1).
+
+Covers:
+- All enums (``SubscriptionStatus``, ``MonitoringRunStatus``)
+- Every field validator on ``ResearchSubscription``
+- ``MonitoringPaperRecord`` + ``MonitoringRun`` construction & limit enforcement
+- ``SubscriptionLimitError`` raising at the documented thresholds
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from src.services.intelligence.models.monitoring import (
+    PaperSource,
+    SubscriptionLimitError,
+)
+from src.services.intelligence.monitoring.models import (
+    MAX_KEYWORDS_PER_SUBSCRIPTION,
+    MAX_PAPERS_PER_CYCLE,
+    MonitoringPaperRecord,
+    MonitoringRun,
+    MonitoringRunStatus,
+    ResearchSubscription,
+    SubscriptionStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Enum surface
+# ---------------------------------------------------------------------------
+
+
+class TestSubscriptionStatusEnum:
+    def test_subscription_status_values(self) -> None:
+        assert SubscriptionStatus.ACTIVE.value == "active"
+        assert SubscriptionStatus.PAUSED.value == "paused"
+
+    def test_subscription_status_str_subclass(self) -> None:
+        # str-Enum interop: comparison with raw string works via ``.value``.
+        assert SubscriptionStatus.ACTIVE == "active"
+        assert SubscriptionStatus("paused") is SubscriptionStatus.PAUSED
+
+
+class TestMonitoringRunStatusEnum:
+    def test_monitoring_run_status_values(self) -> None:
+        assert MonitoringRunStatus.SUCCESS.value == "success"
+        assert MonitoringRunStatus.PARTIAL.value == "partial"
+        assert MonitoringRunStatus.FAILED.value == "failed"
+
+
+# ---------------------------------------------------------------------------
+# ResearchSubscription
+# ---------------------------------------------------------------------------
+
+
+class TestResearchSubscriptionConstruction:
+    def test_construction_minimal_defaults(self) -> None:
+        sub = ResearchSubscription(name="x", query="q")
+        assert sub.subscription_id.startswith("sub-")
+        assert sub.user_id == "default"
+        assert sub.keywords == []
+        assert sub.exclude_keywords == []
+        assert sub.min_relevance_score == 0.7
+        assert sub.sources == [PaperSource.ARXIV]
+        assert sub.poll_interval_hours == 6
+        assert sub.status is SubscriptionStatus.ACTIVE
+        assert sub.last_checked_at is None
+        assert isinstance(sub.created_at, datetime)
+        assert isinstance(sub.updated_at, datetime)
+
+    def test_construction_explicit_fields(self) -> None:
+        sub = ResearchSubscription(
+            subscription_id="sub-abc123",
+            user_id="alice",
+            name="PEFT Research",
+            query="LoRA OR QLoRA",
+            keywords=["lora", "qlora"],
+            exclude_keywords=["survey"],
+            min_relevance_score=0.5,
+            poll_interval_hours=12,
+            sources=[PaperSource.ARXIV],
+            status=SubscriptionStatus.PAUSED,
+        )
+        assert sub.subscription_id == "sub-abc123"
+        assert sub.user_id == "alice"
+        assert sub.keywords == ["lora", "qlora"]
+        assert sub.exclude_keywords == ["survey"]
+        assert sub.status is SubscriptionStatus.PAUSED
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            ResearchSubscription(
+                name="x", query="q", junk="bad"  # type: ignore[call-arg]
+            )
+
+
+class TestIdentifierValidators:
+    def test_subscription_id_strip_whitespace(self) -> None:
+        sub = ResearchSubscription(
+            subscription_id=" sub-x ",
+            name="n",
+            query="q",
+        )
+        assert sub.subscription_id == "sub-x"
+
+    def test_subscription_id_rejects_empty(self) -> None:
+        with pytest.raises(ValidationError):
+            ResearchSubscription(subscription_id="   ", name="n", query="q")
+
+    def test_subscription_id_rejects_invalid_chars(self) -> None:
+        with pytest.raises(ValidationError) as excinfo:
+            ResearchSubscription(subscription_id="bad id!", name="n", query="q")
+        assert "Invalid identifier format" in str(excinfo.value)
+
+    def test_user_id_rejects_empty(self) -> None:
+        with pytest.raises(ValidationError):
+            ResearchSubscription(user_id=" ", name="n", query="q")
+
+    def test_user_id_rejects_invalid_chars(self) -> None:
+        with pytest.raises(ValidationError):
+            ResearchSubscription(user_id="alice@host", name="n", query="q")
+
+
+class TestNameValidator:
+    def test_name_strip_whitespace(self) -> None:
+        sub = ResearchSubscription(name="  My Sub ", query="q")
+        assert sub.name == "My Sub"
+
+    def test_name_rejects_empty(self) -> None:
+        with pytest.raises(ValidationError):
+            ResearchSubscription(name="   ", query="q")
+
+    def test_name_rejects_invalid_chars(self) -> None:
+        with pytest.raises(ValidationError) as excinfo:
+            ResearchSubscription(name="bad/name", query="q")
+        assert "Invalid subscription name" in str(excinfo.value)
+
+    def test_name_accepts_allowed_chars(self) -> None:
+        sub = ResearchSubscription(name="My-Sub_1.0 (v2)", query="q")
+        assert sub.name == "My-Sub_1.0 (v2)"
+
+
+class TestQueryValidator:
+    def test_query_strip_whitespace(self) -> None:
+        sub = ResearchSubscription(name="n", query="  some query  ")
+        assert sub.query == "some query"
+
+    def test_query_rejects_empty(self) -> None:
+        with pytest.raises(ValidationError):
+            ResearchSubscription(name="n", query="   ")
+
+
+class TestKeywordsValidator:
+    def test_keywords_lowercase_dedup(self) -> None:
+        sub = ResearchSubscription(name="n", query="q", keywords=["Foo", "foo", "BAR"])
+        # First-seen casing preserved; duplicate (lowered) dropped.
+        assert sub.keywords == ["Foo", "BAR"]
+
+    def test_keywords_rejects_empty_string(self) -> None:
+        with pytest.raises(ValidationError) as excinfo:
+            ResearchSubscription(name="n", query="q", keywords=["valid", "  "])
+        assert "Keywords cannot be empty" in str(excinfo.value)
+
+    def test_keywords_rejects_invalid_chars(self) -> None:
+        with pytest.raises(ValidationError) as excinfo:
+            ResearchSubscription(name="n", query="q", keywords=["bad@kw"])
+        assert "Invalid keyword" in str(excinfo.value)
+
+    def test_keywords_accepts_allowed_chars(self) -> None:
+        sub = ResearchSubscription(
+            name="n",
+            query="q",
+            keywords=["foo+bar", "baz/qux", "a:b", "c.d-e_f", "(group)"],
+        )
+        assert len(sub.keywords) == 5
+
+    def test_keywords_limit_raises_subscription_limit_error(self) -> None:
+        too_many = [f"kw-{i}" for i in range(MAX_KEYWORDS_PER_SUBSCRIPTION + 1)]
+        with pytest.raises(ValidationError) as excinfo:
+            ResearchSubscription(name="n", query="q", keywords=too_many)
+        # SubscriptionLimitError is a ValueError subclass; Pydantic wraps
+        # it into ValidationError, but the chained cause is preserved.
+        cause = excinfo.value.errors()[0]
+        assert "Subscription limit exceeded" in cause["msg"]
+        assert "keywords per subscription" in cause["msg"]
+
+    def test_keywords_at_limit_accepted(self) -> None:
+        # Exactly at the limit must succeed.
+        kws = [f"kw-{i}" for i in range(MAX_KEYWORDS_PER_SUBSCRIPTION)]
+        sub = ResearchSubscription(name="n", query="q", keywords=kws)
+        assert len(sub.keywords) == MAX_KEYWORDS_PER_SUBSCRIPTION
+
+    def test_exclude_keywords_share_validator(self) -> None:
+        # Same validator runs for both fields.
+        with pytest.raises(ValidationError):
+            ResearchSubscription(name="n", query="q", exclude_keywords=["bad@kw"])
+
+
+class TestSourcesValidator:
+    def test_sources_default_arxiv(self) -> None:
+        sub = ResearchSubscription(name="n", query="q")
+        assert sub.sources == [PaperSource.ARXIV]
+
+    def test_sources_explicit_arxiv_normalized(self) -> None:
+        sub = ResearchSubscription(
+            name="n", query="q", sources=[PaperSource.ARXIV, PaperSource.ARXIV]
+        )
+        # Normalized to single ArXiv entry.
+        assert sub.sources == [PaperSource.ARXIV]
+
+    def test_sources_rejects_non_arxiv(self) -> None:
+        with pytest.raises(ValidationError) as excinfo:
+            ResearchSubscription(
+                name="n", query="q", sources=[PaperSource.SEMANTIC_SCHOLAR]
+            )
+        assert "Only PaperSource.ARXIV is supported" in str(excinfo.value)
+
+    def test_sources_rejects_mixed(self) -> None:
+        with pytest.raises(ValidationError):
+            ResearchSubscription(
+                name="n",
+                query="q",
+                sources=[PaperSource.ARXIV, PaperSource.OPENALEX],
+            )
+
+    def test_sources_validator_rejects_empty_directly(self) -> None:
+        # ``min_length=1`` on the field already catches empty lists, but
+        # the inner validator has its own defensive guard. Exercise it
+        # directly so the branch isn't dead code.
+        with pytest.raises(ValueError, match="At least one source is required"):
+            ResearchSubscription._validate_sources_arxiv_only([])
+
+
+class TestRangeValidators:
+    def test_min_relevance_score_out_of_range_low(self) -> None:
+        with pytest.raises(ValidationError):
+            ResearchSubscription(name="n", query="q", min_relevance_score=-0.01)
+
+    def test_min_relevance_score_out_of_range_high(self) -> None:
+        with pytest.raises(ValidationError):
+            ResearchSubscription(name="n", query="q", min_relevance_score=1.5)
+
+    def test_poll_interval_too_low(self) -> None:
+        with pytest.raises(ValidationError):
+            ResearchSubscription(name="n", query="q", poll_interval_hours=0)
+
+    def test_poll_interval_too_high(self) -> None:
+        with pytest.raises(ValidationError):
+            ResearchSubscription(name="n", query="q", poll_interval_hours=24 * 7 + 1)
+
+
+# ---------------------------------------------------------------------------
+# MonitoringPaperRecord
+# ---------------------------------------------------------------------------
+
+
+class TestMonitoringPaperRecord:
+    def test_paper_record_minimal(self) -> None:
+        rec = MonitoringPaperRecord(paper_id="2301.12345", title="A Paper", is_new=True)
+        assert rec.paper_id == "2301.12345"
+        assert rec.title == "A Paper"
+        assert rec.is_new is True
+        assert rec.url is None
+        assert rec.pdf_url is None
+        assert rec.published_at is None
+        assert rec.relevance_score is None
+        assert rec.relevance_reasoning is None
+
+    def test_paper_record_full(self) -> None:
+        rec = MonitoringPaperRecord(
+            paper_id="2301.12345",
+            title="A Paper",
+            url="https://arxiv.org/abs/2301.12345",
+            pdf_url="https://arxiv.org/pdf/2301.12345",
+            published_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            is_new=False,
+            relevance_score=0.9,
+            relevance_reasoning="strong match",
+        )
+        assert rec.url == "https://arxiv.org/abs/2301.12345"
+        assert rec.relevance_score == 0.9
+
+    def test_paper_record_extra_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            MonitoringPaperRecord(
+                paper_id="x",
+                title="t",
+                is_new=True,
+                junk="bad",  # type: ignore[call-arg]
+            )
+
+    def test_paper_record_relevance_score_out_of_range(self) -> None:
+        with pytest.raises(ValidationError):
+            MonitoringPaperRecord(
+                paper_id="x", title="t", is_new=True, relevance_score=1.5
+            )
+
+
+# ---------------------------------------------------------------------------
+# MonitoringRun
+# ---------------------------------------------------------------------------
+
+
+class TestMonitoringRun:
+    def test_monitoring_run_defaults(self) -> None:
+        run = MonitoringRun(subscription_id="sub-1")
+        assert run.run_id.startswith("run-")
+        assert run.source is PaperSource.ARXIV
+        assert run.status is MonitoringRunStatus.SUCCESS
+        assert run.papers == []
+        assert run.papers_seen == 0
+        assert run.error is None
+        assert run.scheduled_job_id is None
+
+    def test_monitoring_run_below_paper_cap(self) -> None:
+        records = [
+            MonitoringPaperRecord(paper_id=f"p-{i}", title="t", is_new=True)
+            for i in range(3)
+        ]
+        run = MonitoringRun(subscription_id="sub-1", papers=records)
+        assert len(run.papers) == 3
+
+    def test_monitoring_run_at_paper_cap_accepted(self) -> None:
+        records = [
+            MonitoringPaperRecord(paper_id=f"p-{i}", title="t", is_new=True)
+            for i in range(MAX_PAPERS_PER_CYCLE)
+        ]
+        run = MonitoringRun(subscription_id="sub-1", papers=records)
+        assert len(run.papers) == MAX_PAPERS_PER_CYCLE
+
+    def test_monitoring_run_above_paper_cap_raises(self) -> None:
+        records = [
+            MonitoringPaperRecord(paper_id=f"p-{i}", title="t", is_new=True)
+            for i in range(MAX_PAPERS_PER_CYCLE + 1)
+        ]
+        with pytest.raises(ValidationError) as excinfo:
+            MonitoringRun(subscription_id="sub-1", papers=records)
+        cause = excinfo.value.errors()[0]
+        assert "papers per cycle" in cause["msg"]
+
+    def test_monitoring_run_negative_counts_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            MonitoringRun(subscription_id="sub-1", papers_seen=-1)
+
+
+# ---------------------------------------------------------------------------
+# SubscriptionLimitError surface
+# ---------------------------------------------------------------------------
+
+
+class TestSubscriptionLimitErrorIntegration:
+    def test_subscription_limit_error_attributes(self) -> None:
+        # Check attributes set on the canonical exception so callers can
+        # render structured error responses.
+        err = SubscriptionLimitError("keywords per subscription", 105, 100)
+        assert err.limit_type == "keywords per subscription"
+        assert err.current == 105
+        assert err.max_allowed == 100
+        assert "Subscription limit exceeded" in str(err)
+
+    def test_subscription_limit_error_is_value_error(self) -> None:
+        # ValueError ancestry is what lets Pydantic wrap it cleanly.
+        assert issubclass(SubscriptionLimitError, ValueError)

--- a/tests/unit/services/intelligence/monitoring/test_subscription_manager.py
+++ b/tests/unit/services/intelligence/monitoring/test_subscription_manager.py
@@ -1,0 +1,395 @@
+"""Tests for ``SubscriptionManager`` (Milestone 9.1).
+
+Covers:
+- CRUD happy paths (add, get, list, update, delete, set_status, mark_checked)
+- Limit enforcement (per-user cap and per-subscription keyword cap)
+- ``KeyError`` on missing rows for update/set_status/mark_checked
+- ``ValueError`` on duplicate ``subscription_id`` insert
+- ``RuntimeError`` when methods are called before ``initialize``
+- Filtering by ``user_id`` and active flag in ``list_subscriptions``
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from src.services.intelligence.models.monitoring import (
+    PaperSource,
+    SubscriptionLimitError,
+)
+from src.services.intelligence.monitoring.models import (
+    MAX_KEYWORDS_PER_SUBSCRIPTION,
+    ResearchSubscription,
+    SubscriptionStatus,
+)
+from src.services.intelligence.monitoring.subscription_manager import (
+    SubscriptionManager,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db_path() -> Path:
+    """Return a unique sqlite db path under the system temp dir."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        path = Path(f.name)
+    # Remove the empty file so MigrationManager creates it fresh.
+    path.unlink(missing_ok=True)
+    return path
+
+
+@pytest.fixture
+def manager(db_path: Path) -> SubscriptionManager:
+    mgr = SubscriptionManager(db_path)
+    mgr.initialize()
+    return mgr
+
+
+def _make_subscription(
+    *,
+    subscription_id: str = "sub-test001",
+    user_id: str = "alice",
+    name: str = "Test Sub",
+    query: str = "tree of thoughts",
+    keywords: list[str] | None = None,
+    status: SubscriptionStatus = SubscriptionStatus.ACTIVE,
+) -> ResearchSubscription:
+    return ResearchSubscription(
+        subscription_id=subscription_id,
+        user_id=user_id,
+        name=name,
+        query=query,
+        keywords=keywords or [],
+        status=status,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Initialization
+# ---------------------------------------------------------------------------
+
+
+class TestInitialize:
+    def test_initialize_applies_migrations(self, db_path: Path) -> None:
+        mgr = SubscriptionManager(db_path)
+        mgr.initialize()
+        # After init, the subscriptions table exists and is queryable.
+        with sqlite3.connect(str(db_path)) as conn:
+            cur = conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name='subscriptions'"
+            )
+            assert cur.fetchone() is not None
+
+    def test_initialize_idempotent(self, db_path: Path) -> None:
+        mgr = SubscriptionManager(db_path)
+        mgr.initialize()
+        # Second call is a no-op; should not raise.
+        mgr.initialize()
+        assert mgr._initialized is True
+
+    def test_method_before_initialize_raises(self, db_path: Path) -> None:
+        mgr = SubscriptionManager(db_path)
+        with pytest.raises(RuntimeError, match="not initialized"):
+            mgr.add_subscription(_make_subscription())
+
+
+# ---------------------------------------------------------------------------
+# CRUD happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestAdd:
+    def test_add_returns_subscription_id(self, manager: SubscriptionManager) -> None:
+        sub = _make_subscription()
+        result = manager.add_subscription(sub)
+        assert result == "sub-test001"
+
+    def test_add_persists_all_fields(self, manager: SubscriptionManager) -> None:
+        sub = _make_subscription(
+            keywords=["lora", "qlora"], status=SubscriptionStatus.PAUSED
+        )
+        manager.add_subscription(sub)
+        fetched = manager.get_subscription("sub-test001")
+        assert fetched is not None
+        assert fetched.subscription_id == sub.subscription_id
+        assert fetched.user_id == sub.user_id
+        assert fetched.name == sub.name
+        assert fetched.query == sub.query
+        assert fetched.keywords == sub.keywords
+        assert fetched.status == SubscriptionStatus.PAUSED
+        assert fetched.sources == [PaperSource.ARXIV]
+
+    def test_add_with_last_checked_at_persists(
+        self, manager: SubscriptionManager
+    ) -> None:
+        when = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        sub = ResearchSubscription(
+            subscription_id="sub-lc",
+            name="n",
+            query="q",
+            last_checked_at=when,
+        )
+        manager.add_subscription(sub)
+        fetched = manager.get_subscription("sub-lc")
+        assert fetched is not None
+        assert fetched.last_checked_at == when
+
+    def test_add_duplicate_id_raises_value_error(
+        self, manager: SubscriptionManager
+    ) -> None:
+        sub = _make_subscription()
+        manager.add_subscription(sub)
+        with pytest.raises(ValueError, match="already exists"):
+            manager.add_subscription(sub)
+
+
+class TestGet:
+    def test_get_returns_none_for_missing(self, manager: SubscriptionManager) -> None:
+        assert manager.get_subscription("sub-missing") is None
+
+    def test_get_returns_existing(self, manager: SubscriptionManager) -> None:
+        sub = _make_subscription()
+        manager.add_subscription(sub)
+        fetched = manager.get_subscription(sub.subscription_id)
+        assert fetched is not None
+        assert fetched.subscription_id == sub.subscription_id
+
+
+class TestList:
+    def test_list_empty(self, manager: SubscriptionManager) -> None:
+        assert manager.list_subscriptions() == []
+
+    def test_list_all(self, manager: SubscriptionManager) -> None:
+        manager.add_subscription(_make_subscription(subscription_id="sub-a"))
+        manager.add_subscription(_make_subscription(subscription_id="sub-b"))
+        all_subs = manager.list_subscriptions()
+        assert {s.subscription_id for s in all_subs} == {"sub-a", "sub-b"}
+
+    def test_list_filter_by_user(self, manager: SubscriptionManager) -> None:
+        manager.add_subscription(
+            _make_subscription(subscription_id="sub-a", user_id="alice")
+        )
+        manager.add_subscription(
+            _make_subscription(subscription_id="sub-b", user_id="bob")
+        )
+        alice = manager.list_subscriptions(user_id="alice")
+        assert [s.subscription_id for s in alice] == ["sub-a"]
+
+    def test_list_active_only(self, manager: SubscriptionManager) -> None:
+        manager.add_subscription(
+            _make_subscription(
+                subscription_id="sub-a", status=SubscriptionStatus.ACTIVE
+            )
+        )
+        manager.add_subscription(
+            _make_subscription(
+                subscription_id="sub-b", status=SubscriptionStatus.PAUSED
+            )
+        )
+        actives = manager.list_subscriptions(active_only=True)
+        assert [s.subscription_id for s in actives] == ["sub-a"]
+
+    def test_list_combined_filters(self, manager: SubscriptionManager) -> None:
+        manager.add_subscription(
+            _make_subscription(
+                subscription_id="sub-a",
+                user_id="alice",
+                status=SubscriptionStatus.ACTIVE,
+            )
+        )
+        manager.add_subscription(
+            _make_subscription(
+                subscription_id="sub-b",
+                user_id="alice",
+                status=SubscriptionStatus.PAUSED,
+            )
+        )
+        manager.add_subscription(
+            _make_subscription(
+                subscription_id="sub-c",
+                user_id="bob",
+                status=SubscriptionStatus.ACTIVE,
+            )
+        )
+        result = manager.list_subscriptions(user_id="alice", active_only=True)
+        assert [s.subscription_id for s in result] == ["sub-a"]
+
+
+class TestUpdate:
+    def test_update_persists_changes(self, manager: SubscriptionManager) -> None:
+        sub = _make_subscription()
+        manager.add_subscription(sub)
+        sub.name = "Renamed"
+        sub.keywords = ["new"]
+        sub.status = SubscriptionStatus.PAUSED
+        manager.update_subscription(sub)
+        fetched = manager.get_subscription(sub.subscription_id)
+        assert fetched is not None
+        assert fetched.name == "Renamed"
+        assert fetched.keywords == ["new"]
+        assert fetched.status == SubscriptionStatus.PAUSED
+
+    def test_update_missing_raises_keyerror(self, manager: SubscriptionManager) -> None:
+        ghost = _make_subscription(subscription_id="sub-ghost")
+        with pytest.raises(KeyError, match="Subscription not found"):
+            manager.update_subscription(ghost)
+
+    def test_update_with_last_checked(self, manager: SubscriptionManager) -> None:
+        sub = _make_subscription()
+        manager.add_subscription(sub)
+        sub.last_checked_at = datetime(2024, 6, 1, tzinfo=timezone.utc)
+        manager.update_subscription(sub)
+        fetched = manager.get_subscription(sub.subscription_id)
+        assert fetched is not None
+        assert fetched.last_checked_at == sub.last_checked_at
+
+
+class TestDelete:
+    def test_delete_existing_returns_true(self, manager: SubscriptionManager) -> None:
+        sub = _make_subscription()
+        manager.add_subscription(sub)
+        assert manager.delete_subscription(sub.subscription_id) is True
+        assert manager.get_subscription(sub.subscription_id) is None
+
+    def test_delete_missing_returns_false(self, manager: SubscriptionManager) -> None:
+        assert manager.delete_subscription("sub-missing") is False
+
+
+class TestSetStatus:
+    def test_set_status_pauses(self, manager: SubscriptionManager) -> None:
+        sub = _make_subscription()
+        manager.add_subscription(sub)
+        manager.set_status(sub.subscription_id, SubscriptionStatus.PAUSED)
+        fetched = manager.get_subscription(sub.subscription_id)
+        assert fetched is not None
+        assert fetched.status == SubscriptionStatus.PAUSED
+
+    def test_set_status_activates(self, manager: SubscriptionManager) -> None:
+        sub = _make_subscription(status=SubscriptionStatus.PAUSED)
+        manager.add_subscription(sub)
+        manager.set_status(sub.subscription_id, SubscriptionStatus.ACTIVE)
+        fetched = manager.get_subscription(sub.subscription_id)
+        assert fetched is not None
+        assert fetched.status == SubscriptionStatus.ACTIVE
+
+    def test_set_status_missing_raises_keyerror(
+        self, manager: SubscriptionManager
+    ) -> None:
+        with pytest.raises(KeyError, match="Subscription not found"):
+            manager.set_status("sub-missing", SubscriptionStatus.PAUSED)
+
+
+class TestMarkChecked:
+    def test_mark_checked_explicit_timestamp(
+        self, manager: SubscriptionManager
+    ) -> None:
+        sub = _make_subscription()
+        manager.add_subscription(sub)
+        when = datetime(2024, 3, 15, 12, 0, tzinfo=timezone.utc)
+        manager.mark_checked(sub.subscription_id, when=when)
+        fetched = manager.get_subscription(sub.subscription_id)
+        assert fetched is not None
+        assert fetched.last_checked_at == when
+
+    def test_mark_checked_default_now(self, manager: SubscriptionManager) -> None:
+        sub = _make_subscription()
+        manager.add_subscription(sub)
+        before = datetime.now(timezone.utc)
+        manager.mark_checked(sub.subscription_id)
+        after = datetime.now(timezone.utc) + timedelta(seconds=1)
+        fetched = manager.get_subscription(sub.subscription_id)
+        assert fetched is not None
+        assert fetched.last_checked_at is not None
+        assert before - timedelta(seconds=1) <= fetched.last_checked_at <= after
+
+    def test_mark_checked_missing_raises_keyerror(
+        self, manager: SubscriptionManager
+    ) -> None:
+        with pytest.raises(KeyError, match="Subscription not found"):
+            manager.mark_checked("sub-missing")
+
+
+# ---------------------------------------------------------------------------
+# Limit enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestLimits:
+    def test_per_user_subscription_cap(
+        self, manager: SubscriptionManager, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Lower the cap to keep the test fast and deterministic.
+        monkeypatch.setattr(SubscriptionManager, "MAX_SUBSCRIPTIONS_PER_USER", 3)
+        for i in range(3):
+            manager.add_subscription(
+                _make_subscription(subscription_id=f"sub-{i:03d}", user_id="alice")
+            )
+        with pytest.raises(SubscriptionLimitError) as excinfo:
+            manager.add_subscription(
+                _make_subscription(subscription_id="sub-overflow", user_id="alice")
+            )
+        assert excinfo.value.limit_type == "subscriptions per user"
+        assert excinfo.value.current == 3
+        assert excinfo.value.max_allowed == 3
+
+    def test_per_user_cap_isolated_by_user(
+        self, manager: SubscriptionManager, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Other users should not be affected.
+        monkeypatch.setattr(SubscriptionManager, "MAX_SUBSCRIPTIONS_PER_USER", 2)
+        for i in range(2):
+            manager.add_subscription(
+                _make_subscription(subscription_id=f"a-{i}", user_id="alice")
+            )
+        # Bob can still add up to his own cap.
+        manager.add_subscription(
+            _make_subscription(subscription_id="b-0", user_id="bob")
+        )
+        assert len(manager.list_subscriptions(user_id="bob")) == 1
+
+    def test_add_keyword_limit_raises_before_db(
+        self, manager: SubscriptionManager
+    ) -> None:
+        # The model validator enforces the cap, but the manager keeps a
+        # defensive guard. We exercise it by constructing a subscription
+        # with a maxed-out keyword list, then mutating it past the cap
+        # to bypass model validation.
+        sub = _make_subscription(
+            keywords=[f"k-{i}" for i in range(MAX_KEYWORDS_PER_SUBSCRIPTION)]
+        )
+        # Bypass validation by directly mutating the underlying list.
+        sub.keywords.append("overflow-kw")
+        with pytest.raises(SubscriptionLimitError) as excinfo:
+            manager.add_subscription(sub)
+        assert excinfo.value.limit_type == "keywords per subscription"
+        assert excinfo.value.current == MAX_KEYWORDS_PER_SUBSCRIPTION + 1
+
+    def test_update_keyword_limit_raises(self, manager: SubscriptionManager) -> None:
+        sub = _make_subscription()
+        manager.add_subscription(sub)
+        # Push past the cap directly on the model to bypass validation.
+        sub.keywords = [f"k-{i}" for i in range(MAX_KEYWORDS_PER_SUBSCRIPTION + 1)]
+        with pytest.raises(SubscriptionLimitError):
+            manager.update_subscription(sub)
+
+
+# ---------------------------------------------------------------------------
+# Path safety
+# ---------------------------------------------------------------------------
+
+
+class TestPathSafety:
+    def test_rejects_path_outside_approved_roots(self) -> None:
+        from src.utils.security import SecurityError
+
+        with pytest.raises(SecurityError):
+            SubscriptionManager("/etc/forbidden.db")

--- a/tests/unit/services/intelligence/monitoring/test_subscription_manager.py
+++ b/tests/unit/services/intelligence/monitoring/test_subscription_manager.py
@@ -393,3 +393,103 @@ class TestPathSafety:
 
         with pytest.raises(SecurityError):
             SubscriptionManager("/etc/forbidden.db")
+
+
+# ---------------------------------------------------------------------------
+# Concurrency — TOCTOU regression
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentAdd:
+    def test_concurrent_add_under_cap_serializes(
+        self, manager: SubscriptionManager, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression: BEGIN IMMEDIATE closes the count+INSERT race.
+
+        Pre-fix, two concurrent ``add_subscription`` calls could both
+        observe ``count==MAX-1`` (deferred read), both pass the cap
+        check, and both INSERT — leaving the user one subscription over
+        the documented limit. With ``BEGIN IMMEDIATE``, the second
+        writer blocks until the first commits, then re-reads the count
+        and either succeeds (still under cap) or raises
+        ``SubscriptionLimitError``.
+
+        With cap=N and N+M concurrent threads where M>0, exactly N
+        should succeed and M should raise ``SubscriptionLimitError``.
+        """
+        import threading
+
+        cap = 5
+        extra = 5
+        monkeypatch.setattr(SubscriptionManager, "MAX_SUBSCRIPTIONS_PER_USER", cap)
+
+        results: list[Exception | None] = [None] * (cap + extra)
+        barrier = threading.Barrier(cap + extra)
+
+        def worker(idx: int) -> None:
+            barrier.wait()  # release all threads simultaneously
+            try:
+                manager.add_subscription(
+                    _make_subscription(
+                        subscription_id=f"sub-{idx:03d}", user_id="alice"
+                    )
+                )
+            except Exception as exc:  # capture for assertion
+                results[idx] = exc
+
+        threads = [
+            threading.Thread(target=worker, args=(i,)) for i in range(cap + extra)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        successes = sum(1 for r in results if r is None)
+        limit_errors = sum(1 for r in results if isinstance(r, SubscriptionLimitError))
+        assert successes == cap, (
+            f"expected exactly {cap} successes, got {successes}; "
+            f"errors: {[type(r).__name__ for r in results if r is not None]}"
+        )
+        assert limit_errors == extra, (
+            f"expected exactly {extra} SubscriptionLimitError, got {limit_errors}; "
+            f"errors: {[type(r).__name__ for r in results if r is not None]}"
+        )
+        # And the cap is honored in storage.
+        assert len(manager.list_subscriptions(user_id="alice")) == cap
+
+
+# ---------------------------------------------------------------------------
+# Connection lifecycle — leak regression
+# ---------------------------------------------------------------------------
+
+
+class TestConnectionLifecycle:
+    def test_connect_closes_connection_on_exit(
+        self, manager: SubscriptionManager
+    ) -> None:
+        """Regression: ``_connect()`` must close on exit, not just commit.
+
+        Pre-fix, ``with sqlite3.connect(...) as conn`` would commit /
+        rollback but leave the connection open — leaking one file
+        descriptor per CRUD call under a long-running scheduler.
+        """
+        import warnings
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", ResourceWarning)
+            sub = _make_subscription()
+            manager.add_subscription(sub)
+            fetched = manager.get_subscription(sub.subscription_id)
+
+        assert fetched is not None
+        unclosed = [
+            w
+            for w in caught
+            if issubclass(w.category, ResourceWarning)
+            and "unclosed" in str(w.message).lower()
+        ]
+        assert unclosed == [], (
+            f"unexpected ResourceWarning(s) for unclosed resources: "
+            f"{[str(w.message) for w in unclosed]}"
+        )


### PR DESCRIPTION
## Summary
First slice of Milestone 9.1 (Proactive Paper Monitoring). ArXiv-only MVP per resolved decision in .omc/plans/open-questions.md.

**This PR delivers (Week 1 of 2):**
- subscription_manager.py — CRUD with limit enforcement (50/user, 100 keywords/sub) raising SubscriptionLimitError
- arxiv_monitor.py — RSS/API polling with rate limiting, dedup via paper_registry
- Pydantic V2 models for monitoring state
- Comprehensive tests (mocked HTTP, no live API calls)

**Deferred to Week 2 PR:** relevance_scorer.py, digest_generator.py, CLI commands, APScheduler MonitoringCheckJob integration.

## Verification
- ./verify.sh passes
- 4360 tests pass (was 4263 on main; +97)
- Coverage 99.22% combined (>=99% requirement met); 100% on every new module
- Black/Flake8/Mypy clean

## Test plan
- [ ] Reviewer: confirm no live ArXiv calls in tests
- [ ] Reviewer: confirm subscription limit enforcement matches spec REQ-9.1.x
- [ ] Reviewer: confirm dedup uses existing paper_registry (no duplicate logic)

## Refs
- Spec: docs/specs/PHASE_9_RESEARCH_INTELLIGENCE_SPEC.md (Section 4 / REQ-9.1.x)
- Spec addendum: PR #106 (merged)
- Foundation: PR #105 (merged)