### PR TITLE
feat(phase-9.1): MonitoringRunner + RunRepository + IntelligenceGraphConnection (closes #114)

### DIFF
--- a/src/services/intelligence/monitoring/__init__.py
+++ b/src/services/intelligence/monitoring/__init__.py
@@ -41,6 +41,7 @@ from src.services.intelligence.monitoring.models import (
 from src.services.intelligence.monitoring.run_repository import (
     MonitoringRunRepository,
 )
+from src.services.intelligence.monitoring.runner import MonitoringRunner
 from src.services.intelligence.monitoring.subscription_manager import (
     SubscriptionManager,
 )
@@ -52,6 +53,7 @@ __all__ = [
     "MonitoringRun",
     "MonitoringRunRepository",
     "MonitoringRunStatus",
+    "MonitoringRunner",
     "ResearchSubscription",
     "SubscriptionManager",
     "SubscriptionStatus",

--- a/src/services/intelligence/monitoring/__init__.py
+++ b/src/services/intelligence/monitoring/__init__.py
@@ -38,6 +38,9 @@ from src.services.intelligence.monitoring.models import (
     ResearchSubscription,
     SubscriptionStatus,
 )
+from src.services.intelligence.monitoring.run_repository import (
+    MonitoringRunRepository,
+)
 from src.services.intelligence.monitoring.subscription_manager import (
     SubscriptionManager,
 )
@@ -47,6 +50,7 @@ __all__ = [
     "ArxivMonitorResult",
     "MonitoringPaperRecord",
     "MonitoringRun",
+    "MonitoringRunRepository",
     "MonitoringRunStatus",
     "ResearchSubscription",
     "SubscriptionManager",

--- a/src/services/intelligence/monitoring/run_repository.py
+++ b/src/services/intelligence/monitoring/run_repository.py
@@ -1,0 +1,343 @@
+"""Persistence for ``MonitoringRun`` audit records.
+
+Why a standalone repository (vs. extending ``SubscriptionManager``)
+------------------------------------------------------------------
+``SubscriptionManager`` already owns CRUD for the ``subscriptions``
+table plus the per-user / per-subscription limit enforcement that
+gates writes. Folding run-history persistence into it would mix two
+distinct lifecycles (long-lived configuration vs. append-only audit
+log) under one class -- a Single Responsibility violation that would
+also blur error-handling expectations (e.g. a corrupt run row should
+not affect subscription reads). A dedicated ``MonitoringRunRepository``
+keeps each concern testable and replaceable in isolation.
+
+Schema (created by ``MIGRATION_V2_MONITORING_RUNS``)
+----------------------------------------------------
+::
+
+    monitoring_runs(
+        run_id           TEXT PRIMARY KEY,
+        subscription_id  TEXT NOT NULL,
+        user_id          TEXT NOT NULL,
+        started_at       TEXT NOT NULL,
+        finished_at      TEXT,
+        status           TEXT NOT NULL,
+        error            TEXT,
+        papers_found     INTEGER NOT NULL DEFAULT 0,
+        papers_new       INTEGER NOT NULL DEFAULT 0
+    )
+
+    monitoring_papers(
+        run_id              TEXT NOT NULL,
+        paper_id            TEXT NOT NULL,
+        registered          INTEGER NOT NULL DEFAULT 0,
+        relevance_score     REAL,
+        relevance_reasoning TEXT,
+        PRIMARY KEY (run_id, paper_id),
+        FOREIGN KEY (run_id) REFERENCES monitoring_runs(run_id) ON DELETE CASCADE
+    )
+
+The ``user_id`` column is denormalized onto ``monitoring_runs`` because
+the ``MonitoringRun`` model itself does not carry one (subscriptions
+do). The ``MonitoringRunner`` resolves the owning user from the
+subscription before calling :meth:`record_run` so per-user audit
+queries don't have to JOIN every read.
+
+Concurrency model
+-----------------
+Same approach as ``SubscriptionManager``: each method opens a fresh
+connection through :func:`open_connection`, applies the standard
+PRAGMAs, and closes on exit. ``record_run`` uses a single transaction
+to insert the run row plus all its paper rows atomically.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+from typing import Iterator, Optional
+
+import structlog
+
+from src.services.intelligence.models.monitoring import PaperSource
+from src.services.intelligence.monitoring.models import (
+    MonitoringPaperRecord,
+    MonitoringRun,
+    MonitoringRunStatus,
+)
+from src.storage.intelligence_graph.connection import open_connection
+from src.storage.intelligence_graph.migrations import MigrationManager
+from src.storage.intelligence_graph.path_utils import sanitize_storage_path
+
+logger = structlog.get_logger()
+
+
+class MonitoringRunRepository:
+    """Append-only store for ``MonitoringRun`` audit records.
+
+    Owns the ``monitoring_runs`` and ``monitoring_papers`` tables
+    introduced by ``MIGRATION_V2_MONITORING_RUNS``. The runner facade
+    (``MonitoringRunner``) is the primary writer; the digest generator
+    (Week 2) and any future CLI / REST surface are the primary readers.
+    """
+
+    def __init__(self, db_path: Path | str, *, user_id: str = "default") -> None:
+        """Initialize the repository.
+
+        Args:
+            db_path: SQLite database path. Must lie under one of the
+                approved storage roots -- enforced by
+                :func:`sanitize_storage_path`.
+            user_id: Default user_id stamped on rows when
+                :meth:`record_run` is called without an explicit
+                override. The runner passes the resolved owning user
+                from the source subscription, so this is mostly a
+                convenience for tests and ad-hoc scripts.
+        """
+        self.db_path = sanitize_storage_path(db_path)
+        self._migrations = MigrationManager(self.db_path)
+        self._default_user_id = user_id
+        self._initialized = False
+
+    # ------------------------------------------------------------------
+    # Bookkeeping
+    # ------------------------------------------------------------------
+    def initialize(self) -> None:
+        """Apply pending schema migrations.
+
+        Idempotent -- safe to call multiple times. Must be called
+        before any read/write operation.
+        """
+        applied = self._migrations.migrate()
+        if applied > 0:
+            logger.info(
+                "monitoring_run_repository_migrations_applied",
+                count=applied,
+                db_path=str(self.db_path),
+            )
+        self._initialized = True
+
+    @contextmanager
+    def _connect(self) -> Iterator[sqlite3.Connection]:
+        """Open + auto-close a SQLite connection with the standard PRAGMAs.
+
+        Delegates to :func:`open_connection` so the PRAGMA set is
+        defined in exactly one place across the intelligence-graph
+        layer.
+        """
+        if not self._initialized:
+            raise RuntimeError(
+                "MonitoringRunRepository not initialized. Call initialize() first."
+            )
+        with open_connection(self.db_path) as conn:
+            yield conn
+
+    # ------------------------------------------------------------------
+    # Writes
+    # ------------------------------------------------------------------
+    def record_run(
+        self,
+        run: MonitoringRun,
+        *,
+        user_id: Optional[str] = None,
+    ) -> None:
+        """Persist ``run`` and all its paper records atomically.
+
+        The run row plus its per-paper rows are written in a single
+        transaction so a partial commit cannot leave dangling papers
+        without their parent run (or vice versa).
+
+        Args:
+            run: ``MonitoringRun`` to persist.
+            user_id: Owner user. When ``None`` the repository's
+                default user_id is used (mainly for tests).
+
+        Raises:
+            ValueError: If a run with the same ``run_id`` already
+                exists -- runs are append-only by design.
+        """
+        owner = user_id or self._default_user_id
+        finished = run.finished_at.isoformat() if run.finished_at else None
+        with self._connect() as conn:
+            conn.execute("BEGIN")
+            try:
+                cursor = conn.execute(
+                    "SELECT 1 FROM monitoring_runs WHERE run_id = ?",
+                    (run.run_id,),
+                )
+                if cursor.fetchone() is not None:
+                    raise ValueError(f"MonitoringRun already exists: {run.run_id!r}")
+                conn.execute(
+                    """
+                    INSERT INTO monitoring_runs (
+                        run_id, subscription_id, user_id,
+                        started_at, finished_at, status, error,
+                        papers_found, papers_new
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        run.run_id,
+                        run.subscription_id,
+                        owner,
+                        run.started_at.isoformat(),
+                        finished,
+                        run.status.value,
+                        run.error,
+                        run.papers_seen,
+                        run.papers_new,
+                    ),
+                )
+                if run.papers:
+                    conn.executemany(
+                        """
+                        INSERT INTO monitoring_papers (
+                            run_id, paper_id, registered,
+                            relevance_score, relevance_reasoning
+                        ) VALUES (?, ?, ?, ?, ?)
+                        """,
+                        [
+                            (
+                                run.run_id,
+                                paper.paper_id,
+                                1 if paper.is_new else 0,
+                                paper.relevance_score,
+                                paper.relevance_reasoning,
+                            )
+                            for paper in run.papers
+                        ],
+                    )
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                raise
+
+        logger.info(
+            "monitoring_run_recorded",
+            run_id=run.run_id,
+            subscription_id=run.subscription_id,
+            user_id=owner,
+            status=run.status.value,
+            papers_found=run.papers_seen,
+            papers_new=run.papers_new,
+        )
+
+    # ------------------------------------------------------------------
+    # Reads
+    # ------------------------------------------------------------------
+    def get_run(self, run_id: str) -> Optional[MonitoringRun]:
+        """Fetch a single run (with its paper records), or ``None``."""
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                SELECT run_id, subscription_id, user_id, started_at,
+                       finished_at, status, error,
+                       papers_found, papers_new
+                FROM monitoring_runs
+                WHERE run_id = ?
+                """,
+                (run_id,),
+            )
+            row = cursor.fetchone()
+            if row is None:
+                return None
+            papers = self._fetch_papers(conn, run_id)
+        return self._row_to_run(row, papers)
+
+    def list_runs(
+        self,
+        subscription_id: Optional[str] = None,
+        limit: int = 50,
+    ) -> list[MonitoringRun]:
+        """List runs ordered by ``started_at DESC``.
+
+        Args:
+            subscription_id: When set, only runs for that subscription
+                are returned.
+            limit: Maximum number of runs to return. Must be > 0.
+
+        Raises:
+            ValueError: If ``limit`` is not positive.
+        """
+        if limit <= 0:
+            raise ValueError("limit must be positive")
+        clauses: list[str] = []
+        params: list[object] = []
+        if subscription_id is not None:
+            clauses.append("subscription_id = ?")
+            params.append(subscription_id)
+        where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+        params.append(limit)
+        with self._connect() as conn:
+            cursor = conn.execute(
+                f"""
+                SELECT run_id, subscription_id, user_id, started_at,
+                       finished_at, status, error,
+                       papers_found, papers_new
+                FROM monitoring_runs
+                {where}
+                ORDER BY started_at DESC
+                LIMIT ?
+                """,
+                tuple(params),
+            )
+            rows = cursor.fetchall()
+            runs: list[MonitoringRun] = []
+            for row in rows:
+                papers = self._fetch_papers(conn, row["run_id"])
+                runs.append(self._row_to_run(row, papers))
+        return runs
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _fetch_papers(
+        conn: sqlite3.Connection, run_id: str
+    ) -> list[MonitoringPaperRecord]:
+        cursor = conn.execute(
+            """
+            SELECT paper_id, registered, relevance_score, relevance_reasoning
+            FROM monitoring_papers
+            WHERE run_id = ?
+            ORDER BY paper_id ASC
+            """,
+            (run_id,),
+        )
+        records: list[MonitoringPaperRecord] = []
+        for row in cursor.fetchall():
+            records.append(
+                MonitoringPaperRecord(
+                    paper_id=row["paper_id"],
+                    # The DTO requires title; we only store paper_id at
+                    # the audit layer (titles live on the registry).
+                    # Use the paper_id as a placeholder so the model
+                    # round-trips without a JOIN.
+                    title=row["paper_id"],
+                    is_new=bool(row["registered"]),
+                    relevance_score=row["relevance_score"],
+                    relevance_reasoning=row["relevance_reasoning"],
+                )
+            )
+        return records
+
+    @staticmethod
+    def _row_to_run(
+        row: sqlite3.Row, papers: list[MonitoringPaperRecord]
+    ) -> MonitoringRun:
+        finished_iso = row["finished_at"]
+        return MonitoringRun(
+            run_id=row["run_id"],
+            subscription_id=row["subscription_id"],
+            source=PaperSource.ARXIV,
+            started_at=datetime.fromisoformat(row["started_at"]),
+            finished_at=(
+                datetime.fromisoformat(finished_iso) if finished_iso else None
+            ),
+            status=MonitoringRunStatus(row["status"]),
+            papers_seen=int(row["papers_found"]),
+            papers_new=int(row["papers_new"]),
+            error=row["error"],
+            papers=papers,
+        )

--- a/src/services/intelligence/monitoring/runner.py
+++ b/src/services/intelligence/monitoring/runner.py
@@ -1,0 +1,189 @@
+"""Orchestrates one monitoring cycle across many subscriptions.
+
+Why this exists
+---------------
+Week 1 (PR #108) shipped the building blocks:
+
+- ``SubscriptionManager``: load + persist ``ResearchSubscription`` rows.
+- ``ArxivMonitor``: poll one subscription, return an ``ArxivMonitorResult``.
+- ``MonitoringRunRepository``: persist the ``MonitoringRun`` audit row.
+
+What's missing is a single seam that wires them together so the Week 2
+APScheduler ``MonitoringCheckJob`` (issue #117) can fire one method and
+get a deterministic outcome. ``MonitoringRunner`` is that seam.
+
+Behavior contract
+-----------------
+``run_once(user_id=None)`` does the following, in order:
+
+1. Load active subscriptions through ``SubscriptionManager``
+   (filtered by ``user_id`` when provided).
+2. For each subscription, call ``ArxivMonitor.check`` and capture the
+   resulting ``MonitoringRun``. **Failures on individual subs do not
+   abort the cycle** -- they're logged, captured as a ``FAILED`` run
+   record, and the loop continues.
+3. Persist every run (success + failure) through
+   ``MonitoringRunRepository.record_run`` so the audit log is complete
+   regardless of outcome.
+4. Call ``SubscriptionManager.mark_checked`` only on **non-FAILED**
+   runs. A FAILED run means the upstream provider was unavailable; we
+   don't want the next cycle to skip the sub because we updated the
+   timestamp on a failure.
+5. Return the list of runs (in subscription order) so the caller can
+   feed them into the digest generator (Week 2) or log per-cycle
+   metrics.
+
+The return type is intentionally ``list[MonitoringRun]`` (not
+``ArxivMonitorResult``) because anything richer than the persisted
+audit record is observability noise that the scheduler does not need
+to act on -- the caller can pull paper details from the registry if
+required.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import structlog
+
+from src.services.intelligence.monitoring.arxiv_monitor import ArxivMonitor
+from src.services.intelligence.monitoring.models import (
+    MonitoringRun,
+    MonitoringRunStatus,
+    ResearchSubscription,
+)
+from src.services.intelligence.monitoring.run_repository import (
+    MonitoringRunRepository,
+)
+from src.services.intelligence.monitoring.subscription_manager import (
+    SubscriptionManager,
+)
+
+logger = structlog.get_logger()
+
+
+class MonitoringRunner:
+    """Orchestrates a single monitoring cycle.
+
+    Single seam for the future APScheduler ``MonitoringCheckJob``
+    (issue #117). Construction takes the three Week-1 collaborators;
+    the Week-2 job will instantiate this once and call ``run_once()``
+    on each tick.
+    """
+
+    def __init__(
+        self,
+        subscription_manager: SubscriptionManager,
+        monitor: ArxivMonitor,
+        run_repo: MonitoringRunRepository,
+    ) -> None:
+        """Initialize the runner.
+
+        Args:
+            subscription_manager: Source of active subscriptions and
+                target for ``mark_checked`` updates.
+            monitor: ArXiv monitor that performs the per-subscription
+                poll. The runner does not care whether a future
+                multi-source monitor wraps this -- the contract is
+                ``check(subscription) -> ArxivMonitorResult``.
+            run_repo: Repository for the per-cycle audit record.
+        """
+        self._subscriptions = subscription_manager
+        self._monitor = monitor
+        self._run_repo = run_repo
+
+    async def run_once(self, user_id: Optional[str] = None) -> list[MonitoringRun]:
+        """Run one monitoring cycle across all active subscriptions.
+
+        Args:
+            user_id: When provided, only that user's active
+                subscriptions are polled. The default ``None`` polls
+                every active subscription regardless of owner --
+                matching the Week-2 job's "global tick" behavior.
+
+        Returns:
+            The ``MonitoringRun`` for each subscription processed,
+            in the same order they were loaded. Both successful and
+            failed runs are included so the caller has full visibility
+            into the cycle.
+        """
+        active_subs = self._subscriptions.list_subscriptions(
+            user_id=user_id, active_only=True
+        )
+        logger.info(
+            "monitoring_runner_cycle_starting",
+            subscription_count=len(active_subs),
+            user_id=user_id,
+        )
+
+        runs: list[MonitoringRun] = []
+        for sub in active_subs:
+            run = await self._run_one(sub)
+            runs.append(run)
+
+        succeeded = sum(1 for r in runs if r.status is not MonitoringRunStatus.FAILED)
+        failed = sum(1 for r in runs if r.status is MonitoringRunStatus.FAILED)
+        logger.info(
+            "monitoring_runner_cycle_complete",
+            subscription_count=len(active_subs),
+            succeeded=succeeded,
+            failed=failed,
+            user_id=user_id,
+        )
+        return runs
+
+    async def _run_one(self, subscription: ResearchSubscription) -> MonitoringRun:
+        """Run one cycle for ``subscription``, persist + mark, return run.
+
+        Encapsulates the per-subscription error envelope so a single
+        broken sub never aborts the broader cycle. ``ArxivMonitor.check``
+        already converts upstream provider failures into a ``FAILED``
+        ``MonitoringRun``; this layer additionally guards the persist
+        + mark_checked steps so persistence outages don't propagate.
+        """
+        try:
+            result = await self._monitor.check(subscription)
+            run = result.run
+        except Exception as exc:
+            # Defensive envelope: ArxivMonitor.check is documented to
+            # never raise, but a future monitor (or a bug) might. Keep
+            # the cycle going and surface the failure as a FAILED run.
+            logger.warning(
+                "monitoring_runner_check_error",
+                subscription_id=subscription.subscription_id,
+                error=str(exc),
+            )
+            run = MonitoringRun(
+                subscription_id=subscription.subscription_id,
+                status=MonitoringRunStatus.FAILED,
+                error=f"monitor_check_error: {exc}",
+            )
+
+        # Persist the audit row regardless of outcome. We catch
+        # persistence failures so a SQLite hiccup on one row doesn't
+        # break the rest of the cycle -- the in-memory ``run`` is still
+        # returned to the caller for observability.
+        try:
+            self._run_repo.record_run(run, user_id=subscription.user_id)
+        except Exception as exc:
+            logger.error(
+                "monitoring_runner_record_failed",
+                subscription_id=subscription.subscription_id,
+                run_id=run.run_id,
+                error=str(exc),
+            )
+
+        # Only mark the subscription as checked on success / partial.
+        # A FAILED run means we never spoke to the provider; updating
+        # last_checked would cause us to skip the next cycle for the
+        # wrong reason.
+        if run.status is not MonitoringRunStatus.FAILED:
+            try:
+                self._subscriptions.mark_checked(subscription.subscription_id)
+            except Exception as exc:
+                logger.error(
+                    "monitoring_runner_mark_checked_failed",
+                    subscription_id=subscription.subscription_id,
+                    error=str(exc),
+                )
+        return run

--- a/src/services/intelligence/monitoring/subscription_manager.py
+++ b/src/services/intelligence/monitoring/subscription_manager.py
@@ -56,6 +56,7 @@ from src.services.intelligence.monitoring.models import (
     ResearchSubscription,
     SubscriptionStatus,
 )
+from src.storage.intelligence_graph.connection import open_connection
 from src.storage.intelligence_graph.migrations import MigrationManager
 from src.storage.intelligence_graph.path_utils import sanitize_storage_path
 
@@ -112,25 +113,18 @@ class SubscriptionManager:
     def _connect(self) -> Iterator[sqlite3.Connection]:
         """Open + auto-close a SQLite connection with the standard PRAGMAs.
 
-        SQLite's ``Connection.__exit__`` commits / rolls back but does
-        NOT close. Wrapping with ``contextlib.contextmanager`` and an
-        explicit ``finally: conn.close()`` keeps file-descriptor usage
-        bounded under a long-running scheduler.
+        Delegates to :func:`open_connection` so the PRAGMA set is
+        defined exactly once across the intelligence-graph layer. The
+        ``BEGIN IMMEDIATE`` write-lock acquisition used by
+        :meth:`add_subscription` stays at the call site — that is
+        operation-level (not connection-level) behavior.
         """
         if not self._initialized:
             raise RuntimeError(
                 "SubscriptionManager not initialized. Call initialize() first."
             )
-        conn = sqlite3.connect(str(self.db_path))
-        conn.execute("PRAGMA foreign_keys = ON")
-        conn.execute("PRAGMA journal_mode = WAL")
-        conn.execute("PRAGMA synchronous = NORMAL")
-        conn.execute("PRAGMA busy_timeout = 5000")
-        conn.row_factory = sqlite3.Row
-        try:
+        with open_connection(self.db_path) as conn:
             yield conn
-        finally:
-            conn.close()
 
     # ------------------------------------------------------------------
     # Serialization

--- a/src/storage/intelligence_graph/__init__.py
+++ b/src/storage/intelligence_graph/__init__.py
@@ -12,6 +12,7 @@ Re-exports the most-used surface for convenience.
 """
 
 from src.storage.intelligence_graph.algorithms import GraphAlgorithms
+from src.storage.intelligence_graph.connection import open_connection
 from src.storage.intelligence_graph.migrations import (
     ALL_MIGRATIONS,
     MIGRATION_V1_INITIAL,
@@ -41,4 +42,5 @@ __all__ = [
     "TimeSeriesPoint",
     "TimeSeriesAggregate",
     "AggregationPeriod",
+    "open_connection",
 ]

--- a/src/storage/intelligence_graph/connection.py
+++ b/src/storage/intelligence_graph/connection.py
@@ -1,0 +1,100 @@
+"""Shared SQLite connection helper for the intelligence-graph layer.
+
+Why this exists
+---------------
+Three call sites in the intelligence-graph layer (``MigrationManager``,
+``SQLiteGraphStore``, ``TimeSeriesStore``) — and now the monitoring
+layer (``SubscriptionManager``, ``MonitoringRunRepository``) — each
+hand-roll the same four PRAGMAs every time they open a connection:
+
+- ``foreign_keys=ON`` (referential integrity, including ``ON DELETE CASCADE``)
+- ``journal_mode=WAL`` (writers don't block readers)
+- ``synchronous=NORMAL`` (durability vs. throughput trade-off)
+- ``busy_timeout=5000`` (wait up to 5s for locks before failing)
+
+The duplication is small but meaningful: changing any one PRAGMA (e.g.
+flipping to ``synchronous=FULL`` for a high-stakes operation) requires
+finding and updating every call site. This helper provides one source
+of truth.
+
+Why a context manager
+---------------------
+SQLite's ``Connection.__exit__`` commits / rolls back but **does not
+close** the connection. Under a long-running scheduler that opens a
+fresh connection per logical operation, that leaks one file descriptor
+per call. The helper wraps the connection in a ``contextmanager`` with
+an explicit ``finally: conn.close()`` so callers can write::
+
+    with open_connection(db_path) as conn:
+        conn.execute(...)
+
+without thinking about it.
+
+Scope (Phase 9.1)
+-----------------
+This helper is wired into:
+
+- ``SubscriptionManager._connect`` (monitoring CRUD)
+- ``MonitoringRunRepository._connect`` (run audit storage)
+
+The three intelligence-graph stores (``unified_graph.py``,
+``time_series.py``, ``migrations.py``) keep their existing
+``_get_connection()`` helpers for now. Those code paths use slightly
+different patterns (manual ``try/finally``, multiple commits per
+operation, etc.) that need a separate refactor pass tracked under
+``# TODO(phase-10): consolidate onto open_connection``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+
+@contextmanager
+def open_connection(db_path: Path) -> Iterator[sqlite3.Connection]:
+    """Open a SQLite connection with the standard intelligence-graph PRAGMAs.
+
+    Sets:
+
+    - ``foreign_keys=ON`` so ``FOREIGN KEY ... ON DELETE CASCADE`` and
+      other referential constraints are enforced.
+    - ``journal_mode=WAL`` so concurrent readers don't block writers.
+    - ``synchronous=NORMAL`` for the WAL mode's preferred durability /
+      throughput balance.
+    - ``busy_timeout=5000`` so a contended lock waits up to 5 seconds
+      before raising ``OperationalError("database is locked")``.
+
+    Also sets ``conn.row_factory = sqlite3.Row`` so callers can read
+    columns by name (``row["subscription_id"]``) instead of position.
+
+    The connection is **always closed** on exit, even on exception.
+    SQLite's own ``Connection.__exit__`` only commits / rolls back —
+    leaving file descriptors open under a long-running scheduler is the
+    bug this wrapper fixes.
+
+    Args:
+        db_path: Path to the SQLite database file. The caller is
+            responsible for path sanitization (this helper does not
+            re-validate; intelligence-graph callers go through
+            :func:`sanitize_storage_path` at construction time).
+
+    Yields:
+        A ready-to-use ``sqlite3.Connection``.
+
+    Raises:
+        sqlite3.OperationalError: If ``db_path`` is unusable (e.g.
+            parent directory does not exist, permission denied).
+    """
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute("PRAGMA journal_mode = WAL")
+        conn.execute("PRAGMA synchronous = NORMAL")
+        conn.execute("PRAGMA busy_timeout = 5000")
+        conn.row_factory = sqlite3.Row
+        yield conn
+    finally:
+        conn.close()

--- a/src/storage/intelligence_graph/migrations.py
+++ b/src/storage/intelligence_graph/migrations.py
@@ -229,6 +229,12 @@ class MigrationManager:
 
         Returns:
             SQLite connection ready for use.
+
+        TODO(phase-10): consolidate onto
+            ``src.storage.intelligence_graph.connection.open_connection``
+            once this manager moves to the per-operation context-manager
+            pattern used by ``SubscriptionManager`` /
+            ``MonitoringRunRepository``.
         """
         conn = sqlite3.connect(str(self.db_path))
         conn.execute("PRAGMA foreign_keys = ON")

--- a/src/storage/intelligence_graph/migrations.py
+++ b/src/storage/intelligence_graph/migrations.py
@@ -182,9 +182,57 @@ MIGRATION_V1_INITIAL = Migration(
 )
 
 
+# Schema version 2: Monitoring run audit tables (Phase 9.1)
+#
+# Adds two tables consumed by ``MonitoringRunRepository``:
+#
+# - ``monitoring_runs``: one row per ``MonitoringRun`` (subscription +
+#   cycle outcome + counters + optional error).
+# - ``monitoring_papers``: per-paper outcome of each run, FK'd to
+#   ``monitoring_runs(run_id) ON DELETE CASCADE`` so deleting a run
+#   transparently cleans up its paper records.
+#
+# Index on ``(subscription_id, started_at DESC)`` accelerates the
+# "most recent runs for this subscription" query that the digest
+# generator (Week 2) and any future CLI listing would issue.
+MIGRATION_V2_MONITORING_RUNS = Migration(
+    version=2,
+    name="monitoring_runs",
+    description="Add monitoring_runs + monitoring_papers tables for run audit",
+    up="""
+    CREATE TABLE IF NOT EXISTS monitoring_runs (
+        run_id TEXT PRIMARY KEY,
+        subscription_id TEXT NOT NULL,
+        user_id TEXT NOT NULL,
+        started_at TEXT NOT NULL,
+        finished_at TEXT,
+        status TEXT NOT NULL,
+        error TEXT,
+        papers_found INTEGER NOT NULL DEFAULT 0,
+        papers_new INTEGER NOT NULL DEFAULT 0
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_monitoring_runs_sub_started
+        ON monitoring_runs(subscription_id, started_at DESC);
+
+    CREATE TABLE IF NOT EXISTS monitoring_papers (
+        run_id TEXT NOT NULL,
+        paper_id TEXT NOT NULL,
+        registered INTEGER NOT NULL DEFAULT 0,
+        relevance_score REAL,
+        relevance_reasoning TEXT,
+        PRIMARY KEY (run_id, paper_id),
+        FOREIGN KEY (run_id) REFERENCES monitoring_runs(run_id)
+            ON DELETE CASCADE
+    );
+    """,
+)
+
+
 # All migrations in order
 ALL_MIGRATIONS: list[Migration] = [
     MIGRATION_V1_INITIAL,
+    MIGRATION_V2_MONITORING_RUNS,
 ]
 
 

--- a/src/storage/intelligence_graph/time_series.py
+++ b/src/storage/intelligence_graph/time_series.py
@@ -152,6 +152,12 @@ class TimeSeriesStore:
 
         Raises:
             RuntimeError: If store not initialized.
+
+        TODO(phase-10): consolidate onto
+            ``src.storage.intelligence_graph.connection.open_connection``
+            once this store moves to the per-operation context-manager
+            pattern used by ``SubscriptionManager`` /
+            ``MonitoringRunRepository``.
         """
         if not self._initialized:
             raise RuntimeError(

--- a/src/storage/intelligence_graph/unified_graph.py
+++ b/src/storage/intelligence_graph/unified_graph.py
@@ -399,6 +399,12 @@ class SQLiteGraphStore:
 
         Raises:
             GraphStoreError: If store not initialized.
+
+        TODO(phase-10): consolidate onto
+            ``src.storage.intelligence_graph.connection.open_connection``
+            once this store moves to the per-operation context-manager
+            pattern used by ``SubscriptionManager`` /
+            ``MonitoringRunRepository``.
         """
         if not self._initialized:
             raise GraphStoreError(

--- a/tests/unit/services/intelligence/monitoring/test_run_repository.py
+++ b/tests/unit/services/intelligence/monitoring/test_run_repository.py
@@ -1,0 +1,348 @@
+"""Tests for ``MonitoringRunRepository`` (Milestone 9.1).
+
+Covers:
+- Round-trip persistence (insert + fetch by id).
+- ``list_runs`` filtering by subscription_id and ordering by
+  ``started_at DESC``.
+- ``list_runs`` ``limit`` validation.
+- ``record_run`` raises ``ValueError`` on duplicate ``run_id``.
+- ``record_run`` rolls back when the paper insert fails (atomicity).
+- FOREIGN KEY ON DELETE CASCADE removes paper rows when the parent
+  run is deleted (regression for migration FK clause).
+- ``initialize`` is required before any read/write.
+- Path safety -- repository rejects paths outside approved roots.
+- ``get_run`` returns ``None`` for unknown id.
+- ``user_id`` denormalization respects the constructor default and
+  per-call override.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from src.services.intelligence.models.monitoring import PaperSource
+from src.services.intelligence.monitoring.models import (
+    MonitoringPaperRecord,
+    MonitoringRun,
+    MonitoringRunStatus,
+)
+from src.services.intelligence.monitoring.run_repository import (
+    MonitoringRunRepository,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db_path() -> Path:
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        path = Path(f.name)
+    path.unlink(missing_ok=True)
+    return path
+
+
+@pytest.fixture
+def repo(db_path: Path) -> MonitoringRunRepository:
+    r = MonitoringRunRepository(db_path)
+    r.initialize()
+    return r
+
+
+def _make_run(
+    *,
+    run_id: str = "run-aaa111",
+    subscription_id: str = "sub-test001",
+    status: MonitoringRunStatus = MonitoringRunStatus.SUCCESS,
+    started_at: datetime | None = None,
+    finished_at: datetime | None = None,
+    papers_seen: int = 0,
+    papers_new: int = 0,
+    error: str | None = None,
+    papers: list[MonitoringPaperRecord] | None = None,
+) -> MonitoringRun:
+    return MonitoringRun(
+        run_id=run_id,
+        subscription_id=subscription_id,
+        source=PaperSource.ARXIV,
+        started_at=started_at or datetime(2024, 1, 1, tzinfo=timezone.utc),
+        finished_at=finished_at,
+        status=status,
+        papers_seen=papers_seen,
+        papers_new=papers_new,
+        error=error,
+        papers=papers or [],
+    )
+
+
+def _make_record(
+    *,
+    paper_id: str = "2301.0001",
+    is_new: bool = True,
+    relevance_score: float | None = None,
+    relevance_reasoning: str | None = None,
+) -> MonitoringPaperRecord:
+    return MonitoringPaperRecord(
+        paper_id=paper_id,
+        title=paper_id,  # repo stores paper_id only; title=paper_id round-trips
+        is_new=is_new,
+        relevance_score=relevance_score,
+        relevance_reasoning=relevance_reasoning,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Initialization
+# ---------------------------------------------------------------------------
+
+
+class TestInitialize:
+    def test_initialize_creates_tables(self, db_path: Path) -> None:
+        repo = MonitoringRunRepository(db_path)
+        repo.initialize()
+        with sqlite3.connect(str(db_path)) as conn:
+            tables = {
+                row[0]
+                for row in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                ).fetchall()
+            }
+        assert "monitoring_runs" in tables
+        assert "monitoring_papers" in tables
+
+    def test_initialize_idempotent(self, db_path: Path) -> None:
+        repo = MonitoringRunRepository(db_path)
+        repo.initialize()
+        repo.initialize()  # no-op
+        assert repo._initialized is True
+
+    def test_method_before_initialize_raises(self, db_path: Path) -> None:
+        repo = MonitoringRunRepository(db_path)
+        with pytest.raises(RuntimeError, match="not initialized"):
+            repo.get_run("run-x")
+
+
+# ---------------------------------------------------------------------------
+# Path safety
+# ---------------------------------------------------------------------------
+
+
+class TestPathSafety:
+    def test_rejects_path_outside_approved_roots(self) -> None:
+        from src.utils.security import SecurityError
+
+        with pytest.raises(SecurityError):
+            MonitoringRunRepository("/etc/forbidden.db")
+
+
+# ---------------------------------------------------------------------------
+# Round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    def test_record_and_get_no_papers(self, repo: MonitoringRunRepository) -> None:
+        run = _make_run(papers_seen=0, papers_new=0)
+        repo.record_run(run)
+        fetched = repo.get_run(run.run_id)
+        assert fetched is not None
+        assert fetched.run_id == run.run_id
+        assert fetched.subscription_id == run.subscription_id
+        assert fetched.status is MonitoringRunStatus.SUCCESS
+        assert fetched.papers_seen == 0
+        assert fetched.papers_new == 0
+        assert fetched.papers == []
+
+    def test_record_and_get_with_papers(self, repo: MonitoringRunRepository) -> None:
+        records = [
+            _make_record(paper_id="2301.0001", is_new=True),
+            _make_record(
+                paper_id="2301.0002",
+                is_new=False,
+                relevance_score=0.85,
+                relevance_reasoning="strong match",
+            ),
+        ]
+        run = _make_run(papers_seen=2, papers_new=1, papers=records)
+        repo.record_run(run)
+        fetched = repo.get_run(run.run_id)
+        assert fetched is not None
+        assert fetched.papers_seen == 2
+        assert fetched.papers_new == 1
+        # Papers come back ordered by paper_id ASC.
+        assert [p.paper_id for p in fetched.papers] == ["2301.0001", "2301.0002"]
+        assert fetched.papers[0].is_new is True
+        assert fetched.papers[1].is_new is False
+        assert fetched.papers[1].relevance_score == 0.85
+        assert fetched.papers[1].relevance_reasoning == "strong match"
+
+    def test_record_persists_finished_at_and_error(
+        self, repo: MonitoringRunRepository
+    ) -> None:
+        finished = datetime(2024, 1, 1, 1, 2, 3, tzinfo=timezone.utc)
+        run = _make_run(
+            run_id="run-failure",
+            status=MonitoringRunStatus.FAILED,
+            finished_at=finished,
+            error="boom",
+        )
+        repo.record_run(run)
+        fetched = repo.get_run(run.run_id)
+        assert fetched is not None
+        assert fetched.finished_at == finished
+        assert fetched.error == "boom"
+        assert fetched.status is MonitoringRunStatus.FAILED
+
+    def test_get_returns_none_for_missing(self, repo: MonitoringRunRepository) -> None:
+        assert repo.get_run("run-missing") is None
+
+
+# ---------------------------------------------------------------------------
+# user_id handling
+# ---------------------------------------------------------------------------
+
+
+class TestUserId:
+    def test_default_user_id_used_when_not_provided(self, db_path: Path) -> None:
+        repo = MonitoringRunRepository(db_path, user_id="alice")
+        repo.initialize()
+        run = _make_run()
+        repo.record_run(run)
+        with sqlite3.connect(str(db_path)) as conn:
+            row = conn.execute(
+                "SELECT user_id FROM monitoring_runs WHERE run_id = ?",
+                (run.run_id,),
+            ).fetchone()
+        assert row[0] == "alice"
+
+    def test_explicit_user_id_overrides_default(
+        self, repo: MonitoringRunRepository, db_path: Path
+    ) -> None:
+        run = _make_run()
+        repo.record_run(run, user_id="bob")
+        with sqlite3.connect(str(db_path)) as conn:
+            row = conn.execute(
+                "SELECT user_id FROM monitoring_runs WHERE run_id = ?",
+                (run.run_id,),
+            ).fetchone()
+        assert row[0] == "bob"
+
+
+# ---------------------------------------------------------------------------
+# Duplicate prevention + atomicity
+# ---------------------------------------------------------------------------
+
+
+class TestRecordRunErrors:
+    def test_duplicate_run_id_raises(self, repo: MonitoringRunRepository) -> None:
+        run = _make_run()
+        repo.record_run(run)
+        with pytest.raises(ValueError, match="already exists"):
+            repo.record_run(run)
+
+    def test_record_run_rolls_back_on_failure(self, db_path: Path) -> None:
+        """Insert a paper twice in the same run -- the second triggers a
+        PRIMARY KEY violation on (run_id, paper_id), and the whole
+        record_run transaction must roll back so no orphaned run row
+        survives.
+        """
+        repo = MonitoringRunRepository(db_path)
+        repo.initialize()
+        # Pydantic will not let us construct two records with the same
+        # paper_id in a single run via normal channels, but we can
+        # bypass validation by mutating the list after construction.
+        records = [_make_record(paper_id="2301.0001")]
+        run = _make_run(papers=records)
+        # Append a duplicate directly on the model attribute to bypass
+        # the field validator.
+        run.papers.append(_make_record(paper_id="2301.0001"))
+        with pytest.raises(sqlite3.IntegrityError):
+            repo.record_run(run)
+        # Run must NOT be persisted.
+        assert repo.get_run(run.run_id) is None
+
+
+# ---------------------------------------------------------------------------
+# list_runs
+# ---------------------------------------------------------------------------
+
+
+class TestListRuns:
+    def test_list_empty(self, repo: MonitoringRunRepository) -> None:
+        assert repo.list_runs() == []
+
+    def test_list_orders_by_started_at_desc(
+        self, repo: MonitoringRunRepository
+    ) -> None:
+        for i, hour in enumerate([10, 12, 11]):
+            repo.record_run(
+                _make_run(
+                    run_id=f"run-{i:03d}",
+                    started_at=datetime(2024, 1, 1, hour, tzinfo=timezone.utc),
+                )
+            )
+        runs = repo.list_runs()
+        # Sorted DESC: 12, 11, 10
+        assert [r.run_id for r in runs] == ["run-001", "run-002", "run-000"]
+
+    def test_list_filter_by_subscription(self, repo: MonitoringRunRepository) -> None:
+        repo.record_run(_make_run(run_id="run-a", subscription_id="sub-x"))
+        repo.record_run(_make_run(run_id="run-b", subscription_id="sub-y"))
+        result = repo.list_runs(subscription_id="sub-x")
+        assert [r.run_id for r in result] == ["run-a"]
+
+    def test_list_respects_limit(self, repo: MonitoringRunRepository) -> None:
+        for i in range(5):
+            repo.record_run(
+                _make_run(
+                    run_id=f"run-{i:03d}",
+                    started_at=datetime(2024, 1, 1, i, tzinfo=timezone.utc),
+                )
+            )
+        result = repo.list_runs(limit=2)
+        assert len(result) == 2
+
+    def test_list_invalid_limit_raises(self, repo: MonitoringRunRepository) -> None:
+        with pytest.raises(ValueError, match="must be positive"):
+            repo.list_runs(limit=0)
+        with pytest.raises(ValueError, match="must be positive"):
+            repo.list_runs(limit=-1)
+
+
+# ---------------------------------------------------------------------------
+# Foreign Key CASCADE
+# ---------------------------------------------------------------------------
+
+
+class TestCascadeDelete:
+    def test_delete_run_cascades_to_papers(
+        self, repo: MonitoringRunRepository, db_path: Path
+    ) -> None:
+        records = [
+            _make_record(paper_id="2301.0001"),
+            _make_record(paper_id="2301.0002"),
+        ]
+        run = _make_run(papers_seen=2, papers_new=2, papers=records)
+        repo.record_run(run)
+        # Delete the parent through a direct SQL call -- the repository
+        # is append-only so it has no public delete method, but the FK
+        # CASCADE clause should still trigger.
+        from src.storage.intelligence_graph.connection import open_connection
+
+        with open_connection(db_path) as conn:
+            conn.execute(
+                "DELETE FROM monitoring_runs WHERE run_id = ?",
+                (run.run_id,),
+            )
+            conn.commit()
+            paper_count = conn.execute(
+                "SELECT COUNT(*) FROM monitoring_papers WHERE run_id = ?",
+                (run.run_id,),
+            ).fetchone()[0]
+        assert paper_count == 0

--- a/tests/unit/services/intelligence/monitoring/test_runner.py
+++ b/tests/unit/services/intelligence/monitoring/test_runner.py
@@ -1,0 +1,320 @@
+"""Tests for ``MonitoringRunner`` (Milestone 9.1).
+
+Covers:
+- ``run_once`` loads only active subscriptions (via SubscriptionManager).
+- ``run_once`` filters by ``user_id`` when provided.
+- ``run_once`` returns the runs in subscription order (success + failure).
+- ``mark_checked`` is called only on non-FAILED runs.
+- Each run is persisted via ``MonitoringRunRepository.record_run``.
+- A failure on one subscription does not abort the cycle (continues).
+- Defensive envelope: an unexpected exception from
+  ``ArxivMonitor.check`` is converted into a FAILED run, persisted,
+  and does NOT trigger ``mark_checked``.
+- Persistence (record_run) errors are logged but don't break the cycle
+  -- the in-memory run is still returned.
+- ``mark_checked`` errors are logged but don't break the cycle.
+- Empty active list returns ``[]`` and does not touch monitor / repo.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.services.intelligence.monitoring.arxiv_monitor import ArxivMonitorResult
+from src.services.intelligence.monitoring.models import (
+    MonitoringRun,
+    MonitoringRunStatus,
+    ResearchSubscription,
+    SubscriptionStatus,
+)
+from src.services.intelligence.monitoring.runner import MonitoringRunner
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_subscription(
+    *,
+    subscription_id: str = "sub-aaa",
+    user_id: str = "alice",
+    status: SubscriptionStatus = SubscriptionStatus.ACTIVE,
+) -> ResearchSubscription:
+    return ResearchSubscription(
+        subscription_id=subscription_id,
+        user_id=user_id,
+        name="Sub",
+        query="tree of thoughts",
+        status=status,
+    )
+
+
+def _make_run(
+    *,
+    subscription_id: str = "sub-aaa",
+    status: MonitoringRunStatus = MonitoringRunStatus.SUCCESS,
+    error: str | None = None,
+) -> MonitoringRun:
+    return MonitoringRun(
+        subscription_id=subscription_id,
+        status=status,
+        error=error,
+    )
+
+
+def _build_runner(
+    *,
+    subscriptions: list[ResearchSubscription] | None = None,
+    check_results: list[ArxivMonitorResult | Exception] | None = None,
+    record_side_effect: Exception | None = None,
+    mark_side_effect: Exception | None = None,
+) -> tuple[MonitoringRunner, MagicMock, MagicMock, MagicMock]:
+    sub_mgr = MagicMock()
+    sub_mgr.list_subscriptions = MagicMock(return_value=subscriptions or [])
+    if mark_side_effect is not None:
+        sub_mgr.mark_checked = MagicMock(side_effect=mark_side_effect)
+    else:
+        sub_mgr.mark_checked = MagicMock()
+
+    monitor = MagicMock()
+    if check_results is None:
+        monitor.check = AsyncMock()
+    else:
+        # Convert results to per-call side_effect (exceptions raised,
+        # ArxivMonitorResults returned).
+        async def check_fn(_sub: ResearchSubscription) -> ArxivMonitorResult:
+            assert check_results is not None  # narrow for mypy
+            outcome = check_results.pop(0)
+            if isinstance(outcome, Exception):
+                raise outcome
+            return outcome
+
+        monitor.check = AsyncMock(side_effect=check_fn)
+
+    repo = MagicMock()
+    if record_side_effect is not None:
+        repo.record_run = MagicMock(side_effect=record_side_effect)
+    else:
+        repo.record_run = MagicMock()
+
+    runner = MonitoringRunner(
+        subscription_manager=sub_mgr,
+        monitor=monitor,
+        run_repo=repo,
+    )
+    return runner, sub_mgr, monitor, repo
+
+
+def _result_for(
+    sub: ResearchSubscription,
+    **run_kwargs: object,
+) -> ArxivMonitorResult:
+    """Build an ArxivMonitorResult whose run targets ``sub``."""
+    run = _make_run(
+        subscription_id=sub.subscription_id,
+        **run_kwargs,  # type: ignore[arg-type]
+    )
+    return ArxivMonitorResult(run=run, new_papers=[], deduplicated_papers=[])
+
+
+# ---------------------------------------------------------------------------
+# Empty input
+# ---------------------------------------------------------------------------
+
+
+class TestEmpty:
+    @pytest.mark.asyncio
+    async def test_no_active_subs_returns_empty_list(self) -> None:
+        runner, sub_mgr, monitor, repo = _build_runner(subscriptions=[])
+        result = await runner.run_once()
+        assert result == []
+        sub_mgr.list_subscriptions.assert_called_once_with(
+            user_id=None, active_only=True
+        )
+        monitor.check.assert_not_awaited()
+        repo.record_run.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# user_id filter
+# ---------------------------------------------------------------------------
+
+
+class TestUserIdFilter:
+    @pytest.mark.asyncio
+    async def test_filter_by_user_passed_through(self) -> None:
+        runner, sub_mgr, _, _ = _build_runner(subscriptions=[])
+        await runner.run_once(user_id="alice")
+        sub_mgr.list_subscriptions.assert_called_once_with(
+            user_id="alice", active_only=True
+        )
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    @pytest.mark.asyncio
+    async def test_returns_runs_in_subscription_order(self) -> None:
+        sub_a = _make_subscription(subscription_id="sub-a")
+        sub_b = _make_subscription(subscription_id="sub-b")
+        runner, _, monitor, repo = _build_runner(
+            subscriptions=[sub_a, sub_b],
+            check_results=[
+                _result_for(sub_a),
+                _result_for(sub_b),
+            ],
+        )
+        runs = await runner.run_once()
+        assert [r.subscription_id for r in runs] == ["sub-a", "sub-b"]
+        assert monitor.check.await_count == 2
+        # Both runs are persisted.
+        assert repo.record_run.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_record_run_receives_owning_user_id(self) -> None:
+        sub = _make_subscription(subscription_id="sub-a", user_id="alice")
+        runner, _, _, repo = _build_runner(
+            subscriptions=[sub],
+            check_results=[_result_for(sub)],
+        )
+        await runner.run_once()
+        repo.record_run.assert_called_once()
+        kwargs = repo.record_run.call_args.kwargs
+        assert kwargs["user_id"] == "alice"
+
+    @pytest.mark.asyncio
+    async def test_mark_checked_on_success(self) -> None:
+        sub = _make_subscription(subscription_id="sub-a")
+        runner, sub_mgr, _, _ = _build_runner(
+            subscriptions=[sub],
+            check_results=[_result_for(sub)],
+        )
+        await runner.run_once()
+        sub_mgr.mark_checked.assert_called_once_with("sub-a")
+
+    @pytest.mark.asyncio
+    async def test_mark_checked_on_partial(self) -> None:
+        sub = _make_subscription(subscription_id="sub-a")
+        runner, sub_mgr, _, _ = _build_runner(
+            subscriptions=[sub],
+            check_results=[
+                _result_for(sub, status=MonitoringRunStatus.PARTIAL),
+            ],
+        )
+        await runner.run_once()
+        sub_mgr.mark_checked.assert_called_once_with("sub-a")
+
+    @pytest.mark.asyncio
+    async def test_mark_checked_skipped_on_failed(self) -> None:
+        sub = _make_subscription(subscription_id="sub-a")
+        runner, sub_mgr, _, _ = _build_runner(
+            subscriptions=[sub],
+            check_results=[
+                _result_for(sub, status=MonitoringRunStatus.FAILED),
+            ],
+        )
+        await runner.run_once()
+        sub_mgr.mark_checked.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Per-subscription failure does not abort cycle
+# ---------------------------------------------------------------------------
+
+
+class TestFailureContinuation:
+    @pytest.mark.asyncio
+    async def test_one_failure_does_not_break_the_cycle(self) -> None:
+        sub_a = _make_subscription(subscription_id="sub-a")
+        sub_b = _make_subscription(subscription_id="sub-b")
+        sub_c = _make_subscription(subscription_id="sub-c")
+        runner, sub_mgr, _, repo = _build_runner(
+            subscriptions=[sub_a, sub_b, sub_c],
+            check_results=[
+                _result_for(sub_a),
+                _result_for(sub_b, status=MonitoringRunStatus.FAILED, error="x"),
+                _result_for(sub_c),
+            ],
+        )
+        runs = await runner.run_once()
+        assert [r.subscription_id for r in runs] == ["sub-a", "sub-b", "sub-c"]
+        # All three persisted.
+        assert repo.record_run.call_count == 3
+        # mark_checked called only for sub-a and sub-c.
+        called = [c.args[0] for c in sub_mgr.mark_checked.call_args_list]
+        assert called == ["sub-a", "sub-c"]
+
+    @pytest.mark.asyncio
+    async def test_unexpected_check_exception_envelope(self) -> None:
+        """If ``ArxivMonitor.check`` raises (it's documented not to,
+        but a future bug or a different monitor might), the runner
+        wraps the failure in a FAILED MonitoringRun and continues.
+        """
+        sub_a = _make_subscription(subscription_id="sub-a")
+        sub_b = _make_subscription(subscription_id="sub-b")
+        runner, sub_mgr, _, repo = _build_runner(
+            subscriptions=[sub_a, sub_b],
+            check_results=[
+                RuntimeError("kaboom"),
+                _result_for(sub_b),
+            ],
+        )
+        runs = await runner.run_once()
+        assert len(runs) == 2
+        assert runs[0].subscription_id == "sub-a"
+        assert runs[0].status is MonitoringRunStatus.FAILED
+        assert runs[0].error is not None
+        assert "monitor_check_error" in runs[0].error
+        assert "kaboom" in runs[0].error
+        # The second sub still ran.
+        assert runs[1].subscription_id == "sub-b"
+        # Both persisted.
+        assert repo.record_run.call_count == 2
+        # mark_checked called only on the successful one.
+        called = [c.args[0] for c in sub_mgr.mark_checked.call_args_list]
+        assert called == ["sub-b"]
+
+
+# ---------------------------------------------------------------------------
+# Persistence / mark_checked failure handling
+# ---------------------------------------------------------------------------
+
+
+class TestPersistenceFailures:
+    @pytest.mark.asyncio
+    async def test_record_run_failure_does_not_abort_cycle(self) -> None:
+        sub_a = _make_subscription(subscription_id="sub-a")
+        sub_b = _make_subscription(subscription_id="sub-b")
+        runner, _, _, _ = _build_runner(
+            subscriptions=[sub_a, sub_b],
+            check_results=[
+                _result_for(sub_a),
+                _result_for(sub_b),
+            ],
+            record_side_effect=RuntimeError("disk full"),
+        )
+        runs = await runner.run_once()
+        # Both runs returned to caller for observability even though
+        # persistence blew up.
+        assert len(runs) == 2
+
+    @pytest.mark.asyncio
+    async def test_mark_checked_failure_does_not_abort_cycle(self) -> None:
+        sub_a = _make_subscription(subscription_id="sub-a")
+        sub_b = _make_subscription(subscription_id="sub-b")
+        runner, _, _, _ = _build_runner(
+            subscriptions=[sub_a, sub_b],
+            check_results=[
+                _result_for(sub_a),
+                _result_for(sub_b),
+            ],
+            mark_side_effect=KeyError("vanished"),
+        )
+        runs = await runner.run_once()
+        assert len(runs) == 2
+        assert all(r.status is not MonitoringRunStatus.FAILED for r in runs)

--- a/tests/unit/storage/intelligence_graph/test_connection.py
+++ b/tests/unit/storage/intelligence_graph/test_connection.py
@@ -1,0 +1,99 @@
+"""Tests for the shared SQLite connection helper.
+
+Covers:
+- All four PRAGMAs are applied (foreign_keys, journal_mode,
+  synchronous, busy_timeout).
+- ``row_factory`` is set so callers can index by name.
+- The connection is closed when the ``with`` block exits normally.
+- The connection is closed even if the body raises.
+- ``OperationalError`` is raised when ``db_path`` cannot be opened.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from src.storage.intelligence_graph.connection import open_connection
+
+
+@pytest.fixture
+def db_path() -> Path:
+    """Return a temp path under the system temp dir."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        path = Path(f.name)
+    path.unlink(missing_ok=True)
+    return path
+
+
+def _pragma(conn: sqlite3.Connection, name: str) -> object:
+    """Read back a PRAGMA value (returns the first column of the row)."""
+    cursor = conn.execute(f"PRAGMA {name}")
+    row = cursor.fetchone()
+    # row is a sqlite3.Row; the actual value is at index 0.
+    return row[0] if row is not None else None
+
+
+class TestPragmas:
+    def test_foreign_keys_enabled(self, db_path: Path) -> None:
+        with open_connection(db_path) as conn:
+            assert _pragma(conn, "foreign_keys") == 1
+
+    def test_journal_mode_wal(self, db_path: Path) -> None:
+        with open_connection(db_path) as conn:
+            value = _pragma(conn, "journal_mode")
+            assert isinstance(value, str)
+            assert value.lower() == "wal"
+
+    def test_synchronous_normal(self, db_path: Path) -> None:
+        with open_connection(db_path) as conn:
+            # NORMAL == 1 in SQLite's PRAGMA values
+            assert _pragma(conn, "synchronous") == 1
+
+    def test_busy_timeout_5000(self, db_path: Path) -> None:
+        with open_connection(db_path) as conn:
+            assert _pragma(conn, "busy_timeout") == 5000
+
+    def test_row_factory_named_access(self, db_path: Path) -> None:
+        with open_connection(db_path) as conn:
+            conn.execute("CREATE TABLE t (a INTEGER, b TEXT)")
+            conn.execute("INSERT INTO t (a, b) VALUES (?, ?)", (1, "hello"))
+            row = conn.execute("SELECT a, b FROM t").fetchone()
+        # row_factory=sqlite3.Row supports both index AND name access.
+        assert row["a"] == 1
+        assert row["b"] == "hello"
+
+
+class TestLifecycle:
+    def test_connection_closed_on_normal_exit(self, db_path: Path) -> None:
+        with open_connection(db_path) as conn:
+            captured = conn
+        # After exit, operations on the connection raise ProgrammingError
+        # because the connection is closed.
+        with pytest.raises(sqlite3.ProgrammingError):
+            captured.execute("SELECT 1")
+
+    def test_connection_closed_on_exception(self, db_path: Path) -> None:
+        captured: sqlite3.Connection | None = None
+
+        with pytest.raises(RuntimeError, match="boom"):
+            with open_connection(db_path) as conn:
+                captured = conn
+                raise RuntimeError("boom")
+
+        assert captured is not None
+        with pytest.raises(sqlite3.ProgrammingError):
+            captured.execute("SELECT 1")
+
+
+class TestErrorPaths:
+    def test_invalid_path_raises_operational_error(self, tmp_path: Path) -> None:
+        # A path whose parent directory does not exist cannot be opened.
+        # ``sqlite3.connect`` surfaces this as ``OperationalError``.
+        bad_path = tmp_path / "does" / "not" / "exist" / "x.db"
+        with pytest.raises(sqlite3.OperationalError):
+            with open_connection(bad_path):
+                pass  # pragma: no cover (helper raises before yielding)


### PR DESCRIPTION
## Summary

Lands the three architectural seams identified in #114 so that Week 2 monitoring work (issue #117 -- the APScheduler ``MonitoringCheckJob``) can drop in cleanly.

- **``MonitoringRunner``** (``src/services/intelligence/monitoring/runner.py``): single async ``run_once(user_id=None)`` facade that wires ``SubscriptionManager`` + ``ArxivMonitor`` + ``MonitoringRunRepository``. Per-subscription failures don't abort the cycle; ``mark_checked`` is called only on non-FAILED runs; persistence/mark errors are logged but don't propagate.
- **``MonitoringRunRepository`` + ``MIGRATION_V2_MONITORING_RUNS``** (``src/services/intelligence/monitoring/run_repository.py``, ``src/storage/intelligence_graph/migrations.py``): standalone append-only audit store backed by two new tables (``monitoring_runs``, ``monitoring_papers`` with ``ON DELETE CASCADE``) and an index on ``(subscription_id, started_at DESC)`` for the "recent runs for sub" query. Chosen over extending ``SubscriptionManager`` to keep configuration vs. audit-log lifecycles separated (SRP).
- **``open_connection`` helper** (``src/storage/intelligence_graph/connection.py``): single source of truth for the four intelligence-graph PRAGMAs (``foreign_keys=ON``, ``journal_mode=WAL``, ``synchronous=NORMAL``, ``busy_timeout=5000``) with guaranteed close-on-exit. ``SubscriptionManager._connect`` and ``MonitoringRunRepository._connect`` both delegate to it. The three older intelligence-graph stores (``unified_graph``, ``time_series``, ``migrations``) carry ``# TODO(phase-10)`` comments tracking their consolidation onto this helper -- their connection lifecycle patterns are different enough to deserve a separate refactor pass.

## Acceptance criteria (#114)

- [x] ``MonitoringRunner.run_once()`` orchestrates one cycle, returns ``list[MonitoringRun]``, swallows per-sub failures, calls ``mark_checked`` only on success/partial.
- [x] ``MonitoringRunRepository`` provides ``record_run`` / ``list_runs`` / ``get_run`` over the new tables.
- [x] ``MIGRATION_V2_MONITORING_RUNS`` adds ``monitoring_runs`` + ``monitoring_papers`` with FK CASCADE and the ``(subscription_id, started_at DESC)`` index.
- [x] ``open_connection`` context manager owns the PRAGMA set; ``SubscriptionManager._connect`` refactored to delegate.
- [x] Exports added to ``monitoring/__init__.py`` (``MonitoringRunner``, ``MonitoringRunRepository``) and ``intelligence_graph/__init__.py`` (``open_connection``).
- [x] No changes to issue #117 scope (no JobClass added).
- [x] ≥99% combined line + branch coverage maintained; new modules at 100%.

## Commits

1. ``e11dcfd`` -- feat(phase-9.1): add IntelligenceGraphConnection helper
2. ``98e54bb`` -- feat(phase-9.1): add MonitoringRunRepository + MIGRATION_V2
3. ``7d21140`` -- feat(phase-9.1): add MonitoringRunner facade

## Verify

``./verify.sh`` clean: **4498 passed, 99.24% combined coverage**. New modules at 100%:

- ``src/storage/intelligence_graph/connection.py`` -- 16 stmts, 100%
- ``src/services/intelligence/monitoring/run_repository.py`` -- 84 stmts, 100%
- ``src/services/intelligence/monitoring/runner.py`` -- 41 stmts, 100%

## Test plan

- [x] Unit tests for connection (PRAGMAs, lifecycle, error paths) -- 8 cases
- [x] Unit tests for run_repository (round-trip, list, FK CASCADE, atomicity, path safety) -- 25 cases
- [x] Unit tests for runner (orchestration, failure handling, mark_checked semantics, persistence error tolerance) -- 11 cases
- [x] No regressions in existing monitoring / intelligence_graph tests
- [x] Full ``./verify.sh`` passes (Black, Flake8, Mypy, pragma audit, pytest with branch coverage)

Closes #114