### PR TITLE
feat(phase-9.2): Week 1.5 — OpenAlex client + graph builder (closes #113)

### DIFF
--- a/src/services/intelligence/citation/__init__.py
+++ b/src/services/intelligence/citation/__init__.py
@@ -1,20 +1,21 @@
-"""Milestone 9.2: Citation Graph Intelligence (Week 1 surface).
+"""Milestone 9.2: Citation Graph Intelligence (Week 1 + 1.5 surface).
 
 This package builds and persists citation graphs from external APIs
 (Semantic Scholar primary, OpenAlex fallback) using the Phase 9
-``GraphStore`` for storage. Week 1 delivers depth=1 graph construction;
-BFS crawler, coupling analyzer, influence scorer, and recommender are
-deferred to follow-up PRs (Weeks 2-3).
+``GraphStore`` for storage. Week 1 + 1.5 deliver depth=1 graph
+construction; BFS crawler, coupling analyzer, influence scorer, and
+recommender are deferred to follow-up PRs (Weeks 2-3).
 
-Public surface (Week 1 PR — descoped):
+Public surface:
 
 - :class:`CitationNode` / :class:`CitationEdge` — domain models that
   layer over the shared ``GraphNode`` / ``GraphEdge`` kernel.
 - :class:`CitationDirection` — small enum for traversal direction.
 - :class:`SemanticScholarCitationClient` — primary citation source.
+- :class:`OpenAlexCitationClient` — fallback citation source with
+  polite-pool email convention.
 
-Deferred to Week 1.5 follow-up PR (small, focused):
-- ``OpenAlexCitationClient`` (fallback with polite-pool email)
+Deferred to the graph-builder follow-up commit in this same PR:
 - ``CitationGraphBuilder`` (composes clients + persists via
   ``GraphStore.add_nodes_batch`` / ``add_edges_batch``)
 
@@ -37,6 +38,9 @@ from src.services.intelligence.citation.models import (
     make_citation_edge_id,
     make_paper_node_id,
 )
+from src.services.intelligence.citation.openalex_client import (
+    OpenAlexCitationClient,
+)
 from src.services.intelligence.citation.semantic_scholar_client import (
     SemanticScholarCitationClient,
 )
@@ -50,4 +54,5 @@ __all__ = [
     "make_paper_node_id",
     # Clients
     "SemanticScholarCitationClient",
+    "OpenAlexCitationClient",
 ]

--- a/src/services/intelligence/citation/__init__.py
+++ b/src/services/intelligence/citation/__init__.py
@@ -31,8 +31,10 @@ adapter on top — both add coupling without saving meaningful code.
 """
 
 from src.services.intelligence.citation.graph_builder import (
+    BuildForPaperRequest,
     CitationGraphBuilder,
     GraphBuildResult,
+    ProviderTag,
 )
 from src.services.intelligence.citation.models import (
     CitationDirection,
@@ -61,4 +63,6 @@ __all__ = [
     # Builder
     "CitationGraphBuilder",
     "GraphBuildResult",
+    "ProviderTag",
+    "BuildForPaperRequest",
 ]

--- a/src/services/intelligence/citation/__init__.py
+++ b/src/services/intelligence/citation/__init__.py
@@ -14,10 +14,9 @@ Public surface:
 - :class:`SemanticScholarCitationClient` — primary citation source.
 - :class:`OpenAlexCitationClient` — fallback citation source with
   polite-pool email convention.
-
-Deferred to the graph-builder follow-up commit in this same PR:
-- ``CitationGraphBuilder`` (composes clients + persists via
-  ``GraphStore.add_nodes_batch`` / ``add_edges_batch``)
+- :class:`CitationGraphBuilder` / :class:`GraphBuildResult` — composes
+  the two clients and persists via ``GraphStore.add_nodes_batch`` /
+  ``add_edges_batch`` (depth=1 only; BFS crawl is Week 2).
 
 Architecture choice (recorded for downstream milestones):
 We deliberately built **dedicated citation clients alongside** the
@@ -31,6 +30,10 @@ Wrapping them would require either widening the ABC or layering an
 adapter on top — both add coupling without saving meaningful code.
 """
 
+from src.services.intelligence.citation.graph_builder import (
+    CitationGraphBuilder,
+    GraphBuildResult,
+)
 from src.services.intelligence.citation.models import (
     CitationDirection,
     CitationEdge,
@@ -55,4 +58,7 @@ __all__ = [
     # Clients
     "SemanticScholarCitationClient",
     "OpenAlexCitationClient",
+    # Builder
+    "CitationGraphBuilder",
+    "GraphBuildResult",
 ]

--- a/src/services/intelligence/citation/graph_builder.py
+++ b/src/services/intelligence/citation/graph_builder.py
@@ -46,7 +46,12 @@ from src.services.intelligence.citation.openalex_client import (
 from src.services.intelligence.citation.semantic_scholar_client import (
     SemanticScholarCitationClient,
 )
-from src.services.intelligence.models import GraphEdge, GraphNode, GraphStoreError
+from src.services.intelligence.models import (
+    GraphEdge,
+    GraphNode,
+    GraphStoreDuplicateError,
+    GraphStoreError,
+)
 from src.services.providers.base import APIError
 from src.storage.intelligence_graph import GraphStore
 
@@ -382,8 +387,11 @@ class CitationGraphBuilder:
 
         The recovery path exists so a re-run for the same seed (where
         the seed node already exists) does not fail the whole call.
-        Per-row inserts swallow ``GraphStoreError("Node already exists")``
-        and report any other failure into ``errors``.
+        Per-row inserts swallow :class:`GraphStoreDuplicateError` (typed
+        UNIQUE-constraint signal — see #S5) and report any other failure
+        into ``errors``. We deliberately avoid substring-matching on the
+        message text: SQLite's wording is not a stable contract and a
+        rephrase upstream would silently break this loop.
         """
         if not nodes:
             return 0
@@ -401,12 +409,11 @@ class CitationGraphBuilder:
                 try:
                     self.store.add_node(node.node_id, node.node_type, node.properties)
                     inserted += 1
+                except GraphStoreDuplicateError:
+                    # Idempotent re-run — typed signal, not an error.
+                    continue
                 except GraphStoreError as inner_exc:
-                    msg = str(inner_exc)
-                    if "already exists" in msg:
-                        # Idempotent re-run — not an error.
-                        continue
-                    errors.append(f"node {node.node_id}: {msg}")
+                    errors.append(f"node {node.node_id}: {inner_exc}")
             return inserted
 
     def _bulk_insert_edges(self, edges: list[GraphEdge], errors: list[str]) -> int:
@@ -433,9 +440,8 @@ class CitationGraphBuilder:
                         edge.properties,
                     )
                     inserted += 1
+                except GraphStoreDuplicateError:
+                    continue
                 except GraphStoreError as inner_exc:
-                    msg = str(inner_exc)
-                    if "already exists" in msg:
-                        continue
-                    errors.append(f"edge {edge.edge_id}: {msg}")
+                    errors.append(f"edge {edge.edge_id}: {inner_exc}")
             return inserted

--- a/src/services/intelligence/citation/graph_builder.py
+++ b/src/services/intelligence/citation/graph_builder.py
@@ -1,0 +1,441 @@
+"""Citation graph builder (Milestone 9.2 — Week 1.5).
+
+Composes :class:`SemanticScholarCitationClient` (primary) and
+:class:`OpenAlexCitationClient` (fallback) and persists the resulting
+nodes/edges via the :class:`GraphStore` Protocol from
+``src.storage.intelligence_graph``. The builder is best-effort and
+storage-engine-agnostic — it never imports ``sqlite3`` or any other
+backend module, so swapping in a Neo4j store later is a constructor
+change.
+
+Scope of this PR (REQ-9.2.1, descoped Week 1.5):
+- ``depth=1`` only. The BFS crawler that walks beyond direct neighbors
+  is a separate Week-2 deliverable.
+- Two persistence calls per ``build_for_paper``: one
+  :meth:`GraphStore.add_nodes_batch`, one
+  :meth:`GraphStore.add_edges_batch`. Per-row inserts are explicitly
+  *not* used — the bulk APIs from PR #105 give us atomic rollback on
+  any constraint violation, which is what the spec requires.
+- Idempotent: edge ids are SHA-256-hashed (post PR #107 round 1) so
+  re-running ``build_for_paper`` for the same seed at depth=1 is safe;
+  duplicate-edge inserts are detected by the unique constraint and
+  retried via per-edge insert as a recovery path.
+- Provider strategy: try S2 first; if S2 returns *empty results* OR
+  raises ``APIError`` / ``RateLimitError``, fall back to OpenAlex. The
+  builder swallows provider errors and reports them via
+  ``GraphBuildResult.errors`` rather than propagating, because callers
+  will frequently process many seeds at once and one bad paper must
+  not abort the batch.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+import structlog
+
+from src.services.intelligence.citation.models import (
+    CitationDirection,
+    CitationEdge,
+    CitationNode,
+)
+from src.services.intelligence.citation.openalex_client import (
+    OpenAlexCitationClient,
+)
+from src.services.intelligence.citation.semantic_scholar_client import (
+    SemanticScholarCitationClient,
+)
+from src.services.intelligence.models import GraphEdge, GraphNode, GraphStoreError
+from src.services.providers.base import APIError
+from src.storage.intelligence_graph import GraphStore
+
+logger = structlog.get_logger(__name__)
+
+
+# Sentinel so callers can distinguish "we didn't try this provider" from
+# "this provider returned no edges". Used inside ``GraphBuildResult``.
+_PROVIDER_NONE = "none"
+_PROVIDER_S2 = "s2"
+_PROVIDER_OPENALEX = "openalex"
+_PROVIDER_BOTH = "both"
+
+
+@dataclass(frozen=True)
+class GraphBuildResult:
+    """Outcome of one :meth:`CitationGraphBuilder.build_for_paper` call.
+
+    Attributes:
+        seed_paper_id: The paper id passed to ``build_for_paper`` (raw,
+            before any provider-specific normalization).
+        nodes_added: Count of nodes inserted into the graph store. Note
+            this counts *attempts*, not unique rows — duplicates from a
+            re-run still count here because the bulk insert was issued.
+        edges_added: Count of edges inserted into the graph store, with
+            the same caveat as ``nodes_added``.
+        provider_used: Which provider supplied the data.
+            One of ``"s2"``, ``"openalex"``, ``"both"`` (when direction
+            ``BOTH`` got a mixed answer), or ``"none"`` when neither
+            provider returned anything.
+        errors: Human-readable error messages collected during the call.
+            Empty on success. Populated when a provider failed but the
+            builder kept going (e.g. S2 errored → fell back to
+            OpenAlex), or when both providers failed.
+    """
+
+    seed_paper_id: str
+    nodes_added: int
+    edges_added: int
+    provider_used: str
+    errors: list[str] = field(default_factory=list)
+
+
+class CitationGraphBuilder:
+    """Compose citation clients and persist results into a ``GraphStore``.
+
+    The builder is constructed with a single :class:`GraphStore`
+    instance and one client per provider. Both clients are required so
+    the fallback path is always available — pass them explicitly so
+    tests can inject mocks and so callers stay in control of API keys
+    / polite-pool emails.
+    """
+
+    def __init__(
+        self,
+        store: GraphStore,
+        s2_client: SemanticScholarCitationClient,
+        openalex_client: OpenAlexCitationClient,
+    ) -> None:
+        self.store = store
+        self.s2_client = s2_client
+        self.openalex_client = openalex_client
+
+    async def build_for_paper(
+        self,
+        paper_id: str,
+        depth: int = 1,
+        direction: CitationDirection = CitationDirection.OUT,
+        max_results: int = 200,
+    ) -> GraphBuildResult:
+        """Fetch and persist the depth-1 citation graph around a seed.
+
+        Args:
+            paper_id: Provider-recognized paper id. For S2 this can be
+                the S2 native id, a DOI, or an arxiv id; for OpenAlex
+                this should be the OpenAlex work id (``W123…``) — but
+                the fallback only triggers if S2 fails, so callers
+                normally pass the S2-friendly form and rely on the
+                primary path.
+            depth: Currently must be ``1``. Higher values raise
+                ``ValueError`` — BFS crawl is the Week-2 follow-up.
+            direction: ``OUT`` for references, ``IN`` for citations,
+                ``BOTH`` for both directions (one round-trip per side).
+            max_results: Per-direction cap on returned rows. Defaults
+                to 200 to match both clients' built-in cap.
+
+        Returns:
+            A :class:`GraphBuildResult` describing what was persisted
+            and which provider supplied the data.
+        """
+        if depth != 1:
+            # Hard fail for now; once the BFS crawler lands the
+            # builder will recurse instead of refusing.
+            raise ValueError(
+                f"build_for_paper currently supports depth=1 only "
+                f"(got depth={depth})"
+            )
+        if not paper_id or not paper_id.strip():
+            raise ValueError("paper_id must be a non-empty string")
+        if max_results < 1:
+            raise ValueError("max_results must be >= 1")
+
+        errors: list[str] = []
+
+        seeds: list[CitationNode] = []
+        related_lists: list[list[CitationNode]] = []
+        edge_lists: list[list[CitationEdge]] = []
+
+        if direction == CitationDirection.BOTH:
+            # Two provider-strategy passes — one per direction. Each
+            # pass independently chooses S2-then-OpenAlex.
+            out_seed, out_related, out_edges, out_provider, out_errors = (
+                await self._fetch_with_fallback(
+                    paper_id, CitationDirection.OUT, max_results
+                )
+            )
+            in_seed, in_related, in_edges, in_provider, in_errors = (
+                await self._fetch_with_fallback(
+                    paper_id, CitationDirection.IN, max_results
+                )
+            )
+            errors.extend(out_errors)
+            errors.extend(in_errors)
+
+            # Both seeds are persisted — they may differ when one
+            # direction had to fall back to OpenAlex (which produces a
+            # paper:openalex:Wxxx id) while the other succeeded via S2
+            # (paper:s2:xxx). Without both, the IN edges would be
+            # orphans referencing a missing target node.
+            if out_seed is not None:
+                seeds.append(out_seed)
+                related_lists.append(out_related)
+                edge_lists.append(out_edges)
+            if in_seed is not None:
+                seeds.append(in_seed)
+                related_lists.append(in_related)
+                edge_lists.append(in_edges)
+            provider_used = self._combine_providers(out_provider, in_provider)
+        else:
+            seed, related, edges, provider_used, dir_errors = (
+                await self._fetch_with_fallback(paper_id, direction, max_results)
+            )
+            errors.extend(dir_errors)
+            if seed is not None:
+                seeds.append(seed)
+                related_lists.append(related)
+                edge_lists.append(edges)
+
+        if not seeds:
+            # No provider succeeded — nothing to persist.
+            logger.warning(
+                "citation_graph_build_no_data",
+                seed_paper_id=paper_id,
+                errors=errors,
+            )
+            return GraphBuildResult(
+                seed_paper_id=paper_id,
+                nodes_added=0,
+                edges_added=0,
+                provider_used=_PROVIDER_NONE,
+                errors=errors,
+            )
+
+        nodes_added, edges_added, persist_errors = self._persist(
+            seeds, related_lists, edge_lists
+        )
+        errors.extend(persist_errors)
+
+        logger.info(
+            "citation_graph_built",
+            seed_paper_id=paper_id,
+            depth=depth,
+            direction=direction.value,
+            provider_used=provider_used,
+            nodes_added=nodes_added,
+            edges_added=edges_added,
+            error_count=len(errors),
+        )
+        return GraphBuildResult(
+            seed_paper_id=paper_id,
+            nodes_added=nodes_added,
+            edges_added=edges_added,
+            provider_used=provider_used,
+            errors=errors,
+        )
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    async def _fetch_with_fallback(
+        self,
+        paper_id: str,
+        direction: CitationDirection,
+        max_results: int,
+    ) -> tuple[
+        Optional[CitationNode],
+        list[CitationNode],
+        list[CitationEdge],
+        str,
+        list[str],
+    ]:
+        """Call S2 first, fall back to OpenAlex on empty / error.
+
+        Returns a 5-tuple ``(seed, related, edges, provider, errors)``.
+        ``seed`` is ``None`` only when both providers failed. When S2
+        returns successfully but with zero related rows we still treat
+        that as a success (the seed is real, the paper just has no
+        references / citations on file at S2) and do *not* fall back —
+        OpenAlex is unlikely to do better and would double the API
+        cost.
+        """
+        errors: list[str] = []
+
+        # Pass 1: Semantic Scholar.
+        try:
+            seed, related, edges = await self._call_provider(
+                self.s2_client, paper_id, direction, max_results
+            )
+        except APIError as exc:
+            # APIError covers both 404 and 5xx and RateLimitError. We
+            # log + record the error and fall through to OpenAlex.
+            logger.warning(
+                "citation_s2_failed",
+                seed_paper_id=paper_id,
+                direction=direction.value,
+                error=str(exc),
+            )
+            errors.append(f"s2: {exc}")
+            seed = None
+            related = []
+            edges = []
+
+        if seed is not None:
+            return seed, related, edges, _PROVIDER_S2, errors
+
+        # Pass 2: OpenAlex fallback.
+        try:
+            oa_seed, oa_related, oa_edges = await self._call_provider(
+                self.openalex_client, paper_id, direction, max_results
+            )
+            return oa_seed, oa_related, oa_edges, _PROVIDER_OPENALEX, errors
+        except APIError as exc:
+            logger.warning(
+                "citation_openalex_failed",
+                seed_paper_id=paper_id,
+                direction=direction.value,
+                error=str(exc),
+            )
+            errors.append(f"openalex: {exc}")
+            return None, [], [], _PROVIDER_NONE, errors
+
+    @staticmethod
+    async def _call_provider(
+        client: SemanticScholarCitationClient | OpenAlexCitationClient,
+        paper_id: str,
+        direction: CitationDirection,
+        max_results: int,
+    ) -> tuple[CitationNode, list[CitationNode], list[CitationEdge]]:
+        """Dispatch to the right method on the chosen client."""
+        if direction == CitationDirection.OUT:
+            return await client.get_references(paper_id, max_results=max_results)
+        # ``CitationDirection.BOTH`` is split apart in ``build_for_paper``
+        # before we ever reach here, so the only remaining case is IN.
+        return await client.get_citations(paper_id, max_results=max_results)
+
+    @staticmethod
+    def _combine_providers(out_provider: str, in_provider: str) -> str:
+        """Reduce two per-direction provider tags to a single label.
+
+        The exact rules are:
+        - both ``none`` → ``none``
+        - one ``none``, the other set → use the other one (a single
+          direction succeeded)
+        - both the same non-``none`` value → that value
+        - mixed (e.g. ``s2`` + ``openalex``) → ``both``
+        """
+        providers = {p for p in (out_provider, in_provider) if p != _PROVIDER_NONE}
+        if not providers:
+            return _PROVIDER_NONE
+        if len(providers) == 1:
+            return providers.pop()
+        return _PROVIDER_BOTH
+
+    def _persist(
+        self,
+        seeds: list[CitationNode],
+        related_lists: list[list[CitationNode]],
+        edge_lists: list[list[CitationEdge]],
+    ) -> tuple[int, int, list[str]]:
+        """Bulk-insert nodes and edges; return (nodes, edges, errors).
+
+        Implementation notes:
+        - We deduplicate within the call so a single ``add_nodes_batch``
+          never sees the same ``node_id`` twice (that would always
+          violate the UNIQUE constraint and roll back the whole batch).
+          Cross-call duplicates — e.g. a re-run for the same seed — are
+          handled by the recovery path below.
+        - On a constraint violation (duplicate node_id / edge_id from a
+          previous call), the bulk insert is rolled back and we
+          fall back to per-row inserts that swallow duplicates so the
+          re-run remains idempotent. This is the price of using
+          ``add_*_batch`` for the happy path; the alternative would be
+          per-row inserts always, which the spec explicitly disallows.
+        - Multiple seeds appear when the BOTH direction had to fall
+          back to a different provider for one side; both seed nodes
+          are persisted so the IN-side edges aren't orphaned.
+        """
+        all_nodes: dict[str, GraphNode] = {}
+        for seed in seeds:
+            if seed.paper_id not in all_nodes:
+                all_nodes[seed.paper_id] = seed.to_graph_node()
+        for related in related_lists:
+            for node in related:
+                if node.paper_id not in all_nodes:
+                    all_nodes[node.paper_id] = node.to_graph_node()
+
+        all_edges: dict[str, GraphEdge] = {}
+        for edges in edge_lists:
+            for edge in edges:
+                graph_edge = edge.to_graph_edge()
+                # Last-writer wins for properties; ids collapse cleanly
+                # because the SHA-256 hash is deterministic per pair.
+                all_edges[graph_edge.edge_id] = graph_edge
+
+        errors: list[str] = []
+        nodes_added = self._bulk_insert_nodes(list(all_nodes.values()), errors)
+        edges_added = self._bulk_insert_edges(list(all_edges.values()), errors)
+        return nodes_added, edges_added, errors
+
+    def _bulk_insert_nodes(self, nodes: list[GraphNode], errors: list[str]) -> int:
+        """Try one ``add_nodes_batch``; recover with per-row inserts.
+
+        The recovery path exists so a re-run for the same seed (where
+        the seed node already exists) does not fail the whole call.
+        Per-row inserts swallow ``GraphStoreError("Node already exists")``
+        and report any other failure into ``errors``.
+        """
+        if not nodes:
+            return 0
+        try:
+            self.store.add_nodes_batch(nodes)
+            return len(nodes)
+        except GraphStoreError as exc:
+            logger.info(
+                "citation_node_batch_fallback_to_per_row",
+                count=len(nodes),
+                error=str(exc),
+            )
+            inserted = 0
+            for node in nodes:
+                try:
+                    self.store.add_node(node.node_id, node.node_type, node.properties)
+                    inserted += 1
+                except GraphStoreError as inner_exc:
+                    msg = str(inner_exc)
+                    if "already exists" in msg:
+                        # Idempotent re-run — not an error.
+                        continue
+                    errors.append(f"node {node.node_id}: {msg}")
+            return inserted
+
+    def _bulk_insert_edges(self, edges: list[GraphEdge], errors: list[str]) -> int:
+        """Same shape as :meth:`_bulk_insert_nodes` for edges."""
+        if not edges:
+            return 0
+        try:
+            self.store.add_edges_batch(edges)
+            return len(edges)
+        except GraphStoreError as exc:
+            logger.info(
+                "citation_edge_batch_fallback_to_per_row",
+                count=len(edges),
+                error=str(exc),
+            )
+            inserted = 0
+            for edge in edges:
+                try:
+                    self.store.add_edge(
+                        edge.edge_id,
+                        edge.source_id,
+                        edge.target_id,
+                        edge.edge_type,
+                        edge.properties,
+                    )
+                    inserted += 1
+                except GraphStoreError as inner_exc:
+                    msg = str(inner_exc)
+                    if "already exists" in msg:
+                        continue
+                    errors.append(f"edge {edge.edge_id}: {msg}")
+            return inserted

--- a/src/services/intelligence/citation/graph_builder.py
+++ b/src/services/intelligence/citation/graph_builder.py
@@ -31,9 +31,11 @@ Scope of this PR (REQ-9.2.1, descoped Week 1.5):
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import Optional
 
 import structlog
+from pydantic import BaseModel, ConfigDict, Field
 
 from src.services.intelligence.citation.models import (
     CitationDirection,
@@ -58,12 +60,65 @@ from src.storage.intelligence_graph import GraphStore
 logger = structlog.get_logger(__name__)
 
 
-# Sentinel so callers can distinguish "we didn't try this provider" from
-# "this provider returned no edges". Used inside ``GraphBuildResult``.
-_PROVIDER_NONE = "none"
-_PROVIDER_S2 = "s2"
-_PROVIDER_OPENALEX = "openalex"
-_PROVIDER_BOTH = "both"
+class ProviderTag(str, Enum):
+    """Typed label for which provider supplied a build's data (#S6).
+
+    Inherits from ``str`` so JSON serialisation (and existing string
+    comparisons in tests / log enrichment) keep working unchanged. The
+    enum gives mypy and exhaustive-switch consumers a real type instead
+    of a free-form string.
+    """
+
+    NONE = "none"
+    S2 = "s2"
+    OPENALEX = "openalex"
+    BOTH = "both"
+
+
+# Hard cap on the size of error messages we forward into ``errors[]``
+# and structlog records. Bounds memory, cuts log spend, and keeps a
+# misbehaving upstream from exploding our DB row size if errors land in
+# a persistence path later.
+_MAX_FORWARDED_ERROR_LENGTH = 200
+
+
+def _sanitize_error_msg(msg: str, max_len: int = _MAX_FORWARDED_ERROR_LENGTH) -> str:
+    """Strip CR/LF/control chars and cap length to prevent log injection.
+
+    A hostile upstream (or a buggy provider) could embed CRLF or other
+    control bytes inside an error message; if we forwarded that
+    verbatim into a log line or a structured ``errors[]`` field, the
+    bytes could split the log record (log injection) or smuggle ANSI
+    escape sequences into operator terminals. Replacing every
+    non-printable byte with ``?`` is a one-pass defense and keeps the
+    message human-readable for legitimate input (#N4).
+    """
+    cleaned = "".join(c if c.isprintable() else "?" for c in msg)
+    return cleaned[:max_len]
+
+
+class BuildForPaperRequest(BaseModel):
+    """Pydantic input model for ``CitationGraphBuilder.build_for_paper`` (#S9).
+
+    Defense-in-depth on the builder boundary: a future caller bypassing
+    the providers' own validation would otherwise reach URL
+    interpolation with whatever ``paper_id`` they pass. The Pydantic
+    model enforces a strict allow-list and length cap before any
+    provider call is issued.
+
+    The pattern (``[A-Za-z0-9:./_\\-]+``) intentionally allows the
+    punctuation needed for legitimate external id forms — DOIs
+    (``10.x/y``), arxiv ids (``arxiv:1706.03762``), and S2 / OpenAlex
+    native ids — while excluding URL/CRLF/path-traversal metacharacters.
+    """
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    paper_id: str = Field(min_length=1, max_length=256, pattern=r"^[A-Za-z0-9:./_\-]+$")
+    # depth>1 is the Week-2 BFS deliverable; ``ge=1, le=1`` keeps the
+    # surface honest until the crawler ships.
+    depth: int = Field(default=1, ge=1, le=1)
+    direction: CitationDirection = CitationDirection.OUT
 
 
 @dataclass(frozen=True)
@@ -78,20 +133,20 @@ class GraphBuildResult:
             re-run still count here because the bulk insert was issued.
         edges_added: Count of edges inserted into the graph store, with
             the same caveat as ``nodes_added``.
-        provider_used: Which provider supplied the data.
-            One of ``"s2"``, ``"openalex"``, ``"both"`` (when direction
-            ``BOTH`` got a mixed answer), or ``"none"`` when neither
-            provider returned anything.
-        errors: Human-readable error messages collected during the call.
-            Empty on success. Populated when a provider failed but the
-            builder kept going (e.g. S2 errored → fell back to
-            OpenAlex), or when both providers failed.
+        provider_used: Which provider supplied the data, as a
+            :class:`ProviderTag` enum (#S6). String comparison still
+            works because the enum inherits from ``str``.
+        errors: Sanitized human-readable error messages collected during
+            the call (see ``_sanitize_error_msg``). Empty on success.
+            Populated when a provider failed but the builder kept going
+            (e.g. S2 errored → fell back to OpenAlex), or when both
+            providers failed.
     """
 
     seed_paper_id: str
     nodes_added: int
     edges_added: int
-    provider_used: str
+    provider_used: ProviderTag
     errors: list[str] = field(default_factory=list)
 
 
@@ -130,9 +185,11 @@ class CitationGraphBuilder:
                 this should be the OpenAlex work id (``W123…``) — but
                 the fallback only triggers if S2 fails, so callers
                 normally pass the S2-friendly form and rely on the
-                primary path.
+                primary path. Validated against ``BuildForPaperRequest``
+                before any provider call (#S9).
             depth: Currently must be ``1``. Higher values raise
-                ``ValueError`` — BFS crawl is the Week-2 follow-up.
+                ``pydantic.ValidationError`` — BFS crawl is the Week-2
+                follow-up.
             direction: ``OUT`` for references, ``IN`` for citations,
                 ``BOTH`` for both directions (one round-trip per side).
             max_results: Per-direction cap on returned rows. Defaults
@@ -142,15 +199,15 @@ class CitationGraphBuilder:
             A :class:`GraphBuildResult` describing what was persisted
             and which provider supplied the data.
         """
-        if depth != 1:
-            # Hard fail for now; once the BFS crawler lands the
-            # builder will recurse instead of refusing.
-            raise ValueError(
-                f"build_for_paper currently supports depth=1 only "
-                f"(got depth={depth})"
-            )
-        if not paper_id or not paper_id.strip():
-            raise ValueError("paper_id must be a non-empty string")
+        # Defense-in-depth input validation (#S9). The Pydantic model
+        # rejects empty / oversized / regex-failing paper_ids and any
+        # depth > 1 BEFORE we ever reach a provider call.
+        request = BuildForPaperRequest(
+            paper_id=paper_id, depth=depth, direction=direction
+        )
+        paper_id = request.paper_id
+        depth = request.depth
+        direction = request.direction
         if max_results < 1:
             raise ValueError("max_results must be >= 1")
 
@@ -211,7 +268,7 @@ class CitationGraphBuilder:
                 seed_paper_id=paper_id,
                 nodes_added=0,
                 edges_added=0,
-                provider_used=_PROVIDER_NONE,
+                provider_used=ProviderTag.NONE,
                 errors=errors,
             )
 
@@ -251,7 +308,7 @@ class CitationGraphBuilder:
         Optional[CitationNode],
         list[CitationNode],
         list[CitationEdge],
-        str,
+        ProviderTag,
         list[str],
     ]:
         """Call S2 first, fall back to OpenAlex on empty / error.
@@ -263,6 +320,10 @@ class CitationGraphBuilder:
         references / citations on file at S2) and do *not* fall back —
         OpenAlex is unlikely to do better and would double the API
         cost.
+
+        Error messages forwarded into ``errors`` are sanitized via
+        :func:`_sanitize_error_msg` before being appended (#N4) so
+        upstream CRLF cannot inject log lines.
         """
         errors: list[str] = []
 
@@ -274,35 +335,37 @@ class CitationGraphBuilder:
         except APIError as exc:
             # APIError covers both 404 and 5xx and RateLimitError. We
             # log + record the error and fall through to OpenAlex.
+            sanitized = _sanitize_error_msg(str(exc))
             logger.warning(
                 "citation_s2_failed",
                 seed_paper_id=paper_id,
                 direction=direction.value,
-                error=str(exc),
+                error=sanitized,
             )
-            errors.append(f"s2: {exc}")
+            errors.append(_sanitize_error_msg(f"s2: {exc}"))
             seed = None
             related = []
             edges = []
 
         if seed is not None:
-            return seed, related, edges, _PROVIDER_S2, errors
+            return seed, related, edges, ProviderTag.S2, errors
 
         # Pass 2: OpenAlex fallback.
         try:
             oa_seed, oa_related, oa_edges = await self._call_provider(
                 self.openalex_client, paper_id, direction, max_results
             )
-            return oa_seed, oa_related, oa_edges, _PROVIDER_OPENALEX, errors
+            return oa_seed, oa_related, oa_edges, ProviderTag.OPENALEX, errors
         except APIError as exc:
+            sanitized = _sanitize_error_msg(str(exc))
             logger.warning(
                 "citation_openalex_failed",
                 seed_paper_id=paper_id,
                 direction=direction.value,
-                error=str(exc),
+                error=sanitized,
             )
-            errors.append(f"openalex: {exc}")
-            return None, [], [], _PROVIDER_NONE, errors
+            errors.append(_sanitize_error_msg(f"openalex: {exc}"))
+            return None, [], [], ProviderTag.NONE, errors
 
     @staticmethod
     async def _call_provider(
@@ -319,22 +382,24 @@ class CitationGraphBuilder:
         return await client.get_citations(paper_id, max_results=max_results)
 
     @staticmethod
-    def _combine_providers(out_provider: str, in_provider: str) -> str:
+    def _combine_providers(
+        out_provider: ProviderTag, in_provider: ProviderTag
+    ) -> ProviderTag:
         """Reduce two per-direction provider tags to a single label.
 
         The exact rules are:
-        - both ``none`` → ``none``
-        - one ``none``, the other set → use the other one (a single
+        - both ``NONE`` → ``NONE``
+        - one ``NONE``, the other set → use the other one (a single
           direction succeeded)
-        - both the same non-``none`` value → that value
-        - mixed (e.g. ``s2`` + ``openalex``) → ``both``
+        - both the same non-``NONE`` value → that value
+        - mixed (e.g. ``S2`` + ``OPENALEX``) → ``BOTH``
         """
-        providers = {p for p in (out_provider, in_provider) if p != _PROVIDER_NONE}
+        providers = {p for p in (out_provider, in_provider) if p != ProviderTag.NONE}
         if not providers:
-            return _PROVIDER_NONE
+            return ProviderTag.NONE
         if len(providers) == 1:
             return providers.pop()
-        return _PROVIDER_BOTH
+        return ProviderTag.BOTH
 
     def _persist(
         self,
@@ -413,7 +478,9 @@ class CitationGraphBuilder:
                     # Idempotent re-run — typed signal, not an error.
                     continue
                 except GraphStoreError as inner_exc:
-                    errors.append(f"node {node.node_id}: {inner_exc}")
+                    errors.append(
+                        _sanitize_error_msg(f"node {node.node_id}: {inner_exc}")
+                    )
             return inserted
 
     def _bulk_insert_edges(self, edges: list[GraphEdge], errors: list[str]) -> int:
@@ -443,5 +510,7 @@ class CitationGraphBuilder:
                 except GraphStoreDuplicateError:
                     continue
                 except GraphStoreError as inner_exc:
-                    errors.append(f"edge {edge.edge_id}: {inner_exc}")
+                    errors.append(
+                        _sanitize_error_msg(f"edge {edge.edge_id}: {inner_exc}")
+                    )
             return inserted

--- a/src/services/intelligence/citation/openalex_client.py
+++ b/src/services/intelligence/citation/openalex_client.py
@@ -1,0 +1,625 @@
+"""OpenAlex citation client (Milestone 9.2 — fallback source).
+
+This is **not** the existing ``OpenAlexProvider`` from
+``src.services.providers.openalex``; that one implements the
+``DiscoveryProvider`` ABC for keyword paper search and produces
+``PaperMetadata``. The citation graph needs different endpoints
+(``/works/{id}`` to read ``referenced_works``; ``/works?filter=cites:{id}``
+for incoming citations), a different response shape (``CitationNode`` /
+``CitationEdge``), and a 7-day disk cache per spec (Section 11.3). We
+deliberately built alongside the search provider — see the package
+docstring for the full rationale.
+
+Spec mapping:
+- REQ-9.2.1 (Citation Graph Construction): ``get_references`` and
+  ``get_citations`` produce :class:`CitationNode` / :class:`CitationEdge`
+  pairs ready for the graph builder to persist.
+- SR-9.1 (API Key Management): no API key is required by OpenAlex, but
+  the *polite-pool* email is read from ``OPENALEX_POLITE_EMAIL`` (env
+  var). It is never hardcoded; if missing we log a one-shot warning and
+  fall back to the slower anonymous pool.
+- SR-9.2 (Rate Limiting): OpenAlex's polite pool allows 100k req/day
+  (~70/min sustained); we cap at 60 req/min by default to leave
+  headroom for retry storms. The anonymous tier is throttled more
+  aggressively, so we drop to 20 req/min when no email is configured.
+- Cost optimization (Section 11.3): citation lookups are cached on
+  disk for 7 days (TTL configurable for tests).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any, Optional, cast
+
+import aiohttp
+import diskcache
+import structlog
+
+from src.services.intelligence.citation.models import (
+    CitationEdge,
+    CitationNode,
+    make_paper_node_id,
+)
+from src.services.providers.base import APIError, RateLimitError
+from src.utils.rate_limiter import RateLimiter
+
+logger = structlog.get_logger(__name__)
+
+
+# Spec-mandated cache TTL (Section 11.3): citation lookups are cached
+# for 7 days. Tests pass a much shorter TTL via constructor arg.
+_DEFAULT_CITATION_CACHE_TTL_SECONDS = 7 * 24 * 60 * 60
+
+# OpenAlex's documented per-page cap. We default to 200 below, matching
+# the spec's typical max_results, but smaller pages let us bail early
+# once the per-call cap is hit without wasting bandwidth.
+_OPENALEX_MAX_PER_PAGE = 200
+
+# Default per-call ceiling. Identical to the S2 client so the graph
+# builder can switch providers transparently.
+_DEFAULT_MAX_RESULTS = 200
+
+# Maximum number of OpenAlex IDs we pack into a single ``filter=openalex:W1|W2|...``
+# request when hydrating reference metadata. OpenAlex does not publish a
+# hard cap on filter length, but URLs over ~2000 chars risk truncation
+# and CDN rejection — 50 IDs (~1100 chars including ``W`` prefix and
+# pipes) leaves ample headroom.
+_OPENALEX_ID_BATCH_SIZE = 50
+
+# Fields requested from OpenAlex for both endpoints. Matches the spec's
+# ``CitationNode`` schema; we also pull ``referenced_works`` so the
+# references path can resolve outgoing edges in a single hop.
+_OPENALEX_WORK_SELECT = ",".join(
+    [
+        "id",
+        "doi",
+        "title",
+        "publication_year",
+        "cited_by_count",
+        "referenced_works",
+        "referenced_works_count",
+        "ids",
+    ]
+)
+
+# Lightweight select for the seed fetch when we already have the work
+# id and only need basics. Identical to ``_OPENALEX_WORK_SELECT`` for
+# now; kept separate so we can shrink it later without affecting the
+# related-paper hydration call.
+_OPENALEX_SEED_SELECT = _OPENALEX_WORK_SELECT
+
+
+# Module-level flag so we warn at most once per process when the polite
+# email is missing. Tests reset this via ``reset_polite_email_warning``
+# (kept private to the module).
+_POLITE_EMAIL_WARNED = False
+
+
+def _reset_polite_email_warning() -> None:
+    """Reset the once-per-process polite-email warning latch.
+
+    Test-only helper; not part of the public API. Mutating a module
+    global from a function avoids ``global`` declarations in tests.
+    """
+    global _POLITE_EMAIL_WARNED
+    _POLITE_EMAIL_WARNED = False
+
+
+class OpenAlexCitationClient:
+    """Citation-endpoint client for OpenAlex.
+
+    Public methods return ``(seed_node, related_nodes, edges)`` tuples
+    where:
+    - ``seed_node`` is a :class:`CitationNode` for the paper queried,
+    - ``related_nodes`` is the list of cited/citing papers (as
+      :class:`CitationNode`),
+    - ``edges`` is the list of :class:`CitationEdge` connecting them
+      (always pointing from citing to cited).
+
+    The shape is identical to :class:`SemanticScholarCitationClient` so
+    the graph builder can swap providers transparently.
+
+    Caching: each ``(endpoint, paper_id, max_results, polite_email_set)``
+    tuple is cached for ``cache_ttl_seconds`` (7 days by default). The
+    cache is on disk via ``diskcache`` so it survives process restarts.
+    The ``polite_email_set`` bit segregates entries because the polite
+    pool may return slightly fresher data; mixing them would let an
+    anonymous call serve stale polite-pool results. Pass
+    ``cache_dir=None`` to disable caching entirely.
+    """
+
+    BASE_URL = "https://api.openalex.org"
+
+    def __init__(
+        self,
+        polite_email: Optional[str] = None,
+        rate_limiter: Optional[RateLimiter] = None,
+        cache_dir: Optional[Path | str] = None,
+        cache_ttl_seconds: int = _DEFAULT_CITATION_CACHE_TTL_SECONDS,
+        request_timeout_seconds: float = 30.0,
+    ) -> None:
+        """Initialize the client.
+
+        Args:
+            polite_email: Email address used for OpenAlex's polite pool.
+                If ``None``, falls back to the ``OPENALEX_POLITE_EMAIL``
+                env var. If that is also unset we log a single WARN and
+                use the anonymous pool (still works, just slower). The
+                email is *never* logged.
+            rate_limiter: Optional pre-built rate limiter. When ``None``
+                the client builds one matching the polite-pool budget
+                (60 req/min) or the anonymous budget (20 req/min) when
+                no email is available. Both bounds are deliberately
+                conservative — OpenAlex's published limits change
+                without notice and we want headroom for retries.
+            cache_dir: Directory for the disk cache. ``None`` disables
+                caching. Defaults to ``$ARISP_CITATION_CACHE_DIR`` or
+                ``./cache/citation/openalex`` if the env var is set.
+            cache_ttl_seconds: TTL for cached citation lookups. Default
+                is 7 days per spec Section 11.3; tests pass smaller
+                values to exercise expiration logic.
+            request_timeout_seconds: Per-request HTTP timeout.
+        """
+        self.polite_email = (
+            polite_email
+            if polite_email is not None
+            else os.getenv("OPENALEX_POLITE_EMAIL")
+        )
+
+        if not self.polite_email:
+            global _POLITE_EMAIL_WARNED
+            if not _POLITE_EMAIL_WARNED:
+                logger.warning(
+                    "openalex_polite_pool_disabled",
+                    reason=(
+                        "OPENALEX_POLITE_EMAIL not set; falling back to "
+                        "anonymous pool (lower rate limits)."
+                    ),
+                )
+                _POLITE_EMAIL_WARNED = True
+
+        if rate_limiter is None:
+            requests_per_minute = 60 if self.polite_email else 20
+            rate_limiter = RateLimiter(
+                requests_per_minute=requests_per_minute,
+                burst_size=10,
+            )
+        self.rate_limiter = rate_limiter
+
+        self.request_timeout_seconds = request_timeout_seconds
+
+        self._cache: Optional[diskcache.Cache]
+        if cache_dir is None and "ARISP_CITATION_CACHE_DIR" in os.environ:
+            cache_dir = os.environ["ARISP_CITATION_CACHE_DIR"]
+
+        if cache_dir is None:
+            self._cache = None
+            self._cache_ttl_seconds = cache_ttl_seconds
+        else:
+            cache_path = Path(cache_dir) / "openalex"
+            cache_path.mkdir(parents=True, exist_ok=True)
+            self._cache = diskcache.Cache(str(cache_path), timeout=cache_ttl_seconds)
+            self._cache_ttl_seconds = cache_ttl_seconds
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def get_references(
+        self,
+        paper_id: str,
+        max_results: int = _DEFAULT_MAX_RESULTS,
+    ) -> tuple[CitationNode, list[CitationNode], list[CitationEdge]]:
+        """Fetch papers the seed work *references* (outgoing edges).
+
+        OpenAlex returns the reference list inline on the seed work as
+        ``referenced_works`` — a list of OpenAlex URLs. We hydrate the
+        first ``max_results`` of those into full :class:`CitationNode`
+        objects via a batched ``filter=openalex:W1|W2|...`` call so we
+        only pay one extra round-trip per 50 references.
+
+        Args:
+            paper_id: An OpenAlex work id (``W123…``). Bare ids and
+                full URLs (``https://openalex.org/W123…``) are both
+                accepted.
+            max_results: Cap on rows returned. Defaults to 200.
+
+        Returns:
+            ``(seed_node, ref_nodes, edges)`` — see the class docstring.
+        """
+        return await self._fetch_relationships(
+            endpoint="references",
+            paper_id=paper_id,
+            max_results=max_results,
+        )
+
+    async def get_citations(
+        self,
+        paper_id: str,
+        max_results: int = _DEFAULT_MAX_RESULTS,
+    ) -> tuple[CitationNode, list[CitationNode], list[CitationEdge]]:
+        """Fetch papers that *cite* the seed work (incoming edges).
+
+        Uses OpenAlex's ``filter=cites:W123`` query and pages through
+        the result set. Returned edges still point from citing → cited,
+        so in this case every edge has ``cited_paper_id == seed.paper_id``.
+        """
+        return await self._fetch_relationships(
+            endpoint="citations",
+            paper_id=paper_id,
+            max_results=max_results,
+        )
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    async def _fetch_relationships(
+        self,
+        endpoint: str,
+        paper_id: str,
+        max_results: int,
+    ) -> tuple[CitationNode, list[CitationNode], list[CitationEdge]]:
+        """Common path for ``get_references`` / ``get_citations``."""
+        if not paper_id or not paper_id.strip():
+            raise ValueError("paper_id must be a non-empty string")
+        if max_results < 1:
+            raise ValueError("max_results must be >= 1")
+        if endpoint not in {"references", "citations"}:
+            raise ValueError(f"Unsupported endpoint: {endpoint!r}")
+
+        normalized_id = self._normalize_work_id(paper_id)
+
+        cache_key = self._cache_key(endpoint, normalized_id, max_results)
+        cached = self._cache_get(cache_key)
+        if cached is not None:
+            logger.info(
+                "openalex_citation_cache_hit",
+                endpoint=endpoint,
+                paper_id=normalized_id,
+            )
+            return self._deserialize_payload(cached)
+
+        seed_payload = await self._fetch_work(normalized_id)
+        seed_node = self._payload_to_node(seed_payload)
+
+        if endpoint == "references":
+            related_payloads = await self._fetch_referenced_works(
+                seed_payload, max_results
+            )
+        else:  # citations
+            related_payloads = await self._fetch_citing_works(
+                normalized_id, max_results
+            )
+
+        related_nodes: list[CitationNode] = []
+        edges: list[CitationEdge] = []
+        for payload in related_payloads:
+            try:
+                related_node = self._payload_to_node(payload)
+            except (ValueError, KeyError) as exc:
+                logger.warning(
+                    "openalex_citation_skip_invalid_node",
+                    endpoint=endpoint,
+                    seed_paper_id=normalized_id,
+                    error=str(exc),
+                )
+                continue
+
+            related_nodes.append(related_node)
+
+            if endpoint == "references":
+                citing, cited = seed_node.paper_id, related_node.paper_id
+            else:  # citations
+                citing, cited = related_node.paper_id, seed_node.paper_id
+
+            edges.append(
+                CitationEdge(
+                    citing_paper_id=citing,
+                    cited_paper_id=cited,
+                    # OpenAlex does not provide per-citation context,
+                    # section, or an "isInfluential" signal — leave them
+                    # unset so the graph layer omits the JSON fields
+                    # entirely (see ``CitationEdge.to_graph_edge``).
+                    source="openalex",
+                )
+            )
+
+        result = (seed_node, related_nodes, edges)
+        self._cache_set(cache_key, self._serialize_payload(result))
+        logger.info(
+            "openalex_citation_fetched",
+            endpoint=endpoint,
+            paper_id=normalized_id,
+            related_count=len(related_nodes),
+        )
+        return result
+
+    async def _fetch_work(self, work_id: str) -> dict[str, Any]:
+        """Fetch a single work's metadata from OpenAlex."""
+        url = f"{self.BASE_URL}/works/{work_id}"
+        params = {"select": _OPENALEX_SEED_SELECT}
+        return await self._http_get(url, params=params)
+
+    async def _fetch_referenced_works(
+        self,
+        seed_payload: dict[str, Any],
+        max_results: int,
+    ) -> list[dict[str, Any]]:
+        """Hydrate ``seed_payload['referenced_works']`` into full payloads.
+
+        OpenAlex returns a list of work URLs (e.g.
+        ``https://openalex.org/W12345``). To avoid one round-trip per
+        reference we batch them in 50-id chunks via the
+        ``filter=openalex:W1|W2|...`` query.
+        """
+        ref_urls = seed_payload.get("referenced_works") or []
+        ref_ids = [self._normalize_work_id(url) for url in ref_urls if url]
+        ref_ids = ref_ids[:max_results]
+        if not ref_ids:
+            return []
+
+        # Batch the ID list to keep the query string within reasonable
+        # bounds. ``asyncio.gather`` would cut latency further, but
+        # OpenAlex's polite pool is tight enough that serial calls
+        # leave more headroom for retries — and the BFS crawler in
+        # Week 2 will fan out concurrency at the layer above.
+        hydrated: list[dict[str, Any]] = []
+        for i in range(0, len(ref_ids), _OPENALEX_ID_BATCH_SIZE):
+            chunk = ref_ids[i : i + _OPENALEX_ID_BATCH_SIZE]
+            payload = await self._http_get(
+                f"{self.BASE_URL}/works",
+                params={
+                    "filter": "openalex:" + "|".join(chunk),
+                    "per-page": str(min(len(chunk), _OPENALEX_MAX_PER_PAGE)),
+                    "select": _OPENALEX_WORK_SELECT,
+                },
+            )
+            hydrated.extend(payload.get("results") or [])
+
+        # Preserve the original ordering (OpenAlex does not guarantee
+        # filter result order matches input). We map by id then walk
+        # the original list.
+        by_id = {self._extract_id(p): p for p in hydrated if self._extract_id(p)}
+        ordered: list[dict[str, Any]] = []
+        for ref_id in ref_ids:
+            ref_payload = by_id.get(ref_id)
+            if ref_payload is not None:
+                ordered.append(ref_payload)
+        return ordered
+
+    async def _fetch_citing_works(
+        self,
+        work_id: str,
+        max_results: int,
+    ) -> list[dict[str, Any]]:
+        """Page through ``filter=cites:{work_id}`` until done.
+
+        We use page-based pagination (``page=N``) because our default
+        max is 200 (one page). For larger requests OpenAlex's
+        documentation recommends switching to cursor pagination, but
+        that path is reserved for the BFS crawler in Week 2.
+        """
+        url = f"{self.BASE_URL}/works"
+        page_size = min(_OPENALEX_MAX_PER_PAGE, max_results)
+
+        collected: list[dict[str, Any]] = []
+        page = 1
+        while len(collected) < max_results:
+            payload = await self._http_get(
+                url,
+                params={
+                    "filter": f"cites:{work_id}",
+                    "per-page": str(page_size),
+                    "page": str(page),
+                    "select": _OPENALEX_WORK_SELECT,
+                },
+            )
+            results = payload.get("results") or []
+            if not results:
+                break
+            collected.extend(results)
+
+            meta = payload.get("meta") or {}
+            total = meta.get("count")
+            # Stop as soon as we have enough or the API has nothing more.
+            if total is not None and len(collected) >= int(total):
+                break
+            if len(results) < page_size:
+                break
+            page += 1
+
+        return collected[:max_results]
+
+    async def _http_get(
+        self,
+        url: str,
+        params: dict[str, str],
+    ) -> dict[str, Any]:
+        """Issue a single GET to OpenAlex with rate limiting + error handling.
+
+        Distinguishes:
+        - 200: returns the parsed JSON body.
+        - 404: raises ``APIError`` (the work id is unknown — not
+          retryable).
+        - 429: raises ``RateLimitError`` (caller may retry).
+        - 5xx / other: raises ``APIError``.
+        """
+        await self.rate_limiter.acquire("openalex_citations")
+
+        # Polite pool is signaled via a ``mailto`` query param. We add
+        # it server-side rather than relying on the caller because
+        # missing it costs the user rate-limit headroom.
+        request_params = dict(params)
+        if self.polite_email:
+            request_params["mailto"] = self.polite_email
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    url,
+                    params=request_params,
+                    timeout=aiohttp.ClientTimeout(total=self.request_timeout_seconds),
+                ) as response:
+                    if response.status == 429:
+                        raise RateLimitError("OpenAlex rate limit exceeded")
+                    if response.status == 404:
+                        text = await response.text()
+                        raise APIError(f"Work not found on OpenAlex (404): {text}")
+                    if response.status != 200:
+                        text = await response.text()
+                        raise APIError(f"OpenAlex error {response.status}: {text}")
+                    body: dict[str, Any] = await response.json()
+                    return body
+        except asyncio.TimeoutError as exc:
+            raise APIError(
+                f"OpenAlex request timed out after " f"{self.request_timeout_seconds}s"
+            ) from exc
+
+    # ------------------------------------------------------------------
+    # Payload <-> CitationNode glue
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _normalize_work_id(value: str) -> str:
+        """Strip the ``https://openalex.org/`` prefix if present.
+
+        OpenAlex's ``referenced_works`` field stores full URLs; the
+        REST endpoints want the bare id (``W12345``). Accepts either
+        form so callers can pass whichever is convenient.
+        """
+        if not value:
+            return value
+        cleaned = value.strip()
+        if "/" in cleaned:
+            cleaned = cleaned.rsplit("/", 1)[-1]
+        return cleaned
+
+    @classmethod
+    def _extract_id(cls, payload: dict[str, Any]) -> Optional[str]:
+        """Return the bare OpenAlex id from a work payload, or None."""
+        raw = payload.get("id")
+        if not raw:
+            return None
+        return cls._normalize_work_id(str(raw))
+
+    def _payload_to_node(self, payload: dict[str, Any]) -> CitationNode:
+        """Convert an OpenAlex work payload into a :class:`CitationNode`."""
+        oa_id = self._extract_id(payload)
+        if not oa_id:
+            raise KeyError("OpenAlex payload missing id")
+
+        external_ids: dict[str, str] = {"openalex": oa_id}
+        # ``ids`` is OpenAlex's catch-all dict of cross-references
+        # (doi, mag, pmid, openalex). Some are URLs; we strip them so
+        # downstream consumers see bare values.
+        ids_dict = payload.get("ids") or {}
+        for key, value in ids_dict.items():
+            if not value or not isinstance(value, str):
+                continue
+            if key == "openalex":
+                # Already captured under "openalex" above; skip to
+                # avoid duplicating into the external_ids map.
+                continue
+            external_ids[str(key).lower()] = self._strip_id_prefix(str(key), value)
+
+        # Top-level ``doi`` is sometimes a URL; prefer ids.doi when set
+        # but fall back to top-level for older payloads.
+        if "doi" not in external_ids:
+            top_doi = payload.get("doi")
+            if isinstance(top_doi, str) and top_doi:
+                external_ids["doi"] = self._strip_id_prefix("doi", top_doi)
+
+        title = payload.get("title") or "Unknown Title"
+
+        return CitationNode(
+            paper_id=make_paper_node_id("openalex", oa_id),
+            external_ids=external_ids,
+            title=title,
+            year=payload.get("publication_year"),
+            citation_count=int(payload.get("cited_by_count") or 0),
+            reference_count=int(payload.get("referenced_works_count") or 0),
+        )
+
+    @staticmethod
+    def _strip_id_prefix(key: str, value: str) -> str:
+        """Strip well-known URL prefixes from an OpenAlex ``ids`` value.
+
+        OpenAlex publishes its cross-references as URLs (e.g.
+        ``https://doi.org/10.1/abc``). The downstream graph wants bare
+        identifiers so it can render them in any convention. We only
+        strip prefixes we can verify; unknown shapes pass through.
+        """
+        prefixes = {
+            "doi": "https://doi.org/",
+            "openalex": "https://openalex.org/",
+            "mag": (
+                "https://www.microsoft.com/en-us/research/project/"
+                "microsoft-academic-graph/"
+            ),
+            "pmid": "https://pubmed.ncbi.nlm.nih.gov/",
+            "pmcid": "https://www.ncbi.nlm.nih.gov/pmc/articles/",
+        }
+        prefix = prefixes.get(key.lower())
+        if prefix and value.startswith(prefix):
+            return value[len(prefix) :]
+        return value
+
+    # ------------------------------------------------------------------
+    # Cache helpers
+    # ------------------------------------------------------------------
+
+    def _cache_key(self, endpoint: str, paper_id: str, max_results: int) -> str:
+        """Derive a stable cache key.
+
+        The cache key includes ``polite_email_set`` so anonymous-pool
+        and polite-pool fetches do not share entries (see class
+        docstring for the rationale).
+        """
+        polite_bit = "1" if self.polite_email else "0"
+        raw = f"{endpoint}|{paper_id}|{max_results}|polite={polite_bit}"
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+    def _cache_get(self, key: str) -> Optional[bytes]:
+        if self._cache is None:
+            return None
+        value = self._cache.get(key)
+        return cast(Optional[bytes], value)
+
+    def _cache_set(self, key: str, payload: bytes) -> None:
+        if self._cache is None:
+            return
+        self._cache.set(key, payload, expire=self._cache_ttl_seconds)
+
+    @staticmethod
+    def _serialize_payload(
+        result: tuple[CitationNode, list[CitationNode], list[CitationEdge]],
+    ) -> bytes:
+        seed, related, edges = result
+        return json.dumps(
+            {
+                "seed": seed.model_dump(mode="json"),
+                "related": [n.model_dump(mode="json") for n in related],
+                "edges": [e.model_dump(mode="json") for e in edges],
+            }
+        ).encode("utf-8")
+
+    @staticmethod
+    def _deserialize_payload(
+        raw: bytes,
+    ) -> tuple[CitationNode, list[CitationNode], list[CitationEdge]]:
+        data = json.loads(raw.decode("utf-8"))
+        seed = CitationNode.model_validate(data["seed"])
+        related = [CitationNode.model_validate(n) for n in data["related"]]
+        edges = [CitationEdge.model_validate(e) for e in data["edges"]]
+        return seed, related, edges
+
+    def close(self) -> None:
+        """Release any disk cache handle."""
+        if self._cache is not None:
+            self._cache.close()
+            self._cache = None

--- a/src/services/intelligence/citation/openalex_client.py
+++ b/src/services/intelligence/citation/openalex_client.py
@@ -31,9 +31,14 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import logging
 import os
+import re
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from pathlib import Path
 from typing import Any, Optional, cast
+from urllib.parse import quote
 
 import aiohttp
 import diskcache
@@ -93,10 +98,55 @@ _OPENALEX_WORK_SELECT = ",".join(
 _OPENALEX_SEED_SELECT = _OPENALEX_WORK_SELECT
 
 
+# Strict allow-list for OpenAlex work ids. The shape of an OpenAlex
+# work id is the literal letter ``W`` followed by a digit run (typically
+# 8-10 digits today; 15 leaves headroom for future growth). Anything
+# outside this shape is rejected before it ever reaches URL
+# construction. ASCII-only by design — Unicode lookalikes could mask an
+# injection vector.
+_WORK_ID_PATTERN = re.compile(r"^W\d{1,15}$")
+
+# Substrings that the regex above already excludes but which we re-check
+# explicitly as a defense-in-depth tripwire. If a future maintainer
+# loosens the regex (e.g. to support a new namespace prefix), the
+# forbid-list still blocks the worst SSRF / traversal payloads.
+# - ``..`` flags relative-path traversal.
+# - ``://`` flags inlined URLs (``http://evil``).
+# - ``?`` and ``#`` would split the URL into query/fragment segments
+#   and could be used to smuggle parameters past our explicit ones.
+_WORK_ID_FORBIDDEN_SUBSTRINGS = ("..", "://", "?", "#")
+
+# Hard cap on work-id length — well above ``W`` + 15-digit run, so the
+# regex is the binding check, but the length check fails fast on
+# multi-megabyte payload-stuffing attempts before regex backtracking
+# burns CPU.
+_MAX_WORK_ID_LENGTH = 32
+
+# Hard cap on the size of a single OpenAlex response body we will
+# parse. Without this, a malicious or misbehaving upstream could stream
+# an arbitrarily large payload into ``response.json()`` and exhaust
+# memory. 25 MB is intentionally larger than the S2 cap (10 MB) — a
+# single OpenAlex page can include 200 full ``Work`` payloads with all
+# selected fields, which is heavier than S2's per-row shape.
+_MAX_RESPONSE_BYTES = 25 * 1024 * 1024
+
+
 # Module-level flag so we warn at most once per process when the polite
 # email is missing. Tests reset this via ``reset_polite_email_warning``
 # (kept private to the module).
 _POLITE_EMAIL_WARNED = False
+
+
+# Mute aiohttp's transport-level DEBUG logger at import time. The
+# polite-pool email is appended to every URL as a ``mailto`` query
+# param; aiohttp's ``aiohttp.client`` logger emits the full URL at
+# DEBUG which would leak the email into application logs whenever a
+# downstream consumer raises the global log level. Setting the floor to
+# INFO globally is the simplest defensible choice — those DEBUG records
+# are rarely useful in production and never emitted by this module's
+# own structlog calls. The alternative (a redacting handler) adds code
+# without a behavioural difference for any caller we care about.
+logging.getLogger("aiohttp.client").setLevel(logging.INFO)
 
 
 def _reset_polite_email_warning() -> None:
@@ -149,7 +199,10 @@ class OpenAlexCitationClient:
                 If ``None``, falls back to the ``OPENALEX_POLITE_EMAIL``
                 env var. If that is also unset we log a single WARN and
                 use the anonymous pool (still works, just slower). The
-                email is *never* logged.
+                value is never emitted by this client; aiohttp's
+                transport debug logger is muted to INFO at module
+                import time to prevent transport-level URL leakage of
+                the ``mailto`` query parameter (#S7).
             rate_limiter: Optional pre-built rate limiter. When ``None``
                 the client builds one matching the polite-pool budget
                 (60 req/min) or the anonymous budget (20 req/min) when
@@ -340,8 +393,16 @@ class OpenAlexCitationClient:
         return result
 
     async def _fetch_work(self, work_id: str) -> dict[str, Any]:
-        """Fetch a single work's metadata from OpenAlex."""
-        url = f"{self.BASE_URL}/works/{work_id}"
+        """Fetch a single work's metadata from OpenAlex.
+
+        ``work_id`` is presumed to have already been validated by
+        ``_normalize_work_id`` (the only caller goes through
+        ``_fetch_relationships``). We still ``urllib.parse.quote(...,
+        safe="")`` it as defense-in-depth — if a future refactor adds
+        a caller that forgets the normalize step, the quoting still
+        prevents path traversal at URL construction time.
+        """
+        url = f"{self.BASE_URL}/works/{quote(work_id, safe='')}"
         params = {"select": _OPENALEX_SEED_SELECT}
         return await self._http_get(url, params=params)
 
@@ -358,7 +419,21 @@ class OpenAlexCitationClient:
         ``filter=openalex:W1|W2|...`` query.
         """
         ref_urls = seed_payload.get("referenced_works") or []
-        ref_ids = [self._normalize_work_id(url) for url in ref_urls if url]
+        # ``_normalize_work_id`` now raises on hostile / malformed ids;
+        # we silently drop those rather than aborting the whole call —
+        # a single bad reference must not poison the rest of the
+        # hydration batch.
+        ref_ids: list[str] = []
+        for url in ref_urls:
+            if not url:
+                continue
+            try:
+                ref_ids.append(self._normalize_work_id(url))
+            except ValueError:
+                logger.warning(
+                    "openalex_skip_invalid_referenced_work",
+                    referenced_work=url,
+                )
         ref_ids = ref_ids[:max_results]
         if not ref_ids:
             return []
@@ -371,10 +446,15 @@ class OpenAlexCitationClient:
         hydrated: list[dict[str, Any]] = []
         for i in range(0, len(ref_ids), _OPENALEX_ID_BATCH_SIZE):
             chunk = ref_ids[i : i + _OPENALEX_ID_BATCH_SIZE]
+            # Each id was validated by ``_normalize_work_id`` so quoting
+            # is a no-op for legitimate inputs; we still quote each id
+            # individually as defense-in-depth (mirrors #C1 policy in
+            # ``_fetch_work`` / ``_fetch_citing_works``).
+            quoted_chunk = [quote(cid, safe="") for cid in chunk]
             payload = await self._http_get(
                 f"{self.BASE_URL}/works",
                 params={
-                    "filter": "openalex:" + "|".join(chunk),
+                    "filter": "openalex:" + "|".join(quoted_chunk),
                     "per-page": str(min(len(chunk), _OPENALEX_MAX_PER_PAGE)),
                     "select": _OPENALEX_WORK_SELECT,
                 },
@@ -406,6 +486,12 @@ class OpenAlexCitationClient:
         """
         url = f"{self.BASE_URL}/works"
         page_size = min(_OPENALEX_MAX_PER_PAGE, max_results)
+        # ``work_id`` came through ``_normalize_work_id`` already, so
+        # the only legal characters are ``W`` + digits. ``quote`` is
+        # therefore a no-op in practice — we apply it as
+        # defense-in-depth to mirror the URL-construction policy in
+        # ``_fetch_work`` (#C1).
+        safe_work_id = quote(work_id, safe="")
 
         collected: list[dict[str, Any]] = []
         page = 1
@@ -413,7 +499,7 @@ class OpenAlexCitationClient:
             payload = await self._http_get(
                 url,
                 params={
-                    "filter": f"cites:{work_id}",
+                    "filter": f"cites:{safe_work_id}",
                     "per-page": str(page_size),
                     "page": str(page),
                     "select": _OPENALEX_WORK_SELECT,
@@ -443,10 +529,16 @@ class OpenAlexCitationClient:
         """Issue a single GET to OpenAlex with rate limiting + error handling.
 
         Distinguishes:
-        - 200: returns the parsed JSON body.
+        - 200: returns the parsed JSON body (after a content-length cap
+          check; oversized bodies raise ``APIError`` before parsing).
+        - 3xx (301/302/303/307/308): raises ``APIError``. We disable
+          automatic redirects so a compromised or hostile upstream
+          cannot redirect our (potentially polite-pool-bearing)
+          request to an attacker-controlled host (#C2).
         - 404: raises ``APIError`` (the work id is unknown — not
           retryable).
-        - 429: raises ``RateLimitError`` (caller may retry).
+        - 429: raises ``RateLimitError`` carrying the parsed
+          ``Retry-After`` hint when the server provided one (#C4).
         - 5xx / other: raises ``APIError``.
         """
         await self.rate_limiter.acquire("openalex_citations")
@@ -464,21 +556,126 @@ class OpenAlexCitationClient:
                     url,
                     params=request_params,
                     timeout=aiohttp.ClientTimeout(total=self.request_timeout_seconds),
+                    # Disable automatic redirect-following: an upstream
+                    # 3xx pointing at an attacker-controlled host would
+                    # otherwise receive our ``mailto`` polite-pool
+                    # email plus any future auth header (#C2).
+                    allow_redirects=False,
                 ) as response:
                     if response.status == 429:
-                        raise RateLimitError("OpenAlex rate limit exceeded")
+                        retry_after = self._parse_retry_after(
+                            response.headers.get("Retry-After")
+                        )
+                        raise RateLimitError(
+                            "OpenAlex rate limit exceeded",
+                            retry_after=retry_after,
+                        )
+                    # Explicit list of redirect statuses we reject:
+                    # 301/302/303/307/308 are the genuine redirects
+                    # that would otherwise leak our request to whatever
+                    # host the ``Location`` header names. 304 is *not*
+                    # a redirect (it's "Not Modified") so it must not
+                    # be treated as one.
+                    if response.status in (301, 302, 303, 307, 308):
+                        location = response.headers.get("Location", "<none>")
+                        # ``repr`` neutralises CRLF (renders ``\r\n``
+                        # as the literal escape) and the slice caps
+                        # length — a hostile upstream cannot inject
+                        # control characters or arbitrarily long
+                        # payloads into our exception message.
+                        safe_location = repr(location[:200])
+                        raise APIError(
+                            f"OpenAlex returned an unexpected redirect "
+                            f"({response.status} -> {safe_location}); "
+                            "redirects are disabled for SSRF protection."
+                        )
                     if response.status == 404:
                         text = await response.text()
                         raise APIError(f"Work not found on OpenAlex (404): {text}")
                     if response.status != 200:
                         text = await response.text()
                         raise APIError(f"OpenAlex error {response.status}: {text}")
-                    body: dict[str, Any] = await response.json()
+                    # Bound memory before parsing. First check the
+                    # advertised ``content_length`` — cheapest possible
+                    # rejection when the server tells us the size up
+                    # front (#C3).
+                    content_length = response.content_length
+                    if (
+                        content_length is not None
+                        and content_length > _MAX_RESPONSE_BYTES
+                    ):
+                        raise APIError(
+                            f"OpenAlex response too large: "
+                            f"{content_length} bytes > {_MAX_RESPONSE_BYTES} cap."
+                        )
+                    # Even when ``content_length`` is absent (chunked
+                    # transfer, gzip, etc.) we must enforce the cap —
+                    # ``response.json()`` would otherwise buffer
+                    # arbitrarily many bytes. Read at most one byte
+                    # over the cap so we can detect (and reject)
+                    # overruns without ever holding more than cap+1 in
+                    # memory.
+                    raw = await response.content.read(_MAX_RESPONSE_BYTES + 1)
+                    if len(raw) > _MAX_RESPONSE_BYTES:
+                        raise APIError(
+                            f"OpenAlex response exceeded "
+                            f"{_MAX_RESPONSE_BYTES} bytes (streaming/chunked)."
+                        )
+                    body: dict[str, Any] = json.loads(raw)
                     return body
         except asyncio.TimeoutError as exc:
             raise APIError(
                 f"OpenAlex request timed out after " f"{self.request_timeout_seconds}s"
             ) from exc
+
+    @staticmethod
+    def _parse_retry_after(value: Optional[str]) -> Optional[float]:
+        """Parse an HTTP ``Retry-After`` header value to seconds.
+
+        RFC 7231 §7.1.3 allows two forms:
+        - delta-seconds (a non-negative integer), e.g. ``"120"``.
+        - HTTP-date (RFC 7231 §7.1.1.1), e.g.
+          ``"Wed, 21 Oct 2015 07:28:00 GMT"``.
+
+        Returns ``None`` when the header is absent or unparsable;
+        callers should treat ``None`` as "no hint, use your own
+        backoff" and never trust the value blindly (negative or
+        far-future dates clamp to ``0.0``). Mirrors the post-#118
+        S2 client implementation so the orchestrator sees a
+        consistent shape across both providers (#C4).
+        """
+        if value is None:
+            return None
+        value = value.strip()
+        if not value:
+            return None
+        # Numeric (delta-seconds) form first — it's the common case.
+        try:
+            seconds = float(value)
+        except ValueError:
+            seconds = None  # type: ignore[assignment]
+        if seconds is not None:
+            return max(0.0, seconds)
+        # HTTP-date form. ``parsedate_to_datetime`` returns a tz-aware
+        # datetime when the input includes a zone (RFC HTTP-dates
+        # always do); it raises ``ValueError`` (or in pathological
+        # cases ``TypeError``) on bad input.
+        try:
+            target = parsedate_to_datetime(value)
+        except (TypeError, ValueError):
+            return None
+        # Defensive: a non-conforming upstream may send an HTTP-date
+        # with no timezone token, in which case ``parsedate_to_datetime``
+        # returns a *naive* datetime. Subtracting a naive datetime
+        # from a tz-aware ``datetime.now`` raises ``TypeError`` and
+        # would escape ``_http_get`` unwrapped — a DoS-adjacent
+        # failure on the 429 path. Coerce naive → UTC so we still
+        # produce a useful backoff hint instead of dropping the value.
+        if target.tzinfo is None:
+            target = target.replace(tzinfo=timezone.utc)
+        now = datetime.now(target.tzinfo)
+        delta = (target - now).total_seconds()
+        return max(0.0, delta)
 
     # ------------------------------------------------------------------
     # Payload <-> CitationNode glue
@@ -486,26 +683,63 @@ class OpenAlexCitationClient:
 
     @staticmethod
     def _normalize_work_id(value: str) -> str:
-        """Strip the ``https://openalex.org/`` prefix if present.
+        """Strip the ``https://openalex.org/`` prefix and validate.
 
         OpenAlex's ``referenced_works`` field stores full URLs; the
         REST endpoints want the bare id (``W12345``). Accepts either
         form so callers can pass whichever is convenient.
+
+        The returned id is guaranteed to match ``_WORK_ID_PATTERN`` —
+        the strict ``^W\\d{1,15}$`` allow-list — and to be free of any
+        URL/traversal metacharacter listed in
+        ``_WORK_ID_FORBIDDEN_SUBSTRINGS``. Any failure raises
+        ``ValueError`` so the URL builder upstream is never asked to
+        interpolate a hostile payload (#C1).
+
+        Raises:
+            ValueError: If the input is empty after trimming, exceeds
+                ``_MAX_WORK_ID_LENGTH``, contains a forbidden
+                substring, or fails the regex match.
         """
         if not value:
-            return value
+            raise ValueError(f"Invalid OpenAlex work_id: {value!r}")
         cleaned = value.strip()
         if "/" in cleaned:
+            # Last path segment after any URL prefix. Accepts both bare
+            # ids and full ``https://openalex.org/Wxxx`` URLs.
             cleaned = cleaned.rsplit("/", 1)[-1]
+
+        # Length check first — cheapest rejection for payload-stuffing.
+        if not cleaned or len(cleaned) > _MAX_WORK_ID_LENGTH:
+            raise ValueError(f"Invalid OpenAlex work_id: {value!r}")
+
+        # Forbid-list before regex so the failure mode is explicit on
+        # the worst payloads even if someone later loosens the regex.
+        if any(substr in cleaned for substr in _WORK_ID_FORBIDDEN_SUBSTRINGS):
+            raise ValueError(f"Invalid OpenAlex work_id: {value!r}")
+
+        if not _WORK_ID_PATTERN.match(cleaned):
+            raise ValueError(f"Invalid OpenAlex work_id: {value!r}")
+
         return cleaned
 
     @classmethod
     def _extract_id(cls, payload: dict[str, Any]) -> Optional[str]:
-        """Return the bare OpenAlex id from a work payload, or None."""
+        """Return the bare OpenAlex id from a work payload, or None.
+
+        Returns ``None`` when ``id`` is absent OR when the value fails
+        the strict ``_normalize_work_id`` validator. This shields the
+        caller (``_payload_to_node`` / hydration map building) from
+        upstream payloads carrying malformed or hostile ids — those
+        rows are silently dropped rather than poisoning the URL builder.
+        """
         raw = payload.get("id")
         if not raw:
             return None
-        return cls._normalize_work_id(str(raw))
+        try:
+            return cls._normalize_work_id(str(raw))
+        except ValueError:
+            return None
 
     def _payload_to_node(self, payload: dict[str, Any]) -> CitationNode:
         """Convert an OpenAlex work payload into a :class:`CitationNode`."""

--- a/src/services/intelligence/models/__init__.py
+++ b/src/services/intelligence/models/__init__.py
@@ -23,6 +23,7 @@ Submodules:
 
 from src.services.intelligence.models.exceptions import (
     EdgeNotFoundError,
+    GraphStoreDuplicateError,
     GraphStoreError,
     NodeNotFoundError,
     OptimisticLockError,
@@ -45,6 +46,7 @@ __all__ = [
     "ENTITY_NAME_PATTERN",
     # Exceptions
     "GraphStoreError",
+    "GraphStoreDuplicateError",
     "NodeNotFoundError",
     "EdgeNotFoundError",
     "OptimisticLockError",

--- a/src/services/intelligence/models/exceptions.py
+++ b/src/services/intelligence/models/exceptions.py
@@ -6,7 +6,8 @@ Hierarchy:
         └── GraphStoreError
                 ├── NodeNotFoundError
                 ├── EdgeNotFoundError
-                └── ReferentialIntegrityError
+                ├── ReferentialIntegrityError
+                └── GraphStoreDuplicateError
 
     Exception
         └── OptimisticLockError  (concurrent-modification signal)
@@ -14,11 +15,31 @@ Hierarchy:
 ``OptimisticLockError`` is intentionally NOT a subclass of
 ``GraphStoreError`` so callers can distinguish "operation truly failed"
 from "operation should be retried with fresh data".
+
+``GraphStoreDuplicateError`` is a typed signal for UNIQUE-constraint
+violations. Callers performing best-effort idempotent inserts (e.g. the
+citation graph builder's per-row recovery path) should ``except`` this
+specifically rather than substring-matching on the underlying message —
+SQLite's wording is not a stable contract.
 """
 
 
 class GraphStoreError(Exception):
     """Base exception for graph store operations."""
+
+    pass
+
+
+class GraphStoreDuplicateError(GraphStoreError):
+    """Raised when an insert hits a UNIQUE constraint (duplicate id).
+
+    This is a *typed* signal callers can match on instead of inspecting
+    error message strings — SQLite's ``IntegrityError`` text is not a
+    stable contract and would silently break per-row recovery loops if
+    the underlying driver ever rephrased it. Backends other than
+    SQLite (e.g. a future Neo4j store) raise this same type so the
+    builder layer stays storage-agnostic.
+    """
 
     pass
 

--- a/src/storage/intelligence_graph/unified_graph.py
+++ b/src/storage/intelligence_graph/unified_graph.py
@@ -22,6 +22,7 @@ from src.services.intelligence.models import (
     EdgeType,
     GraphEdge,
     GraphNode,
+    GraphStoreDuplicateError,
     GraphStoreError,
     NodeNotFoundError,
     NodeType,
@@ -492,7 +493,10 @@ class SQLiteGraphStore:
         except sqlite3.IntegrityError as e:
             conn.rollback()
             if "UNIQUE constraint failed" in str(e):
-                raise GraphStoreError(f"Node already exists: {node_id}")
+                # Typed signal so callers performing best-effort idempotent
+                # inserts can ``except GraphStoreDuplicateError`` instead of
+                # substring-matching on the message text.
+                raise GraphStoreDuplicateError(f"Node already exists: {node_id}")
             logger.error("node_add_integrity_error", node_id=node_id, error=str(e))
             raise GraphStoreError(f"Failed to add node: {e}")
         finally:
@@ -566,6 +570,13 @@ class SQLiteGraphStore:
                 count=len(rows),
                 error=str(e),
             )
+            # Distinguish duplicate-id collisions (typical re-run) from
+            # other constraint violations so the caller's recovery path
+            # can match on a typed exception (#S5).
+            if "UNIQUE constraint failed" in str(e):
+                raise GraphStoreDuplicateError(
+                    f"Failed to bulk insert nodes (duplicate node_id): {e}"
+                ) from e
             raise GraphStoreError(f"Failed to bulk insert nodes: {e}") from e
         finally:
             conn.close()
@@ -727,7 +738,8 @@ class SQLiteGraphStore:
                     f"Source or target node not found: {source_id}, {target_id}"
                 )
             if "UNIQUE constraint failed" in str(e):
-                raise GraphStoreError(f"Edge already exists: {edge_id}")
+                # Typed signal — see ``add_node`` for rationale.
+                raise GraphStoreDuplicateError(f"Edge already exists: {edge_id}")
             logger.error(
                 "edge_add_integrity_error",
                 edge_id=edge_id,
@@ -810,6 +822,13 @@ class SQLiteGraphStore:
             if "FOREIGN KEY constraint failed" in str(e):
                 raise ReferentialIntegrityError(
                     f"Bulk edge insert hit a missing source/target node: {e}"
+                ) from e
+            # Distinguish duplicate-id collisions from other constraint
+            # violations so the caller's recovery path can match on a
+            # typed exception (#S5).
+            if "UNIQUE constraint failed" in str(e):
+                raise GraphStoreDuplicateError(
+                    f"Failed to bulk insert edges (duplicate edge_id): {e}"
                 ) from e
             raise GraphStoreError(f"Failed to bulk insert edges: {e}") from e
         finally:

--- a/tests/unit/services/intelligence/citation/test_graph_builder.py
+++ b/tests/unit/services/intelligence/citation/test_graph_builder.py
@@ -58,7 +58,11 @@ def temp_db():
     yield path
     try:
         path.unlink()
-    except FileNotFoundError:  # pragma: no cover - belt-and-suspenders
+    except FileNotFoundError:
+        # Belt-and-suspenders: fixture cleanup races against rare path
+        # mutations in tests. No pragma — let coverage report it
+        # honestly; if it's truly unreachable the project's pragma
+        # audit will flag it (#N1).
         pass
 
 
@@ -371,8 +375,12 @@ async def test_both_directions_success(builder, s2_client, store):
 
 
 @pytest.mark.asyncio
-async def test_both_directions_mixed_providers(builder, s2_client, oa_client):
-    """OUT succeeds via S2, IN falls back to OpenAlex → provider='both'."""
+async def test_both_directions_mixed_providers(builder, s2_client, oa_client, store):
+    """OUT succeeds via S2, IN falls back to OpenAlex → provider='both'.
+
+    Also pins (#N3) that BOTH seed rows actually land in the store —
+    without the second seed, the IN-side edges would be orphans
+    referencing a missing target node."""
     seed = _node("s2", "seed1")
     refs = [_node("s2", "ref1")]
     s2_client.get_references.return_value = (seed, refs, [_edge(seed, refs[0])])
@@ -392,6 +400,14 @@ async def test_both_directions_mixed_providers(builder, s2_client, oa_client):
     # OUT seed + 1 ref + IN seed (different id) + 1 citer = 4
     assert result.nodes_added == 4
     assert result.edges_added == 2
+
+    # Both seed nodes must actually exist in the store (#N3) — counting
+    # is not enough; orphaned IN-side edges would otherwise reference
+    # a missing target node.
+    assert store.get_node(seed.paper_id) is not None
+    assert store.get_node(oa_seed.paper_id) is not None
+    assert store.get_node(refs[0].paper_id) is not None
+    assert store.get_node(citers[0].paper_id) is not None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/intelligence/citation/test_graph_builder.py
+++ b/tests/unit/services/intelligence/citation/test_graph_builder.py
@@ -33,6 +33,7 @@ from src.services.intelligence.citation.semantic_scholar_client import (
 )
 from src.services.intelligence.models import (
     EdgeType,
+    GraphStoreDuplicateError,
     GraphStoreError,
     NodeType,
 )
@@ -511,8 +512,9 @@ async def test_node_per_row_recovery_skips_duplicates_silently(
     builder, s2_client, store, monkeypatch
 ):
     """
-    Bulk insert fails, but per-row hits 'already exists' for some rows.
-    Those should NOT be reported as errors.
+    Bulk insert fails, but per-row hits ``GraphStoreDuplicateError`` for
+    some rows. Those should NOT be reported as errors (#S5: typed signal,
+    not substring match on the message).
     """
     seed = _node("s2", "seed1")
     ref = _node("s2", "ref1")
@@ -527,6 +529,62 @@ async def test_node_per_row_recovery_skips_duplicates_silently(
     # ref is new; seed dup
     assert result.nodes_added == 1
     assert result.errors == []
+
+
+@pytest.mark.asyncio
+async def test_node_per_row_recovery_uses_typed_duplicate_exception(
+    builder, s2_client, store, monkeypatch
+):
+    """The recovery path catches ``GraphStoreDuplicateError`` even if the
+    message text wouldn't match the legacy ``"already exists"`` substring
+    — this pins the typed-exception contract from #S5."""
+    seed = _node("s2", "seed1")
+    s2_client.get_references.return_value = (seed, [], [])
+
+    def boom_batch(_nodes):
+        raise GraphStoreError("synthetic bulk failure")
+
+    call_count = {"n": 0}
+
+    def boom_row(node_id, node_type, properties):
+        call_count["n"] += 1
+        # Message intentionally lacks "already exists" — only the typed
+        # exception matters for the silent-skip contract.
+        raise GraphStoreDuplicateError(f"unique violation on {node_id}")
+
+    monkeypatch.setattr(store, "add_nodes_batch", boom_batch)
+    monkeypatch.setattr(store, "add_node", boom_row)
+
+    result = await builder.build_for_paper("seed1")
+
+    # No errors recorded — duplicates are skipped silently.
+    assert result.errors == []
+    assert result.nodes_added == 0
+    assert call_count["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_edge_per_row_recovery_uses_typed_duplicate_exception(
+    builder, s2_client, store, monkeypatch
+):
+    """Same as the node-side typed-exception pin, for edges."""
+    seed = _node("s2", "seed1")
+    ref = _node("s2", "ref1")
+    s2_client.get_references.return_value = (seed, [ref], [_edge(seed, ref)])
+
+    def boom_batch(_edges):
+        raise GraphStoreError("synthetic edge bulk failure")
+
+    def boom_row(*args, **kwargs):
+        raise GraphStoreDuplicateError("unique violation on edge")
+
+    monkeypatch.setattr(store, "add_edges_batch", boom_batch)
+    monkeypatch.setattr(store, "add_edge", boom_row)
+
+    result = await builder.build_for_paper("seed1")
+
+    assert result.errors == []
+    assert result.edges_added == 0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/intelligence/citation/test_graph_builder.py
+++ b/tests/unit/services/intelligence/citation/test_graph_builder.py
@@ -1,0 +1,725 @@
+"""Tests for CitationGraphBuilder (Milestone 9.2 — Week 1.5).
+
+Mocked S2 + OpenAlex clients combined with a real ``SQLiteGraphStore``
+(tempfile-backed, isolated per test) so persistence + idempotency
+behavior is verified end-to-end without any real HTTP traffic.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.services.intelligence.citation.graph_builder import (
+    CitationGraphBuilder,
+    GraphBuildResult,
+)
+from src.services.intelligence.citation.models import (
+    CitationDirection,
+    CitationEdge,
+    CitationNode,
+    make_citation_edge_id,
+    make_paper_node_id,
+)
+from src.services.intelligence.citation.openalex_client import (
+    OpenAlexCitationClient,
+)
+from src.services.intelligence.citation.semantic_scholar_client import (
+    SemanticScholarCitationClient,
+)
+from src.services.intelligence.models import (
+    EdgeType,
+    GraphStoreError,
+    NodeType,
+)
+from src.services.providers.base import APIError, RateLimitError
+from src.storage.intelligence_graph import SQLiteGraphStore
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def temp_db():
+    """Tempfile-backed db path; cleaned up after the test."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        path = Path(f.name)
+    yield path
+    try:
+        path.unlink()
+    except FileNotFoundError:  # pragma: no cover - belt-and-suspenders
+        pass
+
+
+@pytest.fixture
+def store(temp_db):
+    s = SQLiteGraphStore(temp_db)
+    s.initialize()
+    return s
+
+
+@pytest.fixture
+def s2_client():
+    """Mock S2 client; tests override get_references / get_citations."""
+    return AsyncMock(spec=SemanticScholarCitationClient)
+
+
+@pytest.fixture
+def oa_client():
+    """Mock OpenAlex client; tests override get_references / get_citations."""
+    return AsyncMock(spec=OpenAlexCitationClient)
+
+
+@pytest.fixture
+def builder(store, s2_client, oa_client):
+    return CitationGraphBuilder(
+        store=store, s2_client=s2_client, openalex_client=oa_client
+    )
+
+
+def _node(provider: str, raw_id: str, **kwargs) -> CitationNode:
+    return CitationNode(
+        paper_id=make_paper_node_id(provider, raw_id),
+        title=kwargs.pop("title", f"Paper {raw_id}"),
+        external_ids={provider: raw_id},
+        citation_count=kwargs.pop("citation_count", 0),
+        reference_count=kwargs.pop("reference_count", 0),
+        **kwargs,
+    )
+
+
+def _edge(
+    citing: CitationNode, cited: CitationNode, source: str = "s2"
+) -> CitationEdge:
+    return CitationEdge(
+        citing_paper_id=citing.paper_id,
+        cited_paper_id=cited.paper_id,
+        source=source,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Constructor + input validation
+# ---------------------------------------------------------------------------
+
+
+def test_constructor_assigns_dependencies(store, s2_client, oa_client):
+    b = CitationGraphBuilder(store, s2_client, oa_client)
+    assert b.store is store
+    assert b.s2_client is s2_client
+    assert b.openalex_client is oa_client
+
+
+@pytest.mark.asyncio
+async def test_build_rejects_depth_other_than_one(builder):
+    with pytest.raises(ValueError, match="depth=1 only"):
+        await builder.build_for_paper("paper:s2:abc", depth=2)
+
+
+@pytest.mark.asyncio
+async def test_build_rejects_empty_paper_id(builder):
+    with pytest.raises(ValueError, match="non-empty"):
+        await builder.build_for_paper("", depth=1)
+
+
+@pytest.mark.asyncio
+async def test_build_rejects_whitespace_paper_id(builder):
+    with pytest.raises(ValueError, match="non-empty"):
+        await builder.build_for_paper("   ", depth=1)
+
+
+@pytest.mark.asyncio
+async def test_build_rejects_zero_max_results(builder):
+    with pytest.raises(ValueError, match="max_results must be"):
+        await builder.build_for_paper("paper:s2:abc", max_results=0)
+
+
+# ---------------------------------------------------------------------------
+# S2 success path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_out_with_s2_success(builder, s2_client, oa_client, store):
+    seed = _node("s2", "seed1", citation_count=10, reference_count=2)
+    refs = [_node("s2", "ref1"), _node("s2", "ref2")]
+    edges = [_edge(seed, refs[0]), _edge(seed, refs[1])]
+
+    s2_client.get_references.return_value = (seed, refs, edges)
+
+    result = await builder.build_for_paper("seed1")
+
+    assert isinstance(result, GraphBuildResult)
+    assert result.seed_paper_id == "seed1"
+    assert result.nodes_added == 3
+    assert result.edges_added == 2
+    assert result.provider_used == "s2"
+    assert result.errors == []
+
+    s2_client.get_references.assert_awaited_once_with("seed1", max_results=200)
+    oa_client.get_references.assert_not_awaited()
+
+    # Verify persistence
+    assert store.get_node(seed.paper_id) is not None
+    assert store.get_node(refs[0].paper_id) is not None
+    edge_id = make_citation_edge_id(seed.paper_id, refs[0].paper_id)
+    assert store.get_edge(edge_id) is not None
+
+
+@pytest.mark.asyncio
+async def test_build_in_with_s2_success(builder, s2_client, store):
+    seed = _node("s2", "seed1")
+    citers = [_node("s2", "cite1")]
+    edges = [_edge(citers[0], seed)]
+
+    s2_client.get_citations.return_value = (seed, citers, edges)
+
+    result = await builder.build_for_paper("seed1", direction=CitationDirection.IN)
+
+    assert result.provider_used == "s2"
+    assert result.nodes_added == 2
+    assert result.edges_added == 1
+    s2_client.get_citations.assert_awaited_once_with("seed1", max_results=200)
+
+    # Persisted edge points citer → seed
+    edge_id = make_citation_edge_id(citers[0].paper_id, seed.paper_id)
+    persisted = store.get_edge(edge_id)
+    assert persisted is not None
+    assert persisted.source_id == citers[0].paper_id
+    assert persisted.target_id == seed.paper_id
+
+
+@pytest.mark.asyncio
+async def test_build_with_zero_related_does_not_fall_back(
+    builder, s2_client, oa_client, store
+):
+    """S2 returns the seed but no references → success, no fallback."""
+    seed = _node("s2", "seed1")
+    s2_client.get_references.return_value = (seed, [], [])
+
+    result = await builder.build_for_paper("seed1")
+
+    assert result.provider_used == "s2"
+    assert result.nodes_added == 1
+    assert result.edges_added == 0
+    assert result.errors == []
+    oa_client.get_references.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_build_max_results_propagates(builder, s2_client):
+    seed = _node("s2", "seed1")
+    s2_client.get_references.return_value = (seed, [], [])
+
+    await builder.build_for_paper("seed1", max_results=42)
+
+    s2_client.get_references.assert_awaited_once_with("seed1", max_results=42)
+
+
+# ---------------------------------------------------------------------------
+# Fallback path: S2 fails → OpenAlex
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_s2_api_error_falls_back_to_openalex(
+    builder, s2_client, oa_client, store
+):
+    s2_client.get_references.side_effect = APIError("boom")
+
+    seed = _node("openalex", "W1")
+    refs = [_node("openalex", "W101")]
+    edges = [_edge(seed, refs[0], source="openalex")]
+    oa_client.get_references.return_value = (seed, refs, edges)
+
+    result = await builder.build_for_paper("seed1")
+
+    assert result.provider_used == "openalex"
+    assert result.nodes_added == 2
+    assert result.edges_added == 1
+    assert any("s2" in e for e in result.errors)
+    oa_client.get_references.assert_awaited_once_with("seed1", max_results=200)
+
+
+@pytest.mark.asyncio
+async def test_s2_rate_limit_falls_back_to_openalex(builder, s2_client, oa_client):
+    """RateLimitError is a subclass of APIError → also triggers fallback."""
+    s2_client.get_references.side_effect = RateLimitError("slow down")
+
+    seed = _node("openalex", "W1")
+    oa_client.get_references.return_value = (seed, [], [])
+
+    result = await builder.build_for_paper("seed1")
+    assert result.provider_used == "openalex"
+
+
+@pytest.mark.asyncio
+async def test_both_providers_fail_returns_empty_result(builder, s2_client, oa_client):
+    s2_client.get_references.side_effect = APIError("s2 down")
+    oa_client.get_references.side_effect = APIError("openalex down")
+
+    result = await builder.build_for_paper("seed1")
+
+    assert result.provider_used == "none"
+    assert result.nodes_added == 0
+    assert result.edges_added == 0
+    assert len(result.errors) == 2
+    assert any("s2:" in e for e in result.errors)
+    assert any("openalex:" in e for e in result.errors)
+
+
+# ---------------------------------------------------------------------------
+# Direction.BOTH path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_both_directions_success(builder, s2_client, store):
+    seed = _node("s2", "seed1")
+    refs = [_node("s2", "ref1")]
+    citers = [_node("s2", "cite1")]
+    out_edges = [_edge(seed, refs[0])]
+    in_edges = [_edge(citers[0], seed)]
+
+    s2_client.get_references.return_value = (seed, refs, out_edges)
+    s2_client.get_citations.return_value = (seed, citers, in_edges)
+
+    result = await builder.build_for_paper("seed1", direction=CitationDirection.BOTH)
+
+    assert result.provider_used == "s2"
+    # seed (1) + ref (1) + citer (1) = 3 unique nodes
+    assert result.nodes_added == 3
+    # 2 unique edges
+    assert result.edges_added == 2
+
+    s2_client.get_references.assert_awaited_once()
+    s2_client.get_citations.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_both_directions_mixed_providers(builder, s2_client, oa_client):
+    """OUT succeeds via S2, IN falls back to OpenAlex → provider='both'."""
+    seed = _node("s2", "seed1")
+    refs = [_node("s2", "ref1")]
+    s2_client.get_references.return_value = (seed, refs, [_edge(seed, refs[0])])
+
+    s2_client.get_citations.side_effect = APIError("s2 citations down")
+    oa_seed = _node("openalex", "W1")
+    citers = [_node("openalex", "W201")]
+    oa_client.get_citations.return_value = (
+        oa_seed,
+        citers,
+        [_edge(citers[0], oa_seed, source="openalex")],
+    )
+
+    result = await builder.build_for_paper("seed1", direction=CitationDirection.BOTH)
+
+    assert result.provider_used == "both"
+    # OUT seed + 1 ref + IN seed (different id) + 1 citer = 4
+    assert result.nodes_added == 4
+    assert result.edges_added == 2
+
+
+@pytest.mark.asyncio
+async def test_both_directions_one_side_fails_only(builder, s2_client, oa_client):
+    """OUT succeeds, IN fails entirely (both providers fail) → still persists OUT."""
+    seed = _node("s2", "seed1")
+    refs = [_node("s2", "ref1")]
+    s2_client.get_references.return_value = (seed, refs, [_edge(seed, refs[0])])
+
+    s2_client.get_citations.side_effect = APIError("s2 down")
+    oa_client.get_citations.side_effect = APIError("openalex down")
+
+    result = await builder.build_for_paper("seed1", direction=CitationDirection.BOTH)
+
+    # OUT succeeded via s2; IN was lost. provider_used reflects what worked.
+    assert result.provider_used == "s2"
+    assert result.nodes_added == 2  # seed + ref
+    assert result.edges_added == 1
+    assert any("s2:" in e for e in result.errors)
+    assert any("openalex:" in e for e in result.errors)
+
+
+@pytest.mark.asyncio
+async def test_both_directions_all_fail(builder, s2_client, oa_client):
+    s2_client.get_references.side_effect = APIError("a")
+    s2_client.get_citations.side_effect = APIError("b")
+    oa_client.get_references.side_effect = APIError("c")
+    oa_client.get_citations.side_effect = APIError("d")
+
+    result = await builder.build_for_paper("seed1", direction=CitationDirection.BOTH)
+
+    assert result.provider_used == "none"
+    assert result.nodes_added == 0
+    assert result.edges_added == 0
+    assert len(result.errors) == 4
+
+
+# ---------------------------------------------------------------------------
+# Idempotency: re-running for the same paper at depth=1 must not corrupt.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_idempotent_re_call_same_seed(builder, s2_client, store):
+    seed = _node("s2", "seed1")
+    refs = [_node("s2", "ref1"), _node("s2", "ref2")]
+    edges = [_edge(seed, refs[0]), _edge(seed, refs[1])]
+    s2_client.get_references.return_value = (seed, refs, edges)
+
+    r1 = await builder.build_for_paper("seed1")
+    r2 = await builder.build_for_paper("seed1")
+
+    assert r1.errors == []
+    assert r2.errors == []
+    # First call inserted everything via bulk; second call hit the
+    # per-row recovery path and saw all duplicates → 0 new rows.
+    assert r1.nodes_added == 3
+    assert r1.edges_added == 2
+    assert r2.nodes_added == 0
+    assert r2.edges_added == 0
+
+
+@pytest.mark.asyncio
+async def test_idempotent_partial_overlap(builder, s2_client, store):
+    """A second seed shares one reference with the first; only the new
+    node should land."""
+    seed1 = _node("s2", "seed1")
+    shared = _node("s2", "shared")
+    s2_client.get_references.return_value = (seed1, [shared], [_edge(seed1, shared)])
+    r1 = await builder.build_for_paper("seed1")
+    assert r1.nodes_added == 2
+
+    seed2 = _node("s2", "seed2")
+    new_ref = _node("s2", "new")
+    s2_client.get_references.return_value = (
+        seed2,
+        [shared, new_ref],
+        [_edge(seed2, shared), _edge(seed2, new_ref)],
+    )
+    r2 = await builder.build_for_paper("seed2")
+
+    # Per-row fallback inserts: seed2 (new) + shared (dup) + new (new) = 2
+    assert r2.nodes_added == 2
+    # Both edges point seed2→X and are new → both inserted
+    assert r2.edges_added == 2
+
+
+# ---------------------------------------------------------------------------
+# Deduplication within a single call
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_deduplicates_repeated_related_nodes(builder, s2_client, store):
+    """A reference list that lists the same paper twice must not break
+    the bulk insert."""
+    seed = _node("s2", "seed1")
+    dup = _node("s2", "dup")
+    s2_client.get_references.return_value = (
+        seed,
+        [dup, dup],
+        [_edge(seed, dup), _edge(seed, dup)],
+    )
+
+    result = await builder.build_for_paper("seed1")
+
+    assert result.errors == []
+    assert result.nodes_added == 2  # seed + dup
+    assert result.edges_added == 1  # one edge id (deterministic hash)
+
+
+@pytest.mark.asyncio
+async def test_seed_appears_in_related_list_no_duplicate(builder, s2_client, store):
+    """If a provider mistakenly returns the seed inside ``related``, dedupe wins."""
+    seed = _node("s2", "seed1")
+    other = _node("s2", "other")
+    s2_client.get_references.return_value = (
+        seed,
+        [seed, other],
+        [_edge(seed, other)],
+    )
+
+    result = await builder.build_for_paper("seed1")
+    assert result.nodes_added == 2  # seed + other (seed dedup'd)
+
+
+# ---------------------------------------------------------------------------
+# Persistence error handling (non-duplicate failure)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_node_per_row_recovery_records_unrecoverable_error(
+    builder, s2_client, store, monkeypatch
+):
+    """
+    Force the bulk insert to fail, then make per-row also fail with a
+    non-duplicate error, so the unrecoverable path is exercised.
+    """
+    seed = _node("s2", "seed1")
+    s2_client.get_references.return_value = (seed, [], [])
+
+    def boom_batch(_nodes):
+        raise GraphStoreError("synthetic batch failure")
+
+    def boom_row(node_id, node_type, properties):
+        raise GraphStoreError("synthetic row failure")
+
+    monkeypatch.setattr(store, "add_nodes_batch", boom_batch)
+    monkeypatch.setattr(store, "add_node", boom_row)
+
+    result = await builder.build_for_paper("seed1")
+
+    assert result.nodes_added == 0
+    assert any("synthetic row failure" in e for e in result.errors)
+
+
+@pytest.mark.asyncio
+async def test_edge_per_row_recovery_records_unrecoverable_error(
+    builder, s2_client, store, monkeypatch
+):
+    seed = _node("s2", "seed1")
+    ref = _node("s2", "ref1")
+    s2_client.get_references.return_value = (seed, [ref], [_edge(seed, ref)])
+
+    def boom_batch(_edges):
+        raise GraphStoreError("synthetic edge batch failure")
+
+    def boom_row(*args, **kwargs):
+        raise GraphStoreError("synthetic edge row failure")
+
+    monkeypatch.setattr(store, "add_edges_batch", boom_batch)
+    monkeypatch.setattr(store, "add_edge", boom_row)
+
+    result = await builder.build_for_paper("seed1")
+
+    # Nodes still got persisted via the normal path
+    assert result.nodes_added == 2
+    # Edges all failed to insert
+    assert result.edges_added == 0
+    assert any("synthetic edge row failure" in e for e in result.errors)
+
+
+@pytest.mark.asyncio
+async def test_node_per_row_recovery_skips_duplicates_silently(
+    builder, s2_client, store, monkeypatch
+):
+    """
+    Bulk insert fails, but per-row hits 'already exists' for some rows.
+    Those should NOT be reported as errors.
+    """
+    seed = _node("s2", "seed1")
+    ref = _node("s2", "ref1")
+    s2_client.get_references.return_value = (seed, [ref], [])
+
+    # Pre-insert seed so bulk fails on duplicate, then per-row sees
+    # seed-already-exists and inserts ref normally.
+    store.add_node(seed.paper_id, NodeType.PAPER, {"title": seed.title})
+
+    result = await builder.build_for_paper("seed1")
+
+    # ref is new; seed dup
+    assert result.nodes_added == 1
+    assert result.errors == []
+
+
+@pytest.mark.asyncio
+async def test_edge_per_row_recovery_inserts_new_edges_after_duplicate(
+    builder, s2_client, store, temp_db
+):
+    """Bulk fails on a single duplicate edge; per-row should still
+    insert the genuinely new edges (exercises the inserted += 1 path
+    in the edge recovery branch)."""
+    seed = _node("s2", "seed1")
+    ref1 = _node("s2", "ref1")
+    ref2 = _node("s2", "ref2")
+    s2_client.get_references.return_value = (
+        seed,
+        [ref1, ref2],
+        [_edge(seed, ref1), _edge(seed, ref2)],
+    )
+
+    # First call inserts everything cleanly.
+    r1 = await builder.build_for_paper("seed1")
+    assert r1.nodes_added == 3
+    assert r1.edges_added == 2
+
+    # Now extend the response with a brand-new edge to ref3 — bulk
+    # will fail because edge1/edge2 are duplicates, then per-row will
+    # skip the dups and insert the new edge.
+    ref3 = _node("s2", "ref3")
+    s2_client.get_references.return_value = (
+        seed,
+        [ref1, ref2, ref3],
+        [_edge(seed, ref1), _edge(seed, ref2), _edge(seed, ref3)],
+    )
+
+    r2 = await builder.build_for_paper("seed1")
+    assert r2.errors == []
+    # Exactly one new edge inserted via the per-row recovery path
+    assert r2.edges_added == 1
+
+
+@pytest.mark.asyncio
+async def test_persist_skipped_when_only_seed_with_no_other_data(
+    builder, s2_client, store
+):
+    """A seed-only build still inserts the seed (covers the empty-edges
+    no-op path in _bulk_insert_edges)."""
+    seed = _node("s2", "seed_alone")
+    s2_client.get_references.return_value = (seed, [], [])
+
+    result = await builder.build_for_paper("seed_alone")
+    assert result.nodes_added == 1
+    assert result.edges_added == 0
+
+
+def test_bulk_insert_nodes_empty_is_noop(builder):
+    """Direct unit test for the empty-nodes early return path."""
+    errors: list[str] = []
+    inserted = builder._bulk_insert_nodes([], errors)
+    assert inserted == 0
+    assert errors == []
+
+
+def test_bulk_insert_edges_empty_is_noop(builder):
+    """Direct unit test for the empty-edges early return path."""
+    errors: list[str] = []
+    inserted = builder._bulk_insert_edges([], errors)
+    assert inserted == 0
+    assert errors == []
+
+
+# ---------------------------------------------------------------------------
+# Storage-engine agnostic: the builder must not import sqlite3 directly.
+# ---------------------------------------------------------------------------
+
+
+def test_builder_does_not_import_sqlite3():
+    import src.services.intelligence.citation.graph_builder as gb_mod
+
+    src = Path(gb_mod.__file__).read_text(encoding="utf-8")
+    # Allow comments containing the word, but not an actual import line
+    for line in src.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        assert "import sqlite3" not in stripped
+
+
+# ---------------------------------------------------------------------------
+# Combined-provider tag helper
+# ---------------------------------------------------------------------------
+
+
+def test_combine_providers_both_none():
+    assert CitationGraphBuilder._combine_providers("none", "none") == "none"
+
+
+def test_combine_providers_one_none_uses_other():
+    assert CitationGraphBuilder._combine_providers("none", "s2") == "s2"
+    assert CitationGraphBuilder._combine_providers("openalex", "none") == "openalex"
+
+
+def test_combine_providers_same_value():
+    assert CitationGraphBuilder._combine_providers("s2", "s2") == "s2"
+
+
+def test_combine_providers_mixed_returns_both():
+    assert CitationGraphBuilder._combine_providers("s2", "openalex") == "both"
+
+
+# ---------------------------------------------------------------------------
+# _call_provider direct tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_call_provider_out_dispatches_to_get_references(s2_client):
+    s2_client.get_references.return_value = ("seed", [], [])
+    await CitationGraphBuilder._call_provider(
+        s2_client, "X", CitationDirection.OUT, max_results=5
+    )
+    s2_client.get_references.assert_awaited_once_with("X", max_results=5)
+
+
+@pytest.mark.asyncio
+async def test_call_provider_in_dispatches_to_get_citations(s2_client):
+    s2_client.get_citations.return_value = ("seed", [], [])
+    await CitationGraphBuilder._call_provider(
+        s2_client, "X", CitationDirection.IN, max_results=5
+    )
+    s2_client.get_citations.assert_awaited_once_with("X", max_results=5)
+
+
+# ---------------------------------------------------------------------------
+# GraphBuildResult dataclass behavior
+# ---------------------------------------------------------------------------
+
+
+def test_result_is_frozen_dataclass():
+    r = GraphBuildResult(
+        seed_paper_id="x",
+        nodes_added=1,
+        edges_added=2,
+        provider_used="s2",
+    )
+    with pytest.raises((AttributeError, Exception)):
+        r.nodes_added = 99  # type: ignore[misc]
+
+
+def test_result_default_errors_is_empty_list():
+    r = GraphBuildResult(
+        seed_paper_id="x", nodes_added=0, edges_added=0, provider_used="none"
+    )
+    assert r.errors == []
+
+
+# ---------------------------------------------------------------------------
+# End-to-end persistence sanity check via real store rows
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_persisted_edges_have_cites_type_and_metadata(
+    builder, s2_client, store, temp_db
+):
+    seed = _node("s2", "seed1")
+    ref = _node("s2", "ref1")
+    s2_client.get_references.return_value = (
+        seed,
+        [ref],
+        [
+            CitationEdge(
+                citing_paper_id=seed.paper_id,
+                cited_paper_id=ref.paper_id,
+                context="see Section 3.1",
+                section="Methodology",
+                is_influential=True,
+                source="semantic_scholar",
+            )
+        ],
+    )
+
+    await builder.build_for_paper("seed1")
+
+    # Inspect raw row
+    conn = sqlite3.connect(str(temp_db))
+    try:
+        row = conn.execute(
+            "SELECT edge_type, source_id, target_id, properties " "FROM edges LIMIT 1"
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert row[0] == EdgeType.CITES.value
+    assert row[1] == seed.paper_id
+    assert row[2] == ref.paper_id
+    assert "Section 3.1" in row[3]
+    assert "Methodology" in row[3]

--- a/tests/unit/services/intelligence/citation/test_graph_builder.py
+++ b/tests/unit/services/intelligence/citation/test_graph_builder.py
@@ -14,9 +14,14 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from pydantic import ValidationError
+
 from src.services.intelligence.citation.graph_builder import (
+    BuildForPaperRequest,
     CitationGraphBuilder,
     GraphBuildResult,
+    ProviderTag,
+    _sanitize_error_msg,
 )
 from src.services.intelligence.citation.models import (
     CitationDirection,
@@ -118,26 +123,89 @@ def test_constructor_assigns_dependencies(store, s2_client, oa_client):
 
 @pytest.mark.asyncio
 async def test_build_rejects_depth_other_than_one(builder):
-    with pytest.raises(ValueError, match="depth=1 only"):
+    """Pydantic boundary validation rejects depth>1 before any provider call (#S9)."""
+    with pytest.raises(ValidationError):
         await builder.build_for_paper("paper:s2:abc", depth=2)
 
 
 @pytest.mark.asyncio
 async def test_build_rejects_empty_paper_id(builder):
-    with pytest.raises(ValueError, match="non-empty"):
+    with pytest.raises(ValidationError):
         await builder.build_for_paper("", depth=1)
 
 
 @pytest.mark.asyncio
 async def test_build_rejects_whitespace_paper_id(builder):
-    with pytest.raises(ValueError, match="non-empty"):
+    with pytest.raises(ValidationError):
         await builder.build_for_paper("   ", depth=1)
+
+
+@pytest.mark.asyncio
+async def test_build_rejects_oversized_paper_id(builder):
+    """Length cap protects URL builder downstream from megabyte payloads."""
+    with pytest.raises(ValidationError):
+        await builder.build_for_paper("a" * 257, depth=1)
+
+
+@pytest.mark.asyncio
+async def test_build_rejects_paper_id_with_url_scheme(builder):
+    """``://`` is not in the allow-list (no ``:`` followed by ``//`` is legal)."""
+    # ``://`` collapses to colon + slash + slash — all allowed individually
+    # by the pattern. The provider-side ``_normalize_*`` methods enforce
+    # the forbid-list. The builder boundary trusts the provider for that
+    # final check; here we only verify the pattern catches whitespace
+    # and other URL-injection metacharacters that survive both layers.
+    with pytest.raises(ValidationError):
+        await builder.build_for_paper("http://evil@host", depth=1)
+
+
+@pytest.mark.asyncio
+async def test_build_rejects_paper_id_with_query_string(builder):
+    with pytest.raises(ValidationError):
+        await builder.build_for_paper("abc?evil=1", depth=1)
+
+
+@pytest.mark.asyncio
+async def test_build_rejects_paper_id_with_crlf(builder):
+    with pytest.raises(ValidationError):
+        await builder.build_for_paper("abc\r\nLog-Injection: 1", depth=1)
+
+
+@pytest.mark.asyncio
+async def test_build_validation_runs_before_provider_call(
+    builder, s2_client, oa_client
+):
+    """No provider call should happen if input fails Pydantic validation."""
+    with pytest.raises(ValidationError):
+        await builder.build_for_paper("invalid space id", depth=1)
+    s2_client.get_references.assert_not_awaited()
+    oa_client.get_references.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_build_rejects_zero_max_results(builder):
     with pytest.raises(ValueError, match="max_results must be"):
         await builder.build_for_paper("paper:s2:abc", max_results=0)
+
+
+def test_build_for_paper_request_accepts_legitimate_ids():
+    """DOIs, arxiv ids, and S2 native ids all match the allow-list."""
+    BuildForPaperRequest(paper_id="10.18653/v1/2020.acl-main.703")
+    BuildForPaperRequest(paper_id="arxiv:1706.03762")
+    BuildForPaperRequest(paper_id="paper:s2:204e3073")
+    BuildForPaperRequest(paper_id="W2741809807")
+
+
+def test_build_for_paper_request_rejects_extra_fields():
+    """``extra="forbid"`` blocks unknown fields."""
+    with pytest.raises(ValidationError):
+        BuildForPaperRequest(paper_id="W1", unknown_field="x")
+
+
+def test_build_for_paper_request_default_depth_and_direction():
+    r = BuildForPaperRequest(paper_id="W1")
+    assert r.depth == 1
+    assert r.direction == CitationDirection.OUT
 
 
 # ---------------------------------------------------------------------------
@@ -677,20 +745,60 @@ def test_builder_does_not_import_sqlite3():
 
 
 def test_combine_providers_both_none():
-    assert CitationGraphBuilder._combine_providers("none", "none") == "none"
+    assert (
+        CitationGraphBuilder._combine_providers(ProviderTag.NONE, ProviderTag.NONE)
+        == ProviderTag.NONE
+    )
 
 
 def test_combine_providers_one_none_uses_other():
-    assert CitationGraphBuilder._combine_providers("none", "s2") == "s2"
-    assert CitationGraphBuilder._combine_providers("openalex", "none") == "openalex"
+    assert (
+        CitationGraphBuilder._combine_providers(ProviderTag.NONE, ProviderTag.S2)
+        == ProviderTag.S2
+    )
+    assert (
+        CitationGraphBuilder._combine_providers(ProviderTag.OPENALEX, ProviderTag.NONE)
+        == ProviderTag.OPENALEX
+    )
 
 
 def test_combine_providers_same_value():
-    assert CitationGraphBuilder._combine_providers("s2", "s2") == "s2"
+    assert (
+        CitationGraphBuilder._combine_providers(ProviderTag.S2, ProviderTag.S2)
+        == ProviderTag.S2
+    )
 
 
 def test_combine_providers_mixed_returns_both():
-    assert CitationGraphBuilder._combine_providers("s2", "openalex") == "both"
+    assert (
+        CitationGraphBuilder._combine_providers(ProviderTag.S2, ProviderTag.OPENALEX)
+        == ProviderTag.BOTH
+    )
+
+
+def test_provider_tag_string_equality_preserved():
+    """``ProviderTag(str, Enum)`` keeps existing string comparisons working."""
+    assert ProviderTag.S2 == "s2"
+    assert ProviderTag.OPENALEX == "openalex"
+    assert ProviderTag.NONE == "none"
+    assert ProviderTag.BOTH == "both"
+
+
+def test_sanitize_error_msg_strips_crlf():
+    """CRLF and other control bytes are replaced with ``?`` (#N4)."""
+    out = _sanitize_error_msg("abc\r\nX-Injected: 1")
+    assert "\r" not in out
+    assert "\n" not in out
+
+
+def test_sanitize_error_msg_caps_length():
+    out = _sanitize_error_msg("a" * 500, max_len=50)
+    assert len(out) == 50
+
+
+def test_sanitize_error_msg_passes_printable():
+    out = _sanitize_error_msg("simple message")
+    assert out == "simple message"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/intelligence/citation/test_openalex_client.py
+++ b/tests/unit/services/intelligence/citation/test_openalex_client.py
@@ -232,8 +232,68 @@ def test_normalize_handles_bare_id():
     assert OpenAlexCitationClient._normalize_work_id("W123") == "W123"
 
 
-def test_normalize_handles_empty_string():
-    assert OpenAlexCitationClient._normalize_work_id("") == ""
+def test_normalize_rejects_empty_string():
+    with pytest.raises(ValueError, match="Invalid OpenAlex work_id"):
+        OpenAlexCitationClient._normalize_work_id("")
+
+
+def test_normalize_rejects_traversal():
+    with pytest.raises(ValueError, match="Invalid OpenAlex work_id"):
+        OpenAlexCitationClient._normalize_work_id("W123/../../admin")
+
+
+def test_normalize_rejects_url_scheme_smuggled():
+    # The rsplit defang strips the trailing segment, so this id stays
+    # ``W1`` and would normally pass — that's defense in depth: the
+    # forbid-list catches payloads that survive defang. We test the
+    # path-traversal payload above; the URL-scheme payload after
+    # defang is verified by ``test_normalize_strips_url_prefix``.
+    # Here we ensure that a payload WITHOUT a slash but with an
+    # embedded scheme still gets rejected.
+    with pytest.raises(ValueError, match="Invalid OpenAlex work_id"):
+        OpenAlexCitationClient._normalize_work_id("W1://evil")
+
+
+def test_normalize_rejects_query_string():
+    with pytest.raises(ValueError, match="Invalid OpenAlex work_id"):
+        OpenAlexCitationClient._normalize_work_id("W1?evil=1")
+
+
+def test_normalize_rejects_fragment():
+    with pytest.raises(ValueError, match="Invalid OpenAlex work_id"):
+        OpenAlexCitationClient._normalize_work_id("W1#frag")
+
+
+def test_normalize_rejects_oversized():
+    with pytest.raises(ValueError, match="Invalid OpenAlex work_id"):
+        OpenAlexCitationClient._normalize_work_id("W" + "1" * 64)
+
+
+def test_normalize_rejects_lowercase_w():
+    with pytest.raises(ValueError, match="Invalid OpenAlex work_id"):
+        OpenAlexCitationClient._normalize_work_id("w123")
+
+
+def test_normalize_rejects_non_digit_suffix():
+    with pytest.raises(ValueError, match="Invalid OpenAlex work_id"):
+        OpenAlexCitationClient._normalize_work_id("Wabc")
+
+
+def test_normalize_accepts_canonical_W_id():
+    assert OpenAlexCitationClient._normalize_work_id("W12345") == "W12345"
+
+
+def test_normalize_strips_openalex_prefix():
+    assert (
+        OpenAlexCitationClient._normalize_work_id("https://openalex.org/W2741809807")
+        == "W2741809807"
+    )
+
+
+def test_normalize_rejects_only_slash():
+    # ``rsplit("/", 1)[-1]`` returns "" → length-zero rejection
+    with pytest.raises(ValueError, match="Invalid OpenAlex work_id"):
+        OpenAlexCitationClient._normalize_work_id("/")
 
 
 def test_extract_id_returns_none_for_missing_id():
@@ -243,6 +303,11 @@ def test_extract_id_returns_none_for_missing_id():
 def test_extract_id_returns_normalized_id():
     payload = {"id": "https://openalex.org/W42"}
     assert OpenAlexCitationClient._extract_id(payload) == "W42"
+
+
+def test_extract_id_returns_none_for_invalid_id():
+    payload = {"id": "https://openalex.org/../admin"}
+    assert OpenAlexCitationClient._extract_id(payload) is None
 
 
 # ---------------------------------------------------------------------------
@@ -458,6 +523,30 @@ async def test_get_references_referenced_works_field_missing(client):
         _, related, _ = await client.get_references("W1", max_results=5)
 
     assert related == []
+
+
+@pytest.mark.asyncio
+async def test_get_references_skips_invalid_referenced_work_url(client):
+    """Hostile/malformed entries inside ``referenced_works`` are dropped
+    silently so a single bad reference does not poison the batch (#C1)."""
+    seed = dict(
+        SEED_PAYLOAD,
+        referenced_works=[
+            "https://openalex.org/../admin",  # traversal — rejected
+            "https://openalex.org/W101",
+        ],
+    )
+
+    async def fake_http_get(url, params):
+        if url.endswith("/works/W1"):
+            return seed
+        return {"results": [_hydrated_ref("W101")]}
+
+    with patch.object(client, "_http_get", side_effect=fake_http_get):
+        _, related, _ = await client.get_references("W1", max_results=5)
+
+    assert len(related) == 1
+    assert related[0].external_ids["openalex"] == "W101"
 
 
 @pytest.mark.asyncio
@@ -860,11 +949,39 @@ def test_serialize_then_deserialize_roundtrip():
 # ---------------------------------------------------------------------------
 
 
-def _mock_aiohttp_response(status, json_body=None, text_body="oops"):
+def _mock_aiohttp_response(
+    status,
+    json_body=None,
+    text_body="oops",
+    headers=None,
+    content_length=None,
+    raw_body=None,
+):
+    """Build an async-context-manager-compatible mocked response.
+
+    ``json_body`` is the dict the production code is expected to receive
+    after ``json.loads`` of the streamed body. We serialise it to bytes
+    and hand them out via the mocked ``response.content.read`` (the
+    production code now reads bytes itself rather than calling
+    ``.json()`` directly — see #C3).
+
+    ``raw_body`` lets a caller pass exact bytes (e.g. to simulate an
+    oversized chunked-transfer payload that exceeds the cap).
+    """
+    import json as _json
+
     resp = MagicMock()
     resp.status = status
     resp.json = AsyncMock(return_value=json_body)
     resp.text = AsyncMock(return_value=text_body)
+    resp.headers = headers if headers is not None else {}
+    resp.content_length = content_length
+
+    if raw_body is None:
+        raw_body = b"" if json_body is None else _json.dumps(json_body).encode("utf-8")
+    content = MagicMock()
+    content.read = AsyncMock(return_value=raw_body)
+    resp.content = content
 
     cm = MagicMock()
     cm.__aenter__ = AsyncMock(return_value=resp)
@@ -964,6 +1081,236 @@ async def test_http_get_wraps_timeout_as_api_error(client):
     with patch("aiohttp.ClientSession", return_value=session_cm):
         with pytest.raises(APIError, match="timed out"):
             await client._http_get("http://x", {})
+
+
+# ---------------------------------------------------------------------------
+# #C2 — redirect handling (allow_redirects=False)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [301, 302, 303, 307, 308])
+async def test_http_get_rejects_redirect(client, status):
+    cm = _mock_aiohttp_response(
+        status,
+        text_body="moved",
+        headers={"Location": "https://attacker.example/leak"},
+    )
+    p, _ = _patch_session(cm)
+    with p:
+        with pytest.raises(APIError, match="unexpected redirect"):
+            await client._http_get("http://x", {})
+
+
+@pytest.mark.asyncio
+async def test_http_get_passes_allow_redirects_false(client):
+    cm = _mock_aiohttp_response(200, json_body={})
+    p, session = _patch_session(cm)
+    with p:
+        await client._http_get("http://x", {})
+    _, kwargs = session.get.call_args
+    assert kwargs["allow_redirects"] is False
+
+
+@pytest.mark.asyncio
+async def test_http_get_redirect_message_neutralises_crlf(client):
+    """Hostile Location header bytes must not inject newlines into our message."""
+    cm = _mock_aiohttp_response(
+        302,
+        text_body="moved",
+        headers={"Location": "evil\r\nX-Injected: 1"},
+    )
+    p, _ = _patch_session(cm)
+    with p:
+        with pytest.raises(APIError) as exc_info:
+            await client._http_get("http://x", {})
+    msg = str(exc_info.value)
+    # ``repr`` renders \r\n as the literal backslash-r-backslash-n,
+    # so the raw control characters must not appear in the message.
+    assert "\r" not in msg
+    assert "\n" not in msg
+    assert "\\r\\n" in msg
+
+
+@pytest.mark.asyncio
+async def test_http_get_redirect_message_caps_location_length(client):
+    long_loc = "X" * 500
+    cm = _mock_aiohttp_response(302, headers={"Location": long_loc})
+    p, _ = _patch_session(cm)
+    with p:
+        with pytest.raises(APIError) as exc_info:
+            await client._http_get("http://x", {})
+    msg = str(exc_info.value)
+    # 200-char cap on the slice + repr quoting overhead
+    assert "X" * 201 not in msg
+
+
+# ---------------------------------------------------------------------------
+# #C3 — response size cap
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_http_get_rejects_large_advertised_content_length(client):
+    cm = _mock_aiohttp_response(
+        200,
+        json_body={"ok": True},
+        content_length=26 * 1024 * 1024,
+    )
+    p, _ = _patch_session(cm)
+    with p:
+        with pytest.raises(APIError, match="response too large"):
+            await client._http_get("http://x", {})
+
+
+@pytest.mark.asyncio
+async def test_http_get_rejects_oversized_streamed_body(client):
+    # Server lies about content_length (or omits it), but streams more
+    # bytes than the cap. We must reject without calling json.loads.
+    huge = b"{" + (b"x" * (25 * 1024 * 1024 + 1))
+    cm = _mock_aiohttp_response(200, raw_body=huge, content_length=None)
+    p, _ = _patch_session(cm)
+    with p:
+        with pytest.raises(APIError, match="exceeded"):
+            await client._http_get("http://x", {})
+
+
+@pytest.mark.asyncio
+async def test_http_get_accepts_body_within_cap(client):
+    cm = _mock_aiohttp_response(200, json_body={"ok": True}, content_length=100)
+    p, _ = _patch_session(cm)
+    with p:
+        body = await client._http_get("http://x", {})
+    assert body == {"ok": True}
+
+
+# ---------------------------------------------------------------------------
+# #C4 — Retry-After parsing on 429
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_429_with_numeric_retry_after(client):
+    cm = _mock_aiohttp_response(429, headers={"Retry-After": "120"})
+    p, _ = _patch_session(cm)
+    with p:
+        with pytest.raises(RateLimitError) as exc_info:
+            await client._http_get("http://x", {})
+    assert exc_info.value.retry_after == pytest.approx(120.0)
+
+
+@pytest.mark.asyncio
+async def test_429_with_httpdate_retry_after(client):
+    # Date in the future → positive delta clamped to >= 0
+    cm = _mock_aiohttp_response(
+        429,
+        headers={"Retry-After": "Wed, 21 Oct 2099 07:28:00 GMT"},
+    )
+    p, _ = _patch_session(cm)
+    with p:
+        with pytest.raises(RateLimitError) as exc_info:
+            await client._http_get("http://x", {})
+    assert exc_info.value.retry_after is not None
+    assert exc_info.value.retry_after > 0
+
+
+@pytest.mark.asyncio
+async def test_429_with_httpdate_no_timezone_treated_as_utc(client):
+    # No tz token; ``parsedate_to_datetime`` returns naive datetime.
+    # The client must coerce to UTC instead of raising TypeError on
+    # subtraction.
+    cm = _mock_aiohttp_response(
+        429,
+        headers={"Retry-After": "Wed, 21 Oct 2099 07:28:00"},
+    )
+    p, _ = _patch_session(cm)
+    with p:
+        with pytest.raises(RateLimitError) as exc_info:
+            await client._http_get("http://x", {})
+    assert exc_info.value.retry_after is not None
+
+
+@pytest.mark.asyncio
+async def test_429_without_retry_after(client):
+    cm = _mock_aiohttp_response(429, headers={})
+    p, _ = _patch_session(cm)
+    with p:
+        with pytest.raises(RateLimitError) as exc_info:
+            await client._http_get("http://x", {})
+    assert exc_info.value.retry_after is None
+
+
+@pytest.mark.asyncio
+async def test_429_with_unparsable_retry_after(client):
+    cm = _mock_aiohttp_response(429, headers={"Retry-After": "not-a-date"})
+    p, _ = _patch_session(cm)
+    with p:
+        with pytest.raises(RateLimitError) as exc_info:
+            await client._http_get("http://x", {})
+    assert exc_info.value.retry_after is None
+
+
+@pytest.mark.asyncio
+async def test_429_with_negative_retry_after_clamped(client):
+    cm = _mock_aiohttp_response(429, headers={"Retry-After": "-30"})
+    p, _ = _patch_session(cm)
+    with p:
+        with pytest.raises(RateLimitError) as exc_info:
+            await client._http_get("http://x", {})
+    assert exc_info.value.retry_after == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_429_with_past_httpdate_clamped(client):
+    cm = _mock_aiohttp_response(
+        429, headers={"Retry-After": "Wed, 21 Oct 1970 07:28:00 GMT"}
+    )
+    p, _ = _patch_session(cm)
+    with p:
+        with pytest.raises(RateLimitError) as exc_info:
+            await client._http_get("http://x", {})
+    assert exc_info.value.retry_after == pytest.approx(0.0)
+
+
+def test_parse_retry_after_none_returns_none():
+    assert OpenAlexCitationClient._parse_retry_after(None) is None
+
+
+def test_parse_retry_after_empty_returns_none():
+    assert OpenAlexCitationClient._parse_retry_after("   ") is None
+
+
+# ---------------------------------------------------------------------------
+# #C1 — end-to-end: get_references quotes/validates the work_id in the URL
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_references_rejects_hostile_paper_id(client):
+    """Crafted traversal payload must be rejected before any HTTP call."""
+    # ``_normalize_work_id`` raises before we ever build a URL.
+    with pytest.raises(ValueError, match="Invalid OpenAlex work_id"):
+        await client.get_references("../admin")
+
+
+@pytest.mark.asyncio
+async def test_get_references_url_uses_validated_id(client):
+    captured: list[str] = []
+
+    async def fake_http_get(url, params):
+        captured.append(url)
+        if url.endswith("/works/W1"):
+            return SEED_PAYLOAD
+        return {"results": [_hydrated_ref("W101")]}
+
+    with patch.object(client, "_http_get", side_effect=fake_http_get):
+        await client.get_references("W1", max_results=5)
+
+    # No suspicious characters in the URL we built.
+    assert any(u.endswith("/works/W1") for u in captured)
+    # No traversal smuggled in
+    for u in captured:
+        assert ".." not in u
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/intelligence/citation/test_openalex_client.py
+++ b/tests/unit/services/intelligence/citation/test_openalex_client.py
@@ -118,7 +118,14 @@ def test_init_explicit_email_overrides_env(monkeypatch):
     assert c.polite_email == "explicit@example.com"
 
 
-def test_init_no_email_logs_warning_once(monkeypatch, caplog):
+def test_init_no_email_logs_warning_once(monkeypatch, capsys):
+    """Pin the warning is emitted once and only once across constructor
+    calls in the same process — the warning latch is module-level (#N2).
+
+    We use ``capsys`` rather than ``caplog`` because structlog renders
+    to stdout via its default configuration; the stdlib caplog handler
+    sees nothing.
+    """
     monkeypatch.delenv("OPENALEX_POLITE_EMAIL", raising=False)
     _reset_polite_email_warning()
     # First instance should log the warning.
@@ -127,6 +134,12 @@ def test_init_no_email_logs_warning_once(monkeypatch, caplog):
     c2 = OpenAlexCitationClient(polite_email=None)
     assert c1.polite_email is None
     assert c2.polite_email is None
+
+    captured = capsys.readouterr()
+    # Exactly one polite-pool-disabled warning fired across the two
+    # constructor calls — the second call hits the latch.
+    occurrences = captured.out.count("openalex_polite_pool_disabled")
+    assert occurrences == 1, captured.out
 
 
 def test_init_default_rate_limiter_with_email():
@@ -1311,6 +1324,97 @@ async def test_get_references_url_uses_validated_id(client):
     # No traversal smuggled in
     for u in captured:
         assert ".." not in u
+
+
+# ---------------------------------------------------------------------------
+# #S7 — polite email never appears in logs (aiohttp.client muted to INFO)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_polite_email_never_logged_during_get_references(
+    fast_limiter, monkeypatch, capsys, caplog
+):
+    """Pin that the polite email never reaches stdout (structlog) or the
+    stdlib caplog at any level — the client mutes ``aiohttp.client``
+    DEBUG to INFO at module import time so transport-level URL records
+    cannot leak the ``mailto`` query parameter (#S7).
+    """
+    import logging
+
+    monkeypatch.setenv("OPENALEX_POLITE_EMAIL", "secret-mailto@example.com")
+    c = OpenAlexCitationClient(
+        polite_email="secret-mailto@example.com",
+        rate_limiter=fast_limiter,
+        cache_dir=None,
+    )
+
+    async def fake_http_get(url, params):
+        if url.endswith("/works/W1"):
+            return SEED_PAYLOAD
+        return {"results": [_hydrated_ref("W101")]}
+
+    with caplog.at_level(logging.DEBUG):
+        with patch.object(c, "_http_get", side_effect=fake_http_get):
+            await c.get_references("W1", max_results=5)
+
+    captured = capsys.readouterr()
+    assert "secret-mailto@example.com" not in captured.out
+    assert "secret-mailto@example.com" not in captured.err
+    for record in caplog.records:
+        assert "secret-mailto@example.com" not in record.getMessage()
+
+
+def test_aiohttp_client_logger_is_muted_to_info():
+    """The module-level aiohttp.client logger floor must be INFO so its
+    transport-level DEBUG URL records (with ``mailto`` query param) are
+    suppressed (#S7)."""
+    import logging
+
+    # Triggers module import side-effect if not already loaded.
+    import src.services.intelligence.citation.openalex_client  # noqa: F401
+
+    assert logging.getLogger("aiohttp.client").level <= logging.INFO
+
+
+# ---------------------------------------------------------------------------
+# #S8 — cache TTL expiration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cache_entry_expires_after_ttl(tmp_path, fast_limiter):
+    """A cache entry written with a short TTL must miss after expiration,
+    forcing a fresh HTTP fetch (#S8)."""
+    import time
+
+    c = OpenAlexCitationClient(
+        polite_email="x@y.z",
+        rate_limiter=fast_limiter,
+        cache_dir=tmp_path,
+        cache_ttl_seconds=1,
+    )
+
+    call_count = {"n": 0}
+
+    async def fake_http_get(url, params):
+        call_count["n"] += 1
+        if url.endswith("/works/W1"):
+            return SEED_PAYLOAD
+        return {"results": [_hydrated_ref("W101")]}
+
+    with patch.object(c, "_http_get", side_effect=fake_http_get):
+        await c.get_references("W1", max_results=5)
+        first_count = call_count["n"]
+        # Sleep past the TTL so the cache entry expires.
+        time.sleep(1.5)
+        await c.get_references("W1", max_results=5)
+
+    # If the entry had survived, ``_http_get`` would not have been
+    # invoked again — the fact that the count went up confirms the
+    # entry expired and we re-fetched.
+    assert call_count["n"] > first_count
+    c.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/intelligence/citation/test_openalex_client.py
+++ b/tests/unit/services/intelligence/citation/test_openalex_client.py
@@ -1,0 +1,1002 @@
+"""Tests for OpenAlexCitationClient (Milestone 9.2 — Week 1.5).
+
+All HTTP is mocked. No live API calls.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.services.intelligence.citation.models import (
+    CitationEdge,
+    CitationNode,
+    make_paper_node_id,
+)
+from src.services.intelligence.citation.openalex_client import (
+    OpenAlexCitationClient,
+    _reset_polite_email_warning,
+)
+from src.services.providers.base import APIError, RateLimitError
+from src.utils.rate_limiter import RateLimiter
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+SEED_PAYLOAD = {
+    "id": "https://openalex.org/W1",
+    "title": "Seed Work",
+    "publication_year": 2020,
+    "cited_by_count": 42,
+    "referenced_works_count": 3,
+    "referenced_works": [
+        "https://openalex.org/W101",
+        "https://openalex.org/W102",
+        "https://openalex.org/W103",
+    ],
+    "ids": {
+        "openalex": "https://openalex.org/W1",
+        "doi": "https://doi.org/10.1/seed",
+        "mag": "12345",
+    },
+    "doi": "https://doi.org/10.1/seed",
+}
+
+
+def _hydrated_ref(work_id: str = "W101", **overrides):
+    body = {
+        "id": f"https://openalex.org/{work_id}",
+        "title": f"Ref {work_id}",
+        "publication_year": 2019,
+        "cited_by_count": 10,
+        "referenced_works_count": 4,
+        "ids": {
+            "openalex": f"https://openalex.org/{work_id}",
+            "doi": f"https://doi.org/10.1/{work_id}",
+        },
+        "doi": f"https://doi.org/10.1/{work_id}",
+    }
+    body.update(overrides)
+    return body
+
+
+def _citing_payload(work_id: str = "W201", **overrides):
+    body = {
+        "id": f"https://openalex.org/{work_id}",
+        "title": f"Cite {work_id}",
+        "publication_year": 2022,
+        "cited_by_count": 1,
+        "referenced_works_count": 8,
+        "ids": {"openalex": f"https://openalex.org/{work_id}"},
+    }
+    body.update(overrides)
+    return body
+
+
+@pytest.fixture(autouse=True)
+def _reset_warning_latch():
+    """Reset the once-per-process polite-email warning before each test."""
+    _reset_polite_email_warning()
+
+
+@pytest.fixture
+def fast_limiter():
+    return RateLimiter(requests_per_minute=600000, burst_size=1000)
+
+
+@pytest.fixture
+def client(fast_limiter, monkeypatch):
+    """Default test client: no cache, polite email set to skip warning noise."""
+    monkeypatch.delenv("ARISP_CITATION_CACHE_DIR", raising=False)
+    monkeypatch.setenv("OPENALEX_POLITE_EMAIL", "test@example.com")
+    return OpenAlexCitationClient(
+        polite_email="test@example.com",
+        rate_limiter=fast_limiter,
+        cache_dir=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Constructor
+# ---------------------------------------------------------------------------
+
+
+def test_init_uses_env_var_when_polite_email_omitted(monkeypatch):
+    monkeypatch.setenv("OPENALEX_POLITE_EMAIL", "from-env@example.com")
+    monkeypatch.delenv("ARISP_CITATION_CACHE_DIR", raising=False)
+    c = OpenAlexCitationClient()
+    assert c.polite_email == "from-env@example.com"
+
+
+def test_init_explicit_email_overrides_env(monkeypatch):
+    monkeypatch.setenv("OPENALEX_POLITE_EMAIL", "from-env@example.com")
+    c = OpenAlexCitationClient(polite_email="explicit@example.com")
+    assert c.polite_email == "explicit@example.com"
+
+
+def test_init_no_email_logs_warning_once(monkeypatch, caplog):
+    monkeypatch.delenv("OPENALEX_POLITE_EMAIL", raising=False)
+    _reset_polite_email_warning()
+    # First instance should log the warning.
+    c1 = OpenAlexCitationClient(polite_email=None)
+    # Second instance must not re-warn (the latch is process-wide).
+    c2 = OpenAlexCitationClient(polite_email=None)
+    assert c1.polite_email is None
+    assert c2.polite_email is None
+
+
+def test_init_default_rate_limiter_with_email():
+    c = OpenAlexCitationClient(polite_email="x@y.z")
+    # 60 req/min → rate = 1.0 req/sec
+    assert c.rate_limiter.rate == pytest.approx(60 / 60.0)
+
+
+def test_init_default_rate_limiter_without_email(monkeypatch):
+    monkeypatch.delenv("OPENALEX_POLITE_EMAIL", raising=False)
+    c = OpenAlexCitationClient(polite_email=None)
+    # 20 req/min → rate = 20/60
+    assert c.rate_limiter.rate == pytest.approx(20 / 60.0)
+
+
+def test_init_uses_provided_rate_limiter(fast_limiter):
+    c = OpenAlexCitationClient(polite_email="x@y.z", rate_limiter=fast_limiter)
+    assert c.rate_limiter is fast_limiter
+
+
+def test_init_no_cache_when_cache_dir_none_and_no_env(monkeypatch):
+    monkeypatch.delenv("ARISP_CITATION_CACHE_DIR", raising=False)
+    c = OpenAlexCitationClient(polite_email="x@y.z", cache_dir=None)
+    assert c._cache is None
+
+
+def test_init_uses_cache_dir_from_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("ARISP_CITATION_CACHE_DIR", str(tmp_path))
+    c = OpenAlexCitationClient(polite_email="x@y.z", cache_dir=None)
+    assert c._cache is not None
+    assert (tmp_path / "openalex").exists()
+    c.close()
+
+
+def test_init_cache_dir_explicit_path(tmp_path):
+    c = OpenAlexCitationClient(polite_email="x@y.z", cache_dir=tmp_path)
+    assert c._cache is not None
+    assert (tmp_path / "openalex").exists()
+    c.close()
+
+
+def test_init_cache_dir_explicit_str(tmp_path):
+    c = OpenAlexCitationClient(polite_email="x@y.z", cache_dir=str(tmp_path))
+    assert c._cache is not None
+    c.close()
+
+
+def test_close_releases_cache_handle(tmp_path):
+    c = OpenAlexCitationClient(polite_email="x@y.z", cache_dir=tmp_path)
+    assert c._cache is not None
+    c.close()
+    assert c._cache is None
+
+
+def test_close_is_safe_when_no_cache(client):
+    client.close()
+    assert client._cache is None
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_references_rejects_empty_paper_id(client):
+    with pytest.raises(ValueError, match="non-empty"):
+        await client.get_references("")
+
+
+@pytest.mark.asyncio
+async def test_get_references_rejects_whitespace_paper_id(client):
+    with pytest.raises(ValueError, match="non-empty"):
+        await client.get_references("   ")
+
+
+@pytest.mark.asyncio
+async def test_get_references_rejects_zero_max_results(client):
+    with pytest.raises(ValueError, match="max_results must be"):
+        await client.get_references("W1", max_results=0)
+
+
+@pytest.mark.asyncio
+async def test_internal_fetch_rejects_unknown_endpoint(client):
+    with pytest.raises(ValueError, match="Unsupported endpoint"):
+        await client._fetch_relationships(
+            endpoint="bogus", paper_id="W1", max_results=5
+        )
+
+
+# ---------------------------------------------------------------------------
+# normalize_work_id / extract_id helpers
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_strips_url_prefix():
+    assert (
+        OpenAlexCitationClient._normalize_work_id("https://openalex.org/W123") == "W123"
+    )
+
+
+def test_normalize_handles_bare_id():
+    assert OpenAlexCitationClient._normalize_work_id("W123") == "W123"
+
+
+def test_normalize_handles_empty_string():
+    assert OpenAlexCitationClient._normalize_work_id("") == ""
+
+
+def test_extract_id_returns_none_for_missing_id():
+    assert OpenAlexCitationClient._extract_id({}) is None
+
+
+def test_extract_id_returns_normalized_id():
+    payload = {"id": "https://openalex.org/W42"}
+    assert OpenAlexCitationClient._extract_id(payload) == "W42"
+
+
+# ---------------------------------------------------------------------------
+# strip_id_prefix
+# ---------------------------------------------------------------------------
+
+
+def test_strip_id_prefix_removes_doi_prefix():
+    assert (
+        OpenAlexCitationClient._strip_id_prefix("doi", "https://doi.org/10.1/x")
+        == "10.1/x"
+    )
+
+
+def test_strip_id_prefix_passes_through_unknown_key():
+    assert OpenAlexCitationClient._strip_id_prefix("custom", "value") == "value"
+
+
+def test_strip_id_prefix_passes_through_when_prefix_missing():
+    assert OpenAlexCitationClient._strip_id_prefix("doi", "10.1/x") == "10.1/x"
+
+
+def test_strip_id_prefix_pmid():
+    assert (
+        OpenAlexCitationClient._strip_id_prefix(
+            "pmid", "https://pubmed.ncbi.nlm.nih.gov/12345"
+        )
+        == "12345"
+    )
+
+
+# ---------------------------------------------------------------------------
+# payload_to_node
+# ---------------------------------------------------------------------------
+
+
+def test_payload_to_node_full_payload(client):
+    node = client._payload_to_node(SEED_PAYLOAD)
+    assert node.paper_id == make_paper_node_id("openalex", "W1")
+    assert node.title == "Seed Work"
+    assert node.year == 2020
+    assert node.citation_count == 42
+    assert node.reference_count == 3
+    assert node.external_ids["openalex"] == "W1"
+    assert node.external_ids["doi"] == "10.1/seed"
+    assert node.external_ids["mag"] == "12345"
+
+
+def test_payload_to_node_missing_id_raises(client):
+    with pytest.raises(KeyError, match="missing id"):
+        client._payload_to_node({"title": "no id"})
+
+
+def test_payload_to_node_missing_title_uses_unknown(client):
+    payload = {"id": "https://openalex.org/W42"}
+    node = client._payload_to_node(payload)
+    assert node.title == "Unknown Title"
+    assert node.year is None
+    assert node.citation_count == 0
+    assert node.reference_count == 0
+    assert node.external_ids == {"openalex": "W42"}
+
+
+def test_payload_to_node_handles_empty_ids_dict(client):
+    payload = {"id": "https://openalex.org/W42", "title": "T", "ids": {}}
+    node = client._payload_to_node(payload)
+    assert node.external_ids == {"openalex": "W42"}
+
+
+def test_payload_to_node_skips_none_id_value(client):
+    payload = {
+        "id": "https://openalex.org/W42",
+        "title": "T",
+        "ids": {"doi": None, "mag": ""},
+    }
+    node = client._payload_to_node(payload)
+    assert node.external_ids == {"openalex": "W42"}
+
+
+def test_payload_to_node_skips_non_string_id_value(client):
+    payload = {
+        "id": "https://openalex.org/W42",
+        "title": "T",
+        "ids": {"mag": 12345},  # int, not str
+    }
+    node = client._payload_to_node(payload)
+    assert "mag" not in node.external_ids
+
+
+def test_payload_to_node_uses_top_level_doi_when_ids_doi_missing(client):
+    payload = {
+        "id": "https://openalex.org/W42",
+        "title": "T",
+        "ids": {"openalex": "https://openalex.org/W42"},
+        "doi": "https://doi.org/10.1/top",
+    }
+    node = client._payload_to_node(payload)
+    assert node.external_ids["doi"] == "10.1/top"
+
+
+def test_payload_to_node_top_level_doi_ignored_when_not_string(client):
+    payload = {
+        "id": "https://openalex.org/W42",
+        "title": "T",
+        "ids": {},
+        "doi": None,
+    }
+    node = client._payload_to_node(payload)
+    assert "doi" not in node.external_ids
+
+
+def test_payload_to_node_top_level_doi_skipped_when_ids_doi_present(client):
+    payload = {
+        "id": "https://openalex.org/W42",
+        "title": "T",
+        "ids": {"doi": "https://doi.org/10.1/from-ids"},
+        "doi": "https://doi.org/10.1/from-top",
+    }
+    node = client._payload_to_node(payload)
+    # The ids.doi entry wins
+    assert node.external_ids["doi"] == "10.1/from-ids"
+
+
+# ---------------------------------------------------------------------------
+# Happy path: get_references
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_references_happy_path(client):
+    calls: list[str] = []
+
+    async def fake_http_get(url, params):
+        calls.append(url)
+        if url.endswith("/works/W1"):
+            return SEED_PAYLOAD
+        if url.endswith("/works"):
+            # Filter contains the IDs from referenced_works
+            assert "openalex:" in params["filter"]
+            return {
+                "results": [
+                    _hydrated_ref("W101"),
+                    _hydrated_ref("W102"),
+                    _hydrated_ref("W103"),
+                ]
+            }
+        raise AssertionError(f"unexpected url {url}")
+
+    with patch.object(client, "_http_get", side_effect=fake_http_get):
+        seed, related, edges = await client.get_references("W1", max_results=10)
+
+    assert seed.paper_id == make_paper_node_id("openalex", "W1")
+    assert seed.title == "Seed Work"
+    assert seed.year == 2020
+    assert seed.citation_count == 42
+    assert seed.reference_count == 3
+    assert seed.external_ids["doi"] == "10.1/seed"
+
+    assert len(related) == 3
+    assert {n.title for n in related} == {"Ref W101", "Ref W102", "Ref W103"}
+
+    assert len(edges) == 3
+    for e in edges:
+        assert e.citing_paper_id == seed.paper_id
+        assert e.source == "openalex"
+        # OpenAlex provides no per-citation context / influential signal
+        assert e.is_influential is None
+        assert e.context is None
+        assert e.section is None
+
+
+@pytest.mark.asyncio
+async def test_get_references_accepts_full_url_paper_id(client):
+    async def fake_http_get(url, params):
+        if url.endswith("/works/W1"):
+            return SEED_PAYLOAD
+        return {"results": [_hydrated_ref("W101")]}
+
+    with patch.object(client, "_http_get", side_effect=fake_http_get):
+        seed, _, _ = await client.get_references(
+            "https://openalex.org/W1", max_results=5
+        )
+
+    assert seed.paper_id == make_paper_node_id("openalex", "W1")
+
+
+@pytest.mark.asyncio
+async def test_get_references_no_referenced_works(client):
+    seed = dict(SEED_PAYLOAD, referenced_works=[], referenced_works_count=0)
+
+    async def fake_http_get(url, params):
+        if url.endswith("/works/W1"):
+            return seed
+        raise AssertionError(f"unexpected url {url}: should not hydrate")
+
+    with patch.object(client, "_http_get", side_effect=fake_http_get):
+        _, related, edges = await client.get_references("W1", max_results=5)
+
+    assert related == []
+    assert edges == []
+
+
+@pytest.mark.asyncio
+async def test_get_references_referenced_works_field_missing(client):
+    seed = {k: v for k, v in SEED_PAYLOAD.items() if k != "referenced_works"}
+
+    async def fake_http_get(url, params):
+        if url.endswith("/works/W1"):
+            return seed
+        raise AssertionError(f"unexpected url {url}: should not hydrate")
+
+    with patch.object(client, "_http_get", side_effect=fake_http_get):
+        _, related, _ = await client.get_references("W1", max_results=5)
+
+    assert related == []
+
+
+@pytest.mark.asyncio
+async def test_get_references_filters_falsy_urls(client):
+    seed = dict(SEED_PAYLOAD, referenced_works=[None, "", "https://openalex.org/W101"])
+
+    async def fake_http_get(url, params):
+        if url.endswith("/works/W1"):
+            return seed
+        return {"results": [_hydrated_ref("W101")]}
+
+    with patch.object(client, "_http_get", side_effect=fake_http_get):
+        _, related, _ = await client.get_references("W1", max_results=5)
+
+    assert len(related) == 1
+    assert related[0].external_ids["openalex"] == "W101"
+
+
+@pytest.mark.asyncio
+async def test_get_references_caps_at_max_results(client):
+    # Seed has 3 referenced_works but we cap at 2
+    async def fake_http_get(url, params):
+        if url.endswith("/works/W1"):
+            return SEED_PAYLOAD
+        # Verify the chunk only contains 2 IDs
+        assert params["filter"].count("|") == 1
+        return {
+            "results": [_hydrated_ref("W101"), _hydrated_ref("W102")],
+        }
+
+    with patch.object(client, "_http_get", side_effect=fake_http_get):
+        _, related, edges = await client.get_references("W1", max_results=2)
+
+    assert len(related) == 2
+    assert len(edges) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_references_preserves_input_order(client):
+    """Hydrated payloads may come back in any order; client must reorder."""
+
+    async def fake_http_get(url, params):
+        if url.endswith("/works/W1"):
+            return SEED_PAYLOAD
+        # Return in reverse order
+        return {
+            "results": [
+                _hydrated_ref("W103"),
+                _hydrated_ref("W101"),
+                _hydrated_ref("W102"),
+            ]
+        }
+
+    with patch.object(client, "_http_get", side_effect=fake_http_get):
+        _, related, _ = await client.get_references("W1", max_results=10)
+
+    assert [n.external_ids["openalex"] for n in related] == ["W101", "W102", "W103"]
+
+
+@pytest.mark.asyncio
+async def test_get_references_drops_missing_hydrations(client):
+    """If hydration omits a referenced ID, we drop it (no node, no edge)."""
+
+    async def fake_http_get(url, params):
+        if url.endswith("/works/W1"):
+            return SEED_PAYLOAD
+        # Return only one of three
+        return {"results": [_hydrated_ref("W102")]}
+
+    with patch.object(client, "_http_get", side_effect=fake_http_get):
+        _, related, edges = await client.get_references("W1", max_results=10)
+
+    assert len(related) == 1
+    assert related[0].external_ids["openalex"] == "W102"
+    assert len(edges) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_references_chunks_large_id_list(client):
+    # 75 references → 50-id chunk + 25-id chunk = 2 hydration calls
+    seed = dict(
+        SEED_PAYLOAD,
+        referenced_works=[f"https://openalex.org/W{i}" for i in range(1000, 1075)],
+        referenced_works_count=75,
+    )
+    chunk_calls = {"n": 0}
+
+    async def fake_http_get(url, params):
+        if url.endswith("/works/W1"):
+            return seed
+        chunk_calls["n"] += 1
+        ids = params["filter"].split(":", 1)[1].split("|")
+        return {"results": [_hydrated_ref(wid) for wid in ids]}
+
+    with patch.object(client, "_http_get", side_effect=fake_http_get):
+        _, related, _ = await client.get_references("W1", max_results=75)
+
+    assert chunk_calls["n"] == 2
+    assert len(related) == 75
+
+
+@pytest.mark.asyncio
+async def test_get_references_skips_invalid_hydrated_payload(client):
+    async def fake_http_get(url, params):
+        if url.endswith("/works/W1"):
+            return SEED_PAYLOAD
+        # The Pydantic CitationNode validator rejects year < 1800, so we
+        # emit a clearly-invalid year on one entry to drive the
+        # try/except (ValueError) skip branch in _fetch_relationships.
+        bad = _hydrated_ref("W101")
+        bad["publication_year"] = 1500
+        return {"results": [bad, _hydrated_ref("W102"), _hydrated_ref("W103")]}
+
+    with patch.object(client, "_http_get", side_effect=fake_http_get):
+        _, related, edges = await client.get_references("W1", max_results=10)
+
+    # W101 was skipped due to validation failure; W102 + W103 made it
+    assert len(related) == 2
+    ids = {n.external_ids["openalex"] for n in related}
+    assert ids == {"W102", "W103"}
+    assert len(edges) == 2
+
+
+# ---------------------------------------------------------------------------
+# Happy path: get_citations
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_citations_happy_path(client):
+    async def fake_http_get(url, params):
+        if url.endswith("/works/W1"):
+            return SEED_PAYLOAD
+        if url.endswith("/works"):
+            assert params["filter"] == "cites:W1"
+            assert params["page"] == "1"
+            return {
+                "results": [_citing_payload("W201"), _citing_payload("W202")],
+                "meta": {"count": 2},
+            }
+        raise AssertionError(f"unexpected url {url}")
+
+    with patch.object(client, "_http_get", side_effect=fake_http_get):
+        seed, related, edges = await client.get_citations("W1", max_results=10)
+
+    assert len(related) == 2
+    for e, r in zip(edges, related):
+        # edges point citing → cited (= seed)
+        assert e.citing_paper_id == r.paper_id
+        assert e.cited_paper_id == seed.paper_id
+        assert e.source == "openalex"
+
+
+@pytest.mark.asyncio
+async def test_get_citations_pagination_stops_at_total_count(client):
+    page_calls = {"n": 0}
+
+    async def fake_http_get(url, params):
+        if url.endswith("/works/W1"):
+            return SEED_PAYLOAD
+        page_calls["n"] += 1
+        page = int(params["page"])
+        if page == 1:
+            return {
+                "results": [_citing_payload(f"W{2000 + i}") for i in range(5)],
+                "meta": {"count": 5},
+            }
+        raise AssertionError("Should stop after first page")
+
+    with patch.object(client, "_http_get", side_effect=fake_http_get):
+        _, related, _ = await client.get_citations("W1", max_results=200)
+
+    assert len(related) == 5
+    assert page_calls["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_citations_pagination_stops_when_no_results(client):
+    async def fake_http_get(url, params):
+        if url.endswith("/works/W1"):
+            return SEED_PAYLOAD
+        return {"results": [], "meta": {"count": 0}}
+
+    with patch.object(client, "_http_get", side_effect=fake_http_get):
+        _, related, _ = await client.get_citations("W1", max_results=10)
+
+    assert related == []
+
+
+@pytest.mark.asyncio
+async def test_get_citations_pagination_stops_on_short_page(client):
+    page_calls = {"n": 0}
+
+    async def fake_http_get(url, params):
+        if url.endswith("/works/W1"):
+            return SEED_PAYLOAD
+        page_calls["n"] += 1
+        page = int(params["page"])
+        if page == 1:
+            # Return fewer results than requested → stop without
+            # claiming a meta.count
+            return {"results": [_citing_payload(f"W30{i}") for i in range(3)]}
+        raise AssertionError("Should stop on short page")
+
+    with patch.object(client, "_http_get", side_effect=fake_http_get):
+        _, related, _ = await client.get_citations("W1", max_results=200)
+
+    assert len(related) == 3
+    assert page_calls["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_citations_pagination_advances_through_pages(client):
+    async def fake_http_get(url, params):
+        if url.endswith("/works/W1"):
+            return SEED_PAYLOAD
+        page = int(params["page"])
+        per_page = int(params["per-page"])
+        if page == 1:
+            return {
+                "results": [_citing_payload(f"W{4000 + i}") for i in range(per_page)],
+                "meta": {"count": per_page * 2},
+            }
+        if page == 2:
+            return {
+                "results": [_citing_payload(f"W{5000 + i}") for i in range(per_page)],
+                "meta": {"count": per_page * 2},
+            }
+        raise AssertionError("Unexpected page")
+
+    with patch.object(client, "_http_get", side_effect=fake_http_get):
+        _, related, _ = await client.get_citations("W1", max_results=10)
+
+    # max_results=10 caps per-page at 10; two pages * 10 = 20 total but
+    # collected[:max_results] trims to 10
+    assert len(related) == 10
+
+
+@pytest.mark.asyncio
+async def test_get_citations_skips_invalid_payload(client):
+    async def fake_http_get(url, params):
+        if url.endswith("/works/W1"):
+            return SEED_PAYLOAD
+        bad = _citing_payload("W201")
+        bad.pop("id")  # missing id → KeyError → skipped
+        return {
+            "results": [bad, _citing_payload("W202")],
+            "meta": {"count": 2},
+        }
+
+    with patch.object(client, "_http_get", side_effect=fake_http_get):
+        _, related, edges = await client.get_citations("W1", max_results=10)
+
+    assert len(related) == 1
+    assert related[0].external_ids["openalex"] == "W202"
+    assert len(edges) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_citations_handles_meta_missing(client):
+    async def fake_http_get(url, params):
+        if url.endswith("/works/W1"):
+            return SEED_PAYLOAD
+        # No meta dict at all
+        return {"results": [_citing_payload("W201")]}
+
+    with patch.object(client, "_http_get", side_effect=fake_http_get):
+        _, related, _ = await client.get_citations("W1", max_results=10)
+
+    # Single short page → break loop
+    assert len(related) == 1
+
+
+# ---------------------------------------------------------------------------
+# Caching
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_returns_deserialized_payload(tmp_path, fast_limiter):
+    c = OpenAlexCitationClient(
+        polite_email="x@y.z", rate_limiter=fast_limiter, cache_dir=tmp_path
+    )
+
+    seed = CitationNode(paper_id=make_paper_node_id("openalex", "W1"), title="C")
+    related = [CitationNode(paper_id=make_paper_node_id("openalex", "W2"), title="R")]
+    edges = [
+        CitationEdge(
+            citing_paper_id=seed.paper_id,
+            cited_paper_id=related[0].paper_id,
+            source="openalex",
+        )
+    ]
+
+    key = c._cache_key("references", "W1", 5)
+    c._cache_set(key, c._serialize_payload((seed, related, edges)))
+
+    with patch.object(c, "_http_get", side_effect=AssertionError("HTTP called!")):
+        s, r, e = await c.get_references("W1", max_results=5)
+
+    assert s.title == "C"
+    assert r[0].title == "R"
+    assert len(e) == 1
+    c.close()
+
+
+@pytest.mark.asyncio
+async def test_cache_miss_then_populated(tmp_path, fast_limiter):
+    c = OpenAlexCitationClient(
+        polite_email="x@y.z", rate_limiter=fast_limiter, cache_dir=tmp_path
+    )
+
+    async def fake_http_get(url, params):
+        if url.endswith("/works/W1"):
+            return SEED_PAYLOAD
+        return {"results": [_hydrated_ref("W101")]}
+
+    with patch.object(c, "_http_get", side_effect=fake_http_get):
+        await c.get_references("W1", max_results=5)
+
+    cached = c._cache_get(c._cache_key("references", "W1", 5))
+    assert cached is not None
+    assert b"Seed Work" in cached
+    c.close()
+
+
+@pytest.mark.asyncio
+async def test_second_call_hits_cache_no_http(tmp_path, fast_limiter):
+    c = OpenAlexCitationClient(
+        polite_email="x@y.z", rate_limiter=fast_limiter, cache_dir=tmp_path
+    )
+
+    call_count = {"n": 0}
+
+    async def fake_http_get(url, params):
+        call_count["n"] += 1
+        if url.endswith("/works/W1"):
+            return SEED_PAYLOAD
+        return {"results": [_hydrated_ref("W101")]}
+
+    with patch.object(c, "_http_get", side_effect=fake_http_get):
+        await c.get_references("W1", max_results=5)
+        first = call_count["n"]
+        await c.get_references("W1", max_results=5)
+
+    assert call_count["n"] == first
+    c.close()
+
+
+def test_cache_get_returns_none_when_no_cache(client):
+    assert client._cache_get("any-key") is None
+
+
+def test_cache_set_no_op_when_no_cache(client):
+    client._cache_set("k", b"v")
+    assert client._cache_get("k") is None
+
+
+def test_cache_key_segregates_polite_vs_anonymous(monkeypatch, fast_limiter):
+    monkeypatch.delenv("OPENALEX_POLITE_EMAIL", raising=False)
+    polite = OpenAlexCitationClient(polite_email="x@y.z", rate_limiter=fast_limiter)
+    anon = OpenAlexCitationClient(polite_email=None, rate_limiter=fast_limiter)
+
+    k_polite = polite._cache_key("references", "W1", 5)
+    k_anon = anon._cache_key("references", "W1", 5)
+
+    assert k_polite != k_anon
+
+
+def test_cache_key_is_stable_and_deterministic(client):
+    k1 = client._cache_key("references", "W1", 10)
+    k2 = client._cache_key("references", "W1", 10)
+    k3 = client._cache_key("references", "W1", 11)
+    assert k1 == k2
+    assert k1 != k3
+    assert len(k1) == 64
+
+
+def test_serialize_then_deserialize_roundtrip():
+    seed = CitationNode(paper_id="paper:openalex:W1", title="X")
+    related = [CitationNode(paper_id="paper:openalex:W2", title="Y")]
+    edges = [
+        CitationEdge(
+            citing_paper_id="paper:openalex:W1",
+            cited_paper_id="paper:openalex:W2",
+            source="openalex",
+        )
+    ]
+
+    raw = OpenAlexCitationClient._serialize_payload((seed, related, edges))
+    s, r, e = OpenAlexCitationClient._deserialize_payload(raw)
+
+    assert s.paper_id == seed.paper_id
+    assert r[0].paper_id == related[0].paper_id
+    assert e[0].cited_paper_id == "paper:openalex:W2"
+
+
+# ---------------------------------------------------------------------------
+# _http_get path (real aiohttp mock)
+# ---------------------------------------------------------------------------
+
+
+def _mock_aiohttp_response(status, json_body=None, text_body="oops"):
+    resp = MagicMock()
+    resp.status = status
+    resp.json = AsyncMock(return_value=json_body)
+    resp.text = AsyncMock(return_value=text_body)
+
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=resp)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+def _patch_session(response_cm):
+    session = MagicMock()
+    session.get = MagicMock(return_value=response_cm)
+    session_cm = MagicMock()
+    session_cm.__aenter__ = AsyncMock(return_value=session)
+    session_cm.__aexit__ = AsyncMock(return_value=False)
+    return patch("aiohttp.ClientSession", return_value=session_cm), session
+
+
+@pytest.mark.asyncio
+async def test_http_get_returns_json_on_200(client):
+    cm = _mock_aiohttp_response(200, json_body={"hello": "world"})
+    p, _ = _patch_session(cm)
+    with p:
+        body = await client._http_get("http://x", {"a": "b"})
+    assert body == {"hello": "world"}
+
+
+@pytest.mark.asyncio
+async def test_http_get_adds_polite_email_when_present(client):
+    cm = _mock_aiohttp_response(200, json_body={})
+    p, session = _patch_session(cm)
+    with p:
+        await client._http_get("http://x", {"a": "b"})
+    _, kwargs = session.get.call_args
+    assert kwargs["params"]["mailto"] == "test@example.com"
+    # Original params preserved
+    assert kwargs["params"]["a"] == "b"
+
+
+@pytest.mark.asyncio
+async def test_http_get_omits_email_when_absent(monkeypatch, fast_limiter):
+    monkeypatch.delenv("OPENALEX_POLITE_EMAIL", raising=False)
+    c = OpenAlexCitationClient(
+        polite_email=None, rate_limiter=fast_limiter, cache_dir=None
+    )
+    cm = _mock_aiohttp_response(200, json_body={})
+    p, session = _patch_session(cm)
+    with p:
+        await c._http_get("http://x", {})
+    _, kwargs = session.get.call_args
+    assert "mailto" not in kwargs["params"]
+
+
+@pytest.mark.asyncio
+async def test_http_get_does_not_mutate_input_params(client):
+    """The original params dict the caller passed must not gain mailto."""
+    cm = _mock_aiohttp_response(200, json_body={})
+    p, _session = _patch_session(cm)
+    original_params = {"a": "b"}
+    with p:
+        await client._http_get("http://x", original_params)
+    assert "mailto" not in original_params
+
+
+@pytest.mark.asyncio
+async def test_http_get_raises_rate_limit_on_429(client):
+    cm = _mock_aiohttp_response(429, text_body="slow down")
+    p, _ = _patch_session(cm)
+    with p:
+        with pytest.raises(RateLimitError, match="rate limit exceeded"):
+            await client._http_get("http://x", {})
+
+
+@pytest.mark.asyncio
+async def test_http_get_raises_api_error_on_404(client):
+    cm = _mock_aiohttp_response(404, text_body="not here")
+    p, _ = _patch_session(cm)
+    with p:
+        with pytest.raises(APIError, match="not found"):
+            await client._http_get("http://x", {})
+
+
+@pytest.mark.asyncio
+async def test_http_get_raises_api_error_on_500(client):
+    cm = _mock_aiohttp_response(500, text_body="boom")
+    p, _ = _patch_session(cm)
+    with p:
+        with pytest.raises(APIError, match="error 500"):
+            await client._http_get("http://x", {})
+
+
+@pytest.mark.asyncio
+async def test_http_get_wraps_timeout_as_api_error(client):
+    session_cm = MagicMock()
+    session = MagicMock()
+    session.get = MagicMock(side_effect=asyncio.TimeoutError())
+    session_cm.__aenter__ = AsyncMock(return_value=session)
+    session_cm.__aexit__ = AsyncMock(return_value=False)
+    with patch("aiohttp.ClientSession", return_value=session_cm):
+        with pytest.raises(APIError, match="timed out"):
+            await client._http_get("http://x", {})
+
+
+# ---------------------------------------------------------------------------
+# Transient failure → caller-side retry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_transient_failure_then_retry_success(client):
+    state = {"attempt": 0}
+
+    async def flaky_http_get(url, params):
+        if url.endswith("/works/W1"):
+            state["attempt"] += 1
+            if state["attempt"] == 1:
+                raise RateLimitError("temporary")
+            return SEED_PAYLOAD
+        return {"results": [_hydrated_ref("W101")]}
+
+    with patch.object(client, "_http_get", side_effect=flaky_http_get):
+        with pytest.raises(RateLimitError):
+            await client.get_references("W1", max_results=5)
+
+        seed, related, _ = await client.get_references("W1", max_results=5)
+
+    assert seed.title == "Seed Work"
+    assert len(related) == 1
+
+
+# ---------------------------------------------------------------------------
+# Class constants
+# ---------------------------------------------------------------------------
+
+
+def test_base_url_is_openalex_root():
+    assert OpenAlexCitationClient.BASE_URL == "https://api.openalex.org"

--- a/tests/unit/storage/intelligence_graph/test_unified_graph.py
+++ b/tests/unit/storage/intelligence_graph/test_unified_graph.py
@@ -26,6 +26,7 @@ from src.services.intelligence.models import (
     EdgeType,
     GraphEdge,
     GraphNode,
+    GraphStoreDuplicateError,
     GraphStoreError,
     NodeNotFoundError,
     NodeType,
@@ -123,10 +124,22 @@ class TestNodeOperations:
         assert node.properties == props
 
     def test_add_node_duplicate_raises(self, graph_store: SQLiteGraphStore) -> None:
-        """Test adding duplicate node raises error."""
+        """Test adding duplicate node raises typed duplicate error."""
         graph_store.add_node("paper:1", NodeType.PAPER, {})
 
-        with pytest.raises(GraphStoreError, match="already exists"):
+        # Typed signal — must be a ``GraphStoreDuplicateError`` (a
+        # subclass of ``GraphStoreError`` so existing handlers still
+        # match) and the message must still say "already exists" so
+        # any human-facing logs stay readable (#S5).
+        with pytest.raises(GraphStoreDuplicateError, match="already exists"):
+            graph_store.add_node("paper:1", NodeType.PAPER, {})
+
+    def test_add_node_duplicate_is_graph_store_error_subclass(
+        self, graph_store: SQLiteGraphStore
+    ) -> None:
+        """Existing ``except GraphStoreError`` handlers still catch dup errors."""
+        graph_store.add_node("paper:1", NodeType.PAPER, {})
+        with pytest.raises(GraphStoreError):
             graph_store.add_node("paper:1", NodeType.PAPER, {})
 
     def test_get_node_exists(self, graph_store: SQLiteGraphStore) -> None:
@@ -272,12 +285,12 @@ class TestEdgeOperations:
             graph_store.add_edge("edge:1", "paper:1", "nonexistent", EdgeType.CITES, {})
 
     def test_add_edge_duplicate_raises(self, graph_store: SQLiteGraphStore) -> None:
-        """Test adding duplicate edge raises error."""
+        """Test adding duplicate edge raises typed duplicate error."""
         graph_store.add_node("paper:1", NodeType.PAPER, {})
         graph_store.add_node("paper:2", NodeType.PAPER, {})
         graph_store.add_edge("edge:1", "paper:1", "paper:2", EdgeType.CITES, {})
 
-        with pytest.raises(GraphStoreError, match="already exists"):
+        with pytest.raises(GraphStoreDuplicateError, match="already exists"):
             graph_store.add_edge("edge:1", "paper:1", "paper:2", EdgeType.CITES, {})
 
     def test_get_edge_exists(self, graph_store: SQLiteGraphStore) -> None:
@@ -1263,7 +1276,8 @@ class TestAddNodesBatch:
     def test_add_nodes_batch_atomic_rollback(
         self, graph_store: SQLiteGraphStore
     ) -> None:
-        """A duplicate node_id inside the batch rolls back the whole batch."""
+        """A duplicate node_id inside the batch rolls back the whole batch
+        and surfaces the typed ``GraphStoreDuplicateError`` (#S5)."""
         # Pre-existing node that will collide with one in the batch.
         graph_store.add_node("paper:dup", NodeType.PAPER, {})
         baseline_count = graph_store.get_node_count()
@@ -1274,7 +1288,7 @@ class TestAddNodesBatch:
             self._make_node("paper:new2"),
         ]
 
-        with pytest.raises(GraphStoreError, match="Failed to bulk insert nodes"):
+        with pytest.raises(GraphStoreDuplicateError, match="duplicate node_id"):
             graph_store.add_nodes_batch(batch)
 
         # No new nodes from the batch should have been inserted.
@@ -1283,12 +1297,54 @@ class TestAddNodesBatch:
         assert graph_store.get_node("paper:new2") is None
 
     def test_add_nodes_batch_chains_cause(self, graph_store: SQLiteGraphStore) -> None:
-        """The wrapped GraphStoreError chains the underlying IntegrityError."""
+        """The wrapped GraphStoreDuplicateError chains the IntegrityError."""
         graph_store.add_node("paper:dup", NodeType.PAPER, {})
         batch = [self._make_node("paper:dup")]
-        with pytest.raises(GraphStoreError) as exc_info:
+        with pytest.raises(GraphStoreDuplicateError) as exc_info:
             graph_store.add_nodes_batch(batch)
         assert isinstance(exc_info.value.__cause__, sqlite3.IntegrityError)
+
+    def test_add_nodes_batch_non_unique_error_falls_back_to_generic(
+        self, graph_store: SQLiteGraphStore
+    ) -> None:
+        """A non-UNIQUE IntegrityError surfaces as the generic
+        ``GraphStoreError`` (not the duplicate subclass) so callers'
+        recovery loops do not silently swallow it (#S5)."""
+        batch = [self._make_node("paper:1")]
+
+        original_get_conn = graph_store._get_connection
+
+        class _ConnProxy:
+            def __init__(self, conn: sqlite3.Connection) -> None:
+                self._conn = conn
+
+            def __enter__(self):  # type: ignore[no-untyped-def]
+                return self._conn.__enter__()
+
+            def __exit__(self, *args):  # type: ignore[no-untyped-def]
+                return self._conn.__exit__(*args)
+
+            def executemany(self, sql: str, rows):  # type: ignore[no-untyped-def]
+                # Drive the non-UNIQUE branch — message shape mirrors
+                # what SQLite produces for a CHECK constraint failure.
+                raise sqlite3.IntegrityError("CHECK constraint failed: synthetic")
+
+            def execute(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+                return self._conn.execute(*args, **kwargs)
+
+            def close(self) -> None:
+                self._conn.close()
+
+        def get_conn() -> _ConnProxy:  # type: ignore[type-arg]
+            return _ConnProxy(original_get_conn())
+
+        with patch.object(graph_store, "_get_connection", side_effect=get_conn):
+            with pytest.raises(GraphStoreError) as exc_info:
+                graph_store.add_nodes_batch(batch)
+        # Must NOT be the duplicate subclass — the recovery loop relies
+        # on this distinction to surface unrecoverable errors.
+        assert not isinstance(exc_info.value, GraphStoreDuplicateError)
+        assert "Failed to bulk insert nodes" in str(exc_info.value)
 
     def test_add_nodes_batch_rejects_oversized_batch(
         self, graph_store: SQLiteGraphStore
@@ -1354,7 +1410,8 @@ class TestAddEdgesBatch:
     def test_add_edges_batch_atomic_rollback(
         self, graph_store: SQLiteGraphStore
     ) -> None:
-        """A duplicate edge_id inside the batch rolls back the whole batch."""
+        """A duplicate edge_id inside the batch rolls back the whole batch
+        and surfaces the typed ``GraphStoreDuplicateError`` (#S5)."""
         graph_store.add_node("paper:1", NodeType.PAPER, {})
         graph_store.add_node("paper:2", NodeType.PAPER, {})
         graph_store.add_edge("e:dup", "paper:1", "paper:2", EdgeType.CITES, {})
@@ -1366,7 +1423,7 @@ class TestAddEdgesBatch:
             self._make_edge("e:new2", "paper:1", "paper:2"),
         ]
 
-        with pytest.raises(GraphStoreError, match="Failed to bulk insert edges"):
+        with pytest.raises(GraphStoreDuplicateError, match="duplicate edge_id"):
             graph_store.add_edges_batch(batch)
 
         # None of the new edges should be inserted.
@@ -1396,15 +1453,55 @@ class TestAddEdgesBatch:
         assert graph_store.get_edge("e:ok") is None
 
     def test_add_edges_batch_chains_cause(self, graph_store: SQLiteGraphStore) -> None:
-        """The wrapped error chains the underlying IntegrityError as __cause__."""
+        """The wrapped duplicate error chains the IntegrityError as __cause__."""
         graph_store.add_node("paper:1", NodeType.PAPER, {})
         graph_store.add_node("paper:2", NodeType.PAPER, {})
         graph_store.add_edge("e:dup", "paper:1", "paper:2", EdgeType.CITES, {})
-        with pytest.raises(GraphStoreError) as exc_info:
+        with pytest.raises(GraphStoreDuplicateError) as exc_info:
             graph_store.add_edges_batch(
                 [self._make_edge("e:dup", "paper:1", "paper:2")]
             )
         assert isinstance(exc_info.value.__cause__, sqlite3.IntegrityError)
+
+    def test_add_edges_batch_non_unique_non_fk_error_falls_back_to_generic(
+        self, graph_store: SQLiteGraphStore
+    ) -> None:
+        """A non-UNIQUE non-FK IntegrityError surfaces as the generic
+        ``GraphStoreError`` (not the duplicate subclass) so callers'
+        recovery loops do not silently swallow it (#S5)."""
+        graph_store.add_node("paper:1", NodeType.PAPER, {})
+        graph_store.add_node("paper:2", NodeType.PAPER, {})
+        batch = [self._make_edge("e:1", "paper:1", "paper:2")]
+
+        original_get_conn = graph_store._get_connection
+
+        class _ConnProxy:
+            def __init__(self, conn: sqlite3.Connection) -> None:
+                self._conn = conn
+
+            def __enter__(self):  # type: ignore[no-untyped-def]
+                return self._conn.__enter__()
+
+            def __exit__(self, *args):  # type: ignore[no-untyped-def]
+                return self._conn.__exit__(*args)
+
+            def executemany(self, sql: str, rows):  # type: ignore[no-untyped-def]
+                raise sqlite3.IntegrityError("CHECK constraint failed: synthetic")
+
+            def execute(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+                return self._conn.execute(*args, **kwargs)
+
+            def close(self) -> None:
+                self._conn.close()
+
+        def get_conn() -> _ConnProxy:  # type: ignore[type-arg]
+            return _ConnProxy(original_get_conn())
+
+        with patch.object(graph_store, "_get_connection", side_effect=get_conn):
+            with pytest.raises(GraphStoreError) as exc_info:
+                graph_store.add_edges_batch(batch)
+        assert not isinstance(exc_info.value, GraphStoreDuplicateError)
+        assert "Failed to bulk insert edges" in str(exc_info.value)
 
     def test_add_edges_batch_rejects_oversized_batch(
         self, graph_store: SQLiteGraphStore


### PR DESCRIPTION
## Summary

Lands the two files deferred from PR #107 (Phase 9.2 Week 1) — completes the original Week 1 scope:

1. `src/services/intelligence/citation/openalex_client.py` — OpenAlex citation client (fallback) mirroring the S2 client's API, with OPENALEX_POLITE_EMAIL polite-pool support and 7-day disk cache.
2. `src/services/intelligence/citation/graph_builder.py` — `CitationGraphBuilder` that composes the two clients (S2 first, OpenAlex fallback) and persists nodes/edges via `GraphStore.add_nodes_batch` / `add_edges_batch`.

Both files have **100% line + branch coverage**; the citation package as a whole is now at 100% combined coverage across all four files (models + 2 clients + builder).

## What changed

### OpenAlex citation client
- Sibling to `SemanticScholarCitationClient` (built alongside `src/services/providers/openalex.py`, not extending it — same rationale as PR #107's S2 sibling: the existing provider implements the keyword-search `DiscoveryProvider` ABC and its request/response shapes don't transfer cleanly to the citation endpoints).
- Polite-pool email read from `OPENALEX_POLITE_EMAIL` env var; missing email logs a one-shot WARN and falls back to the anonymous tier (still works, just slower).
- References: hydrates `referenced_works` URL list in 50-id chunks via `filter=openalex:W1|W2|...` (one extra round-trip per 50 refs).
- Citations: page-based pagination on `filter=cites:Wxxx`. Cursor pagination is reserved for the Week-2 BFS crawler.
- Cache key includes a polite-vs-anonymous bit so the two pools never share entries.

### Citation graph builder
- API: `await builder.build_for_paper(paper_id, depth=1, direction=CitationDirection.OUT) -> GraphBuildResult`.
- depth=1 only (BFS crawl is Week 2, separate issue).
- One `add_nodes_batch` + one `add_edges_batch` per direction (per spec — bulk insert APIs from PR #105).
- Within-call dedup so duplicate node_ids / edge_ids never reach the bulk API (they would otherwise roll back the whole batch).
- On bulk constraint violation (typical: re-running for the same seed), per-row recovery path swallows "already exists" errors so re-runs stay idempotent. Any other error is reported via `GraphBuildResult.errors` instead of raising — the builder is best-effort.
- Provider strategy: S2 first; on `APIError` / `RateLimitError`, fall back to OpenAlex. Empty-but-successful S2 results are NOT a fallback trigger (would just double API cost).
- Storage-engine agnostic: no `sqlite3` imports — only the `GraphStore` Protocol. Verified by a dedicated source-scanning test.

## Acceptance criteria

- [x] Both files implemented with mocked-HTTP tests (104 new tests, all mocked; 0 live calls).
- [x] No live API calls in tests (`unittest.mock.AsyncMock` + manual aiohttp mocks).
- [x] Composes existing OpenAlex provider rationale (built alongside, see code comments).
- [x] Uses `add_*_batch` for ingest, not per-row insert (per-row is recovery-only).
- [x] OpenAlex polite-pool email read from env or constructor (no hardcode).
- [x] `./verify.sh` passes (4567 tests pass, 99.26% project coverage).
- [x] Graph builder is storage-engine-agnostic (no `sqlite3` imports).

## Test plan
- [x] `pytest tests/unit/services/intelligence/citation/ -q --cov=src/services/intelligence/citation --cov-branch` → 205 tests pass, 100% coverage on all 4 citation files
- [x] `./verify.sh` → 4567 passed, 99.26% combined project coverage, lint/type checks clean
- [x] Idempotency: building the same seed twice persists no duplicate nodes/edges (covered by `test_idempotent_re_call_same_seed`)
- [x] Storage agnostic: source-scanning test confirms no `sqlite3` imports in `graph_builder.py`

Closes #113