### PR TITLE
refactor(phase-9.1): MonitoringPaperAudit DTO + MonitoringRunner.from_paths factory (PR #119 follow-up, stacked on #123)

### DIFF
--- a/src/services/intelligence/monitoring/__init__.py
+++ b/src/services/intelligence/monitoring/__init__.py
@@ -32,8 +32,10 @@ from src.services.intelligence.monitoring.arxiv_monitor import (
     ArxivMonitorResult,
 )
 from src.services.intelligence.monitoring.models import (
+    MonitoringPaperAudit,
     MonitoringPaperRecord,
     MonitoringRun,
+    MonitoringRunAudit,
     MonitoringRunStatus,
     ResearchSubscription,
     SubscriptionStatus,
@@ -49,8 +51,10 @@ from src.services.intelligence.monitoring.subscription_manager import (
 __all__ = [
     "ArxivMonitor",
     "ArxivMonitorResult",
+    "MonitoringPaperAudit",
     "MonitoringPaperRecord",
     "MonitoringRun",
+    "MonitoringRunAudit",
     "MonitoringRunRepository",
     "MonitoringRunStatus",
     "MonitoringRunner",

--- a/src/services/intelligence/monitoring/models.py
+++ b/src/services/intelligence/monitoring/models.py
@@ -276,7 +276,7 @@ class MonitoringPaperRecord(BaseModel):
     paper_id: str = Field(
         ...,
         min_length=1,
-        max_length=128,
+        max_length=512,
         description="Provider paper id (e.g. ArXiv id 2301.12345).",
     )
     title: str = Field(..., min_length=1, max_length=1024)
@@ -298,7 +298,7 @@ class MonitoringPaperRecord(BaseModel):
     )
     relevance_reasoning: Optional[str] = Field(
         default=None,
-        max_length=1000,
+        max_length=4096,
         description="Filled in by the Week 2 RelevanceScorer.",
     )
 
@@ -316,9 +316,25 @@ class MonitoringPaperAudit(BaseModel):
     cause Week 2's digest generator to render arXiv ids as titles).
 
     Reviewed in PR #119 self-review #S6.
+
+    Title and other rich metadata
+    -----------------------------
+    Audit rows do not store paper title, abstract, URL, or PDF URL.
+    Consumers (e.g., the Week-2 digest generator) should look up
+    ``paper_id`` against
+    :class:`~src.services.registry.service.RegistryService` to retrieve
+    the rich representation. Storing rich fields here would duplicate
+    the registry and bloat the audit table.
+
+    Schema evolution
+    ----------------
+    Adding ``Optional[...]`` fields to this DTO is forward-compatible
+    with existing audit rows (Pydantic strict accepts default ``None``).
+    Adding non-null fields requires a new ``MIGRATION_V4`` to backfill
+    the column with a sensible default before the field is added here.
     """
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", strict=True)
 
     paper_id: str = Field(
         ...,
@@ -359,9 +375,16 @@ class MonitoringRunAudit(BaseModel):
     Carries the same ``user_id`` denormalization that the table uses,
     so per-user audit consumers (digest generator, future REST/CLI)
     don't need a JOIN to ``subscriptions`` for the common case.
+
+    Schema evolution
+    ----------------
+    Adding ``Optional[...]`` fields to this DTO is forward-compatible
+    with existing audit rows (Pydantic strict accepts default ``None``).
+    Adding non-null fields requires a new ``MIGRATION_V4`` to backfill
+    the column with a sensible default before the field is added here.
     """
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", strict=True)
 
     run_id: str = Field(..., min_length=1, max_length=64)
     subscription_id: str = Field(..., min_length=1, max_length=64)

--- a/src/services/intelligence/monitoring/models.py
+++ b/src/services/intelligence/monitoring/models.py
@@ -303,6 +303,78 @@ class MonitoringPaperRecord(BaseModel):
     )
 
 
+class MonitoringPaperAudit(BaseModel):
+    """Persisted audit fields for a paper seen in a monitoring run.
+
+    Distinct from :class:`MonitoringPaperRecord`, which carries the
+    richer in-memory metadata (``title``, ``url``, ``pdf_url``,
+    ``published_at``, ...) produced by ``ArxivMonitor``. The audit
+    type carries only the columns the ``monitoring_papers`` table
+    actually stores -- so the repository's read path doesn't have to
+    fabricate placeholder data (e.g. PR #119 reviewed
+    ``MonitoringPaperRecord(title=paper_id)`` aliasing, which would
+    cause Week 2's digest generator to render arXiv ids as titles).
+
+    Reviewed in PR #119 self-review #S6.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    paper_id: str = Field(
+        ...,
+        min_length=1,
+        max_length=512,
+        description="Provider paper id (e.g. ArXiv id 2301.12345).",
+    )
+    registered: bool = Field(
+        default=False,
+        description=(
+            "True if the paper was newly registered with the global "
+            "PaperRegistry during this run. Mirrors the ``is_new`` "
+            "flag on ``MonitoringPaperRecord``."
+        ),
+    )
+    relevance_score: Optional[float] = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description="Filled in by the Week 2 RelevanceScorer.",
+    )
+    relevance_reasoning: Optional[str] = Field(
+        default=None,
+        max_length=4096,
+        description="Filled in by the Week 2 RelevanceScorer.",
+    )
+
+
+class MonitoringRunAudit(BaseModel):
+    """Persisted audit-only view of a ``MonitoringRun`` (PR #119 #S6).
+
+    The repository returns this from ``get_run`` / ``list_runs`` instead
+    of the in-memory :class:`MonitoringRun`, so callers see only the
+    columns the audit tables actually stored. Avoids the
+    ``MonitoringPaperRecord(title=paper_id)`` fabrication that the
+    self-review flagged as silent contract corruption.
+
+    Carries the same ``user_id`` denormalization that the table uses,
+    so per-user audit consumers (digest generator, future REST/CLI)
+    don't need a JOIN to ``subscriptions`` for the common case.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    run_id: str = Field(..., min_length=1, max_length=64)
+    subscription_id: str = Field(..., min_length=1, max_length=64)
+    user_id: str = Field(..., min_length=1, max_length=64)
+    started_at: datetime = Field(...)
+    finished_at: Optional[datetime] = Field(default=None)
+    status: MonitoringRunStatus = Field(...)
+    papers_seen: int = Field(default=0, ge=0)
+    papers_new: int = Field(default=0, ge=0)
+    error: Optional[str] = Field(default=None, max_length=2000)
+    papers: list[MonitoringPaperAudit] = Field(default_factory=list)
+
+
 class MonitoringRun(BaseModel):
     """Audit record for one execution of the monitor.
 

--- a/src/services/intelligence/monitoring/run_repository.py
+++ b/src/services/intelligence/monitoring/run_repository.py
@@ -43,6 +43,17 @@ do). The ``MonitoringRunner`` resolves the owning user from the
 subscription before calling :meth:`record_run` so per-user audit
 queries don't have to JOIN every read.
 
+Read-side type boundary
+-----------------------
+``record_run`` accepts the rich in-memory :class:`MonitoringRun`
+(produced by ``ArxivMonitor``). The read paths (``get_run``,
+``list_runs``) return the audit-only counterparts -- ``MonitoringRunAudit``
+plus per-paper ``MonitoringPaperAudit`` -- which carry exactly the
+columns the audit tables store. This separation prevents the
+``MonitoringPaperRecord(title=paper_id)`` placeholder fabrication
+that was flagged in PR #119 self-review #S6 (which would have
+caused Week 2's digest generator to render arXiv ids as titles).
+
 Concurrency model
 -----------------
 Same approach as ``SubscriptionManager``: each method opens a fresh
@@ -62,10 +73,10 @@ from typing import Iterator, Optional
 
 import structlog
 
-from src.services.intelligence.models.monitoring import PaperSource
 from src.services.intelligence.monitoring.models import (
-    MonitoringPaperRecord,
+    MonitoringPaperAudit,
     MonitoringRun,
+    MonitoringRunAudit,
     MonitoringRunStatus,
 )
 from src.storage.intelligence_graph.connection import open_connection
@@ -324,8 +335,18 @@ class MonitoringRunRepository:
     # ------------------------------------------------------------------
     # Reads
     # ------------------------------------------------------------------
-    def get_run(self, run_id: str) -> Optional[MonitoringRun]:
-        """Fetch a single run (with its paper records), or ``None``."""
+    # Read paths return the audit-only types (PR #119 review #S6) so
+    # consumers see exactly what the table stores -- no fabricated
+    # ``title=paper_id`` placeholders that would silently corrupt the
+    # downstream digest generator.
+    def get_run(self, run_id: str) -> Optional[MonitoringRunAudit]:
+        """Fetch a single run (with its paper records), or ``None``.
+
+        Returns a :class:`MonitoringRunAudit` carrying only the columns
+        actually stored in the audit tables -- callers that need richer
+        in-memory metadata (titles, abstracts, ...) should fetch from
+        the registry by ``paper_id``.
+        """
         with self._connect() as conn:
             cursor = conn.execute(
                 """
@@ -341,13 +362,13 @@ class MonitoringRunRepository:
             if row is None:
                 return None
             papers = self._fetch_papers(conn, run_id)
-        return self._row_to_run(row, papers)
+        return self._row_to_audit(row, papers)
 
     def list_runs(
         self,
         subscription_id: Optional[str] = None,
         limit: int = 50,
-    ) -> list[MonitoringRun]:
+    ) -> list[MonitoringRunAudit]:
         """List runs ordered by ``started_at DESC``.
 
         Args:
@@ -381,10 +402,10 @@ class MonitoringRunRepository:
                 tuple(params),
             )
             rows = cursor.fetchall()
-            runs: list[MonitoringRun] = []
+            runs: list[MonitoringRunAudit] = []
             for row in rows:
                 papers = self._fetch_papers(conn, row["run_id"])
-                runs.append(self._row_to_run(row, papers))
+                runs.append(self._row_to_audit(row, papers))
         return runs
 
     # ------------------------------------------------------------------
@@ -393,7 +414,7 @@ class MonitoringRunRepository:
     @staticmethod
     def _fetch_papers(
         conn: sqlite3.Connection, run_id: str
-    ) -> list[MonitoringPaperRecord]:
+    ) -> list[MonitoringPaperAudit]:
         cursor = conn.execute(
             """
             SELECT paper_id, registered, relevance_score, relevance_reasoning
@@ -403,32 +424,25 @@ class MonitoringRunRepository:
             """,
             (run_id,),
         )
-        records: list[MonitoringPaperRecord] = []
-        for row in cursor.fetchall():
-            records.append(
-                MonitoringPaperRecord(
-                    paper_id=row["paper_id"],
-                    # The DTO requires title; we only store paper_id at
-                    # the audit layer (titles live on the registry).
-                    # Use the paper_id as a placeholder so the model
-                    # round-trips without a JOIN.
-                    title=row["paper_id"],
-                    is_new=bool(row["registered"]),
-                    relevance_score=row["relevance_score"],
-                    relevance_reasoning=row["relevance_reasoning"],
-                )
+        return [
+            MonitoringPaperAudit(
+                paper_id=row["paper_id"],
+                registered=bool(row["registered"]),
+                relevance_score=row["relevance_score"],
+                relevance_reasoning=row["relevance_reasoning"],
             )
-        return records
+            for row in cursor.fetchall()
+        ]
 
     @staticmethod
-    def _row_to_run(
-        row: sqlite3.Row, papers: list[MonitoringPaperRecord]
-    ) -> MonitoringRun:
+    def _row_to_audit(
+        row: sqlite3.Row, papers: list[MonitoringPaperAudit]
+    ) -> MonitoringRunAudit:
         finished_iso = row["finished_at"]
-        return MonitoringRun(
+        return MonitoringRunAudit(
             run_id=row["run_id"],
             subscription_id=row["subscription_id"],
-            source=PaperSource.ARXIV,
+            user_id=row["user_id"],
             started_at=datetime.fromisoformat(row["started_at"]),
             finished_at=(
                 datetime.fromisoformat(finished_iso) if finished_iso else None

--- a/src/services/intelligence/monitoring/run_repository.py
+++ b/src/services/intelligence/monitoring/run_repository.py
@@ -415,6 +415,18 @@ class MonitoringRunRepository:
     def _fetch_papers(
         conn: sqlite3.Connection, run_id: str
     ) -> list[MonitoringPaperAudit]:
+        """Fetch all paper-audit rows for ``run_id``.
+
+        Returns:
+            A list of validated :class:`MonitoringPaperAudit` Pydantic
+            models -- never raw rows / dicts. The defensive
+            ``isinstance`` assertion below pins this contract for
+            future refactors of the repository read-path (PR #124 team
+            review): if anyone ever short-circuits the constructor and
+            returns sqlite3.Row / dict objects, the assertion fails
+            loudly during tests rather than silently corrupting the
+            digest generator's expectations downstream.
+        """
         cursor = conn.execute(
             """
             SELECT paper_id, registered, relevance_score, relevance_reasoning
@@ -424,7 +436,7 @@ class MonitoringRunRepository:
             """,
             (run_id,),
         )
-        return [
+        result: list[MonitoringPaperAudit] = [
             MonitoringPaperAudit(
                 paper_id=row["paper_id"],
                 registered=bool(row["registered"]),
@@ -433,6 +445,13 @@ class MonitoringRunRepository:
             )
             for row in cursor.fetchall()
         ]
+        # Defense-in-depth: pin the typed-DTO contract so a future
+        # refactor (e.g., introducing a "fast path" that returns rows
+        # directly) cannot silently leak dicts to the caller.
+        assert all(
+            isinstance(paper, MonitoringPaperAudit) for paper in result
+        ), "_fetch_papers must return list[MonitoringPaperAudit]"
+        return result
 
     @staticmethod
     def _row_to_audit(

--- a/src/services/intelligence/monitoring/runner.py
+++ b/src/services/intelligence/monitoring/runner.py
@@ -102,7 +102,7 @@ class MonitoringRunner:
     def from_paths(
         cls,
         *,
-        db_path: Path,
+        db_path: Path | str,
         registry: "RegistryService",
         arxiv_provider: "ArxivProvider",
     ) -> "MonitoringRunner":
@@ -125,6 +125,9 @@ class MonitoringRunner:
                 the system temp dir) -- enforced by
                 :func:`sanitize_storage_path` inside both
                 ``SubscriptionManager`` and ``MonitoringRunRepository``.
+                Accepts ``str`` or ``Path``; coerced to ``Path``
+                upfront for downstream typing (matches
+                ``SubscriptionManager.__init__``).
             registry: The shared global ``RegistryService`` used by the
                 monitor for paper deduplication.
             arxiv_provider: The shared ``ArxivProvider`` used by the
@@ -133,7 +136,22 @@ class MonitoringRunner:
         Returns:
             A fully-wired, initialized ``MonitoringRunner`` ready for
             ``run_once()``.
+
+        Lifecycle note
+        --------------
+        Intended to be constructed ONCE per process (e.g., at scheduler
+        startup) and reused across run cycles. Each construction calls
+        ``MigrationManager.migrate()`` on both repos -- migrations are
+        idempotent but still hit the DB. The future Week-2
+        ``MonitoringCheckJob`` (#117) should hold the runner instance
+        in ``__init__`` and call ``run_once()`` per tick.
+
+        Failure recovery: if either ``initialize()`` raises, simply
+        re-call ``from_paths()`` -- both subscription manager and run
+        repository migrations are idempotent, so the partial
+        construction left behind is safe to discard.
         """
+        db_path = Path(db_path)  # accept str | Path; coerce for downstream typing
         sub_mgr = SubscriptionManager(db_path)
         sub_mgr.initialize()
         monitor = ArxivMonitor(provider=arxiv_provider, registry=registry)

--- a/src/services/intelligence/monitoring/runner.py
+++ b/src/services/intelligence/monitoring/runner.py
@@ -230,7 +230,8 @@ class MonitoringRunner:
                 error=f"monitor_check_error: {exc}",
             )
 
-        # Persist the audit row regardless of outcome. We catch
+        # Persist the audit row regardless of provider outcome (success,
+        # partial, AND failed runs go to the audit log). We catch
         # persistence failures so a SQLite hiccup on one row doesn't
         # break the rest of the cycle -- the in-memory ``run`` is still
         # returned to the caller for observability.
@@ -241,22 +242,35 @@ class MonitoringRunner:
         # the event loop would starve every concurrent task in the
         # interim. ``asyncio.to_thread`` parks it on the default thread
         # executor so the loop stays responsive (PR #123 review #H1).
+        #
+        # Atomic-state-transition guarantee (PR #124 team review):
+        # ``mark_checked`` MUST NOT be called if persistence failed.
+        # Otherwise the subscription's ``last_checked_at`` advances
+        # past the polling window while the audit row of papers found
+        # in that window is lost -- the Week-2 digest generator would
+        # silently miss research updates for that interval. We early-
+        # return on persistence failure so the next cycle re-polls the
+        # same window and re-records the audit row.
         try:
             await asyncio.to_thread(
                 self._run_repo.record_run, run, user_id=subscription.user_id
             )
         except Exception as exc:
             logger.error(
-                "monitoring_runner_record_failed",
+                "monitoring_persistence_failed_skipping_mark_checked",
                 subscription_id=subscription.subscription_id,
                 run_id=run.run_id,
                 error=str(exc),
             )
+            # IMPORTANT: skip mark_checked so the next cycle retries
+            # the window. Returning the in-memory ``run`` preserves
+            # observability for the caller.
+            return run
 
-        # Only mark the subscription as checked on success / partial.
-        # A FAILED run means we never spoke to the provider; updating
-        # last_checked would cause us to skip the next cycle for the
-        # wrong reason.
+        # Persistence succeeded. Only mark the subscription as checked
+        # on success / partial. A FAILED run means we never spoke to
+        # the provider; updating last_checked would cause us to skip
+        # the next cycle for the wrong reason.
         if run.status is not MonitoringRunStatus.FAILED:
             try:
                 self._subscriptions.mark_checked(subscription.subscription_id)

--- a/src/services/intelligence/monitoring/runner.py
+++ b/src/services/intelligence/monitoring/runner.py
@@ -43,7 +43,8 @@ required.
 from __future__ import annotations
 
 import asyncio
-from typing import Optional
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional
 
 import structlog
 
@@ -59,6 +60,10 @@ from src.services.intelligence.monitoring.run_repository import (
 from src.services.intelligence.monitoring.subscription_manager import (
     SubscriptionManager,
 )
+
+if TYPE_CHECKING:
+    from src.services.providers.arxiv import ArxivProvider
+    from src.services.registry.service import RegistryService
 
 logger = structlog.get_logger()
 
@@ -92,6 +97,53 @@ class MonitoringRunner:
         self._subscriptions = subscription_manager
         self._monitor = monitor
         self._run_repo = run_repo
+
+    @classmethod
+    def from_paths(
+        cls,
+        *,
+        db_path: Path,
+        registry: "RegistryService",
+        arxiv_provider: "ArxivProvider",
+    ) -> "MonitoringRunner":
+        """Convenience factory wiring the standard collaborators.
+
+        The Week-2 ``MonitoringCheckJob`` (#117) and any CLI / REST
+        surface that just has a ``db_path`` plus the shared
+        infrastructure handles (registry, arxiv provider) shouldn't
+        have to instantiate ``SubscriptionManager`` + ``ArxivMonitor`` +
+        ``MonitoringRunRepository`` by hand -- the facade promises a
+        one-liner. This classmethod is that one-liner.
+
+        Both subscription manager and run repo are eagerly initialized
+        so the caller doesn't have to remember the two-phase
+        construct-then-initialize idiom.
+
+        Args:
+            db_path: SQLite database file path. Must lie under one of
+                the approved storage roots (``data/``, ``cache/``, or
+                the system temp dir) -- enforced by
+                :func:`sanitize_storage_path` inside both
+                ``SubscriptionManager`` and ``MonitoringRunRepository``.
+            registry: The shared global ``RegistryService`` used by the
+                monitor for paper deduplication.
+            arxiv_provider: The shared ``ArxivProvider`` used by the
+                monitor to poll ArXiv.
+
+        Returns:
+            A fully-wired, initialized ``MonitoringRunner`` ready for
+            ``run_once()``.
+        """
+        sub_mgr = SubscriptionManager(db_path)
+        sub_mgr.initialize()
+        monitor = ArxivMonitor(provider=arxiv_provider, registry=registry)
+        repo = MonitoringRunRepository(db_path)
+        repo.initialize()
+        return cls(
+            subscription_manager=sub_mgr,
+            monitor=monitor,
+            run_repo=repo,
+        )
 
     async def run_once(self, user_id: Optional[str] = None) -> list[MonitoringRun]:
         """Run one monitoring cycle across all active subscriptions.

--- a/tests/unit/services/intelligence/monitoring/test_models.py
+++ b/tests/unit/services/intelligence/monitoring/test_models.py
@@ -21,8 +21,10 @@ from src.services.intelligence.models.monitoring import (
 from src.services.intelligence.monitoring.models import (
     MAX_KEYWORDS_PER_SUBSCRIPTION,
     MAX_PAPERS_PER_CYCLE,
+    MonitoringPaperAudit,
     MonitoringPaperRecord,
     MonitoringRun,
+    MonitoringRunAudit,
     MonitoringRunStatus,
     ResearchSubscription,
     SubscriptionStatus,
@@ -364,3 +366,204 @@ class TestSubscriptionLimitErrorIntegration:
     def test_subscription_limit_error_is_value_error(self) -> None:
         # ValueError ancestry is what lets Pydantic wrap it cleanly.
         assert issubclass(SubscriptionLimitError, ValueError)
+
+
+# ---------------------------------------------------------------------------
+# MonitoringPaperAudit (PR #124 #C5)
+# ---------------------------------------------------------------------------
+#
+# CLAUDE.md requires Pydantic validators to be behaviorally tested. The
+# audit DTOs were added in PR #124 with field caps + ``extra="forbid"``
+# but no per-field validator coverage; this block adds happy/reject
+# cases that pin every constraint on ``MonitoringPaperAudit`` and
+# ``MonitoringRunAudit``.
+
+
+class TestMonitoringPaperAudit:
+    """Validator + boundary coverage for ``MonitoringPaperAudit``.
+
+    Pinned constraints:
+    - ``paper_id``: min_length=1, max_length=512 (post-#S6 alignment)
+    - ``relevance_score``: range [0.0, 1.0], Optional, default None
+    - ``relevance_reasoning``: max_length=4096 (post-#S7 alignment),
+      Optional, default None
+    - ``registered``: bool, default False
+    - ``extra="forbid"``: unknown fields rejected
+    """
+
+    def test_audit_minimal_defaults(self) -> None:
+        rec = MonitoringPaperAudit(paper_id="2301.12345")
+        assert rec.paper_id == "2301.12345"
+        assert rec.registered is False
+        assert rec.relevance_score is None
+        assert rec.relevance_reasoning is None
+
+    def test_audit_full_construction(self) -> None:
+        rec = MonitoringPaperAudit(
+            paper_id="2301.12345",
+            registered=True,
+            relevance_score=0.9,
+            relevance_reasoning="strong match",
+        )
+        assert rec.paper_id == "2301.12345"
+        assert rec.registered is True
+        assert rec.relevance_score == 0.9
+        assert rec.relevance_reasoning == "strong match"
+
+    def test_audit_paper_id_rejects_empty(self) -> None:
+        with pytest.raises(ValidationError, match="at least 1 character"):
+            MonitoringPaperAudit(paper_id="")
+
+    def test_audit_paper_id_at_boundary_accepted(self) -> None:
+        # 512 chars exactly -- the post-#S6 cap.
+        rec = MonitoringPaperAudit(paper_id="x" * 512)
+        assert len(rec.paper_id) == 512
+
+    def test_audit_paper_id_above_boundary_rejected(self) -> None:
+        # 513 chars -- one over the max_length boundary.
+        with pytest.raises(ValidationError, match="at most 512 character"):
+            MonitoringPaperAudit(paper_id="x" * 513)
+
+    def test_audit_relevance_score_below_range_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            MonitoringPaperAudit(paper_id="x", relevance_score=-0.01)
+
+    def test_audit_relevance_score_above_range_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            MonitoringPaperAudit(paper_id="x", relevance_score=1.01)
+
+    def test_audit_relevance_reasoning_at_boundary_accepted(self) -> None:
+        rec = MonitoringPaperAudit(paper_id="x", relevance_reasoning="r" * 4096)
+        assert len(rec.relevance_reasoning or "") == 4096
+
+    def test_audit_relevance_reasoning_above_boundary_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="at most 4096 character"):
+            MonitoringPaperAudit(paper_id="x", relevance_reasoning="r" * 4097)
+
+    def test_audit_extra_field_forbidden(self) -> None:
+        # Pinning ``extra="forbid"`` -- unknown fields like ``unknown=...``
+        # must raise so callers can't silently smuggle data the audit
+        # table cannot store.
+        with pytest.raises(ValidationError):
+            MonitoringPaperAudit(paper_id="x", unknown="y")  # type: ignore[call-arg]
+
+
+class TestMonitoringRunAudit:
+    """Validator + composition coverage for ``MonitoringRunAudit``.
+
+    Pinned constraints:
+    - String fields capped at 64 chars; ``error`` capped at 2000.
+    - ``papers``: list of ``MonitoringPaperAudit`` only, defaults to [].
+    - ``papers_seen`` / ``papers_new``: ge=0.
+    - ``extra="forbid"``: unknown fields rejected.
+    - Round-trip via ``model_dump`` / ``model_validate``.
+    """
+
+    def _audit(
+        self, *, papers: list[MonitoringPaperAudit] | None = None
+    ) -> MonitoringRunAudit:
+        return MonitoringRunAudit(
+            run_id="run-001",
+            subscription_id="sub-001",
+            user_id="alice",
+            started_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            status=MonitoringRunStatus.SUCCESS,
+            papers=papers or [],
+        )
+
+    def test_audit_run_minimal_no_papers(self) -> None:
+        run = self._audit()
+        assert run.papers == []
+        assert run.papers_seen == 0
+        assert run.papers_new == 0
+        assert run.finished_at is None
+        assert run.error is None
+
+    def test_audit_run_with_one_paper(self) -> None:
+        papers = [MonitoringPaperAudit(paper_id="2301.0001", registered=True)]
+        run = self._audit(papers=papers)
+        assert len(run.papers) == 1
+        assert run.papers[0].paper_id == "2301.0001"
+
+    def test_audit_run_with_many_papers(self) -> None:
+        papers = [MonitoringPaperAudit(paper_id=f"p-{i}") for i in range(5)]
+        run = self._audit(papers=papers)
+        assert len(run.papers) == 5
+
+    def test_audit_run_papers_must_be_audit_instances(self) -> None:
+        # Composition guard: passing a MonitoringPaperRecord (the rich
+        # in-memory type) must fail. Pydantic will try to coerce dict
+        # values, but a record carries fields like ``title`` that the
+        # audit type forbids -- so the coercion fails.
+        record = MonitoringPaperRecord(
+            paper_id="2301.0001", title="Some Paper", is_new=True
+        )
+        with pytest.raises(ValidationError):
+            MonitoringRunAudit(
+                run_id="run-001",
+                subscription_id="sub-001",
+                user_id="alice",
+                started_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                status=MonitoringRunStatus.SUCCESS,
+                papers=[record.model_dump()],  # type: ignore[list-item]
+            )
+
+    def test_audit_run_negative_paper_counts_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            MonitoringRunAudit(
+                run_id="run-001",
+                subscription_id="sub-001",
+                user_id="alice",
+                started_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                status=MonitoringRunStatus.SUCCESS,
+                papers_seen=-1,
+            )
+
+    def test_audit_run_extra_field_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            MonitoringRunAudit(
+                run_id="run-001",
+                subscription_id="sub-001",
+                user_id="alice",
+                started_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                status=MonitoringRunStatus.SUCCESS,
+                junk="bad",  # type: ignore[call-arg]
+            )
+
+    def test_audit_run_round_trip_via_model_dump(self) -> None:
+        original = self._audit(
+            papers=[
+                MonitoringPaperAudit(paper_id="p-1", registered=True),
+                MonitoringPaperAudit(
+                    paper_id="p-2",
+                    relevance_score=0.5,
+                    relevance_reasoning="ok",
+                ),
+            ]
+        )
+        rebuilt = MonitoringRunAudit.model_validate(original.model_dump())
+        assert rebuilt == original
+        assert isinstance(rebuilt, MonitoringRunAudit)
+        for p in rebuilt.papers:
+            assert isinstance(p, MonitoringPaperAudit)
+
+    def test_audit_run_run_id_rejects_empty(self) -> None:
+        with pytest.raises(ValidationError):
+            MonitoringRunAudit(
+                run_id="",
+                subscription_id="sub-001",
+                user_id="alice",
+                started_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                status=MonitoringRunStatus.SUCCESS,
+            )
+
+    def test_audit_run_status_must_be_enum_member(self) -> None:
+        # Strict mode -- arbitrary string is not coerced.
+        with pytest.raises(ValidationError):
+            MonitoringRunAudit(
+                run_id="run-001",
+                subscription_id="sub-001",
+                user_id="alice",
+                started_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                status="bogus",  # type: ignore[arg-type]
+            )

--- a/tests/unit/services/intelligence/monitoring/test_run_repository.py
+++ b/tests/unit/services/intelligence/monitoring/test_run_repository.py
@@ -329,6 +329,42 @@ class TestRoundTrip:
     def test_get_returns_none_for_missing(self, repo: MonitoringRunRepository) -> None:
         assert repo.get_run("run-missing") is None
 
+    def test_fetch_papers_returns_only_validated_audit_dtos(
+        self, repo: MonitoringRunRepository
+    ) -> None:
+        """PR #124 team review: pin the read-path type contract.
+
+        ``_fetch_papers`` must return ``list[MonitoringPaperAudit]`` --
+        never raw rows / dicts. The source-side assertion in the
+        method enforces this at runtime; this test pins the contract
+        from the consumer's perspective.
+        """
+        records = [
+            _make_record(paper_id="2301.0001", is_new=True),
+            _make_record(
+                paper_id="2301.0002",
+                is_new=False,
+                relevance_score=0.5,
+                relevance_reasoning="ok",
+            ),
+        ]
+        run = _make_run(papers_seen=2, papers_new=1, papers=records)
+        repo.record_run(run)
+
+        # Use the public read path (which delegates to _fetch_papers).
+        fetched = repo.get_run(run.run_id)
+        assert fetched is not None
+        # Every element must be the audit DTO type -- not a dict, not
+        # the rich MonitoringPaperRecord, not a sqlite3.Row.
+        # Strict identity check (``type(...) is ...``, not ``isinstance``):
+        # a future MonitoringPaperRecord-style subclass that bypasses
+        # audit-DTO validation would still satisfy ``isinstance``; only
+        # ``is`` catches the type-leak we're guarding against.
+        for paper in fetched.papers:
+            assert (
+                type(paper) is MonitoringPaperAudit
+            ), f"_fetch_papers leaked non-audit type: {type(paper).__name__}"
+
 
 # ---------------------------------------------------------------------------
 # user_id handling

--- a/tests/unit/services/intelligence/monitoring/test_run_repository.py
+++ b/tests/unit/services/intelligence/monitoring/test_run_repository.py
@@ -277,8 +277,11 @@ class TestRoundTrip:
         assert fetched.papers_new == 1
         # Papers come back ordered by paper_id ASC.
         assert [p.paper_id for p in fetched.papers] == ["2301.0001", "2301.0002"]
-        assert fetched.papers[0].is_new is True
-        assert fetched.papers[1].is_new is False
+        # Read path returns MonitoringPaperAudit (PR #119 #S6); the
+        # ``is_new`` flag on the rich record is persisted as
+        # ``registered`` in the audit type.
+        assert fetched.papers[0].registered is True
+        assert fetched.papers[1].registered is False
         assert fetched.papers[1].relevance_score == 0.85
         assert fetched.papers[1].relevance_reasoning == "strong match"
 

--- a/tests/unit/services/intelligence/monitoring/test_run_repository.py
+++ b/tests/unit/services/intelligence/monitoring/test_run_repository.py
@@ -27,8 +27,10 @@ import pytest
 
 from src.services.intelligence.models.monitoring import PaperSource
 from src.services.intelligence.monitoring.models import (
+    MonitoringPaperAudit,
     MonitoringPaperRecord,
     MonitoringRun,
+    MonitoringRunAudit,
     MonitoringRunStatus,
 )
 from src.services.intelligence.monitoring.run_repository import (
@@ -111,7 +113,12 @@ def _make_record(
 ) -> MonitoringPaperRecord:
     return MonitoringPaperRecord(
         paper_id=paper_id,
-        title=paper_id,  # repo stores paper_id only; title=paper_id round-trips
+        # Audit DTO has no title field; the rich ``title`` here is for
+        # in-memory MonitoringPaperRecord round-trip only -- the
+        # repository's read path returns MonitoringPaperAudit which
+        # carries only the persisted columns (paper_id, registered,
+        # relevance_score, relevance_reasoning).
+        title=paper_id,
         is_new=is_new,
         relevance_score=relevance_score,
         relevance_reasoning=relevance_reasoning,
@@ -252,6 +259,10 @@ class TestRoundTrip:
         repo.record_run(run)
         fetched = repo.get_run(run.run_id)
         assert fetched is not None
+        # Regression guard for the DTO rename (PR #124 #C3): a refactor
+        # that reverts ``_row_to_audit`` to MonitoringRun would still
+        # match all field-value asserts since the types share columns.
+        assert isinstance(fetched, MonitoringRunAudit)
         assert fetched.run_id == run.run_id
         assert fetched.subscription_id == run.subscription_id
         assert fetched.status is MonitoringRunStatus.SUCCESS
@@ -273,15 +284,27 @@ class TestRoundTrip:
         repo.record_run(run)
         fetched = repo.get_run(run.run_id)
         assert fetched is not None
+        # Regression guard for the DTO rename (PR #124 #C3).
+        assert isinstance(fetched, MonitoringRunAudit)
         assert fetched.papers_seen == 2
         assert fetched.papers_new == 1
         # Papers come back ordered by paper_id ASC.
         assert [p.paper_id for p in fetched.papers] == ["2301.0001", "2301.0002"]
+        for p in fetched.papers:
+            # Per-paper DTO type guard (PR #124 #C3) -- prevents a
+            # regression that smuggles MonitoringPaperRecord back onto
+            # the read path.
+            assert isinstance(p, MonitoringPaperAudit)
         # Read path returns MonitoringPaperAudit (PR #119 #S6); the
         # ``is_new`` flag on the rich record is persisted as
         # ``registered`` in the audit type.
         assert fetched.papers[0].registered is True
         assert fetched.papers[1].registered is False
+        # Default-NULL round-trip on papers[0] -- prior tests only
+        # asserted the non-NULL papers[1] case, leaving the most likely
+        # column-mapping regression vector uncovered (PR #124 #C4).
+        assert fetched.papers[0].relevance_score is None
+        assert fetched.papers[0].relevance_reasoning is None
         assert fetched.papers[1].relevance_score == 0.85
         assert fetched.papers[1].relevance_reasoning == "strong match"
 
@@ -298,6 +321,7 @@ class TestRoundTrip:
         repo.record_run(run)
         fetched = repo.get_run(run.run_id)
         assert fetched is not None
+        assert isinstance(fetched, MonitoringRunAudit)
         assert fetched.finished_at == finished
         assert fetched.error == "boom"
         assert fetched.status is MonitoringRunStatus.FAILED
@@ -394,6 +418,9 @@ class TestListRuns:
         runs = repo.list_runs()
         # Sorted DESC: 12, 11, 10
         assert [r.run_id for r in runs] == ["run-001", "run-002", "run-000"]
+        # DTO rename regression guard (PR #124 #C3).
+        for r in runs:
+            assert isinstance(r, MonitoringRunAudit)
 
     def test_list_filter_by_subscription(
         self, repo: MonitoringRunRepository, db_path: Path
@@ -404,6 +431,8 @@ class TestListRuns:
         repo.record_run(_make_run(run_id="run-b", subscription_id="sub-y"))
         result = repo.list_runs(subscription_id="sub-x")
         assert [r.run_id for r in result] == ["run-a"]
+        for r in result:
+            assert isinstance(r, MonitoringRunAudit)
 
     def test_list_respects_limit(self, repo: MonitoringRunRepository) -> None:
         for i in range(5):
@@ -415,6 +444,8 @@ class TestListRuns:
             )
         result = repo.list_runs(limit=2)
         assert len(result) == 2
+        for r in result:
+            assert isinstance(r, MonitoringRunAudit)
 
     def test_list_invalid_limit_raises(self, repo: MonitoringRunRepository) -> None:
         with pytest.raises(ValueError, match="must be positive"):

--- a/tests/unit/services/intelligence/monitoring/test_runner.py
+++ b/tests/unit/services/intelligence/monitoring/test_runner.py
@@ -120,6 +120,72 @@ def _result_for(
 
 
 # ---------------------------------------------------------------------------
+# Factory: from_paths
+# ---------------------------------------------------------------------------
+
+
+class TestFromPathsFactory:
+    """Test ``MonitoringRunner.from_paths`` (PR #119 #S7).
+
+    Verifies that the convenience factory wires SubscriptionManager,
+    ArxivMonitor, and MonitoringRunRepository correctly so the Week-2
+    job can construct + run a complete cycle in a single call.
+    """
+
+    @pytest.mark.asyncio
+    async def test_from_paths_constructs_full_runner(
+        self, tmp_path  # type: ignore[no-untyped-def]
+    ) -> None:
+        """A from_paths-constructed runner should run_once cleanly
+        against an empty database and return an empty list (no
+        subscriptions registered yet).
+        """
+        from src.services.intelligence.monitoring.runner import MonitoringRunner
+
+        # Use a path inside the system temp dir (one of the approved
+        # storage roots for sanitize_storage_path).
+        db_path = tmp_path / "monitoring.db"
+        registry = MagicMock()  # ArxivMonitor only touches it on .check
+        provider = MagicMock()  # ditto
+
+        runner = MonitoringRunner.from_paths(
+            db_path=db_path,
+            registry=registry,
+            arxiv_provider=provider,
+        )
+        # No subscriptions persisted -> empty cycle.
+        runs = await runner.run_once()
+        assert runs == []
+
+    def test_from_paths_returns_initialized_components(
+        self, tmp_path  # type: ignore[no-untyped-def]
+    ) -> None:
+        """Factory must initialize both the SubscriptionManager and the
+        MonitoringRunRepository so the caller doesn't have to remember
+        the construct-then-initialize idiom.
+        """
+        from src.services.intelligence.monitoring.run_repository import (
+            MonitoringRunRepository,
+        )
+        from src.services.intelligence.monitoring.runner import MonitoringRunner
+        from src.services.intelligence.monitoring.subscription_manager import (
+            SubscriptionManager,
+        )
+
+        db_path = tmp_path / "init.db"
+        runner = MonitoringRunner.from_paths(
+            db_path=db_path,
+            registry=MagicMock(),
+            arxiv_provider=MagicMock(),
+        )
+        assert isinstance(runner._subscriptions, SubscriptionManager)
+        assert isinstance(runner._run_repo, MonitoringRunRepository)
+        # Both are initialized -- internal flag is the cheapest check.
+        assert runner._subscriptions._initialized is True
+        assert runner._run_repo._initialized is True
+
+
+# ---------------------------------------------------------------------------
 # Empty input
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/services/intelligence/monitoring/test_runner.py
+++ b/tests/unit/services/intelligence/monitoring/test_runner.py
@@ -457,6 +457,84 @@ class TestPersistenceFailures:
         assert len(runs) == 2
 
     @pytest.mark.asyncio
+    async def test_record_run_failure_skips_mark_checked(self) -> None:
+        """Atomic-state-transition guarantee (PR #124 team review).
+
+        If ``record_run`` raises (persistence outage), the runner MUST
+        NOT call ``mark_checked``. Otherwise the subscription's
+        ``last_checked_at`` advances past the polling window while the
+        audit row of papers found in that window is lost -- the Week-2
+        digest generator would silently miss research updates for that
+        interval.
+
+        Rebound: the next cycle re-polls the same window and re-records
+        the audit row.
+        """
+        sub_a = _make_subscription(subscription_id="sub-a")
+        sub_b = _make_subscription(subscription_id="sub-b")
+        runner, sub_mgr, _, _ = _build_runner(
+            subscriptions=[sub_a, sub_b],
+            check_results=[
+                _result_for(sub_a),
+                _result_for(sub_b),
+            ],
+            record_side_effect=RuntimeError("disk full"),
+        )
+        runs = await runner.run_once()
+
+        # Cycle continues -- both runs returned for observability.
+        assert len(runs) == 2
+        # Critical: NEITHER subscription gets marked-checked because
+        # both record_run calls raised. Mark-checked must be strictly
+        # downstream of audit-trail durability.
+        sub_mgr.mark_checked.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_record_run_failure_logs_skipping_mark_checked_event(
+        self,
+    ) -> None:
+        """The skip is observable -- ops can grep for the structured
+        event when investigating why a subscription's audit trail has
+        gaps.
+
+        Uses ``structlog.testing.capture_logs`` (project convention --
+        see test_run_repository.py:608) since structlog is not wired
+        through stdlib's root logger, so plain ``caplog`` would not
+        see the events.
+        """
+        import structlog.testing
+
+        sub = _make_subscription(subscription_id="sub-a")
+        runner, _, _, _ = _build_runner(
+            subscriptions=[sub],
+            check_results=[_result_for(sub)],
+            record_side_effect=RuntimeError("disk full"),
+        )
+        with structlog.testing.capture_logs() as logs:
+            runs = await runner.run_once()
+
+        skip_logs = [
+            entry
+            for entry in logs
+            if entry.get("event")
+            == "monitoring_persistence_failed_skipping_mark_checked"
+        ]
+        assert len(skip_logs) == 1, (
+            f"expected one persistence-skip log, got "
+            f"{[entry.get('event') for entry in logs]}"
+        )
+        # Pin all three bound fields the production call emits so a
+        # future refactor that drops one (e.g., run_id) trips the test.
+        skip = skip_logs[0]
+        assert skip.get("subscription_id") == "sub-a"
+        assert skip.get("error") == "disk full"
+        # run_id is auto-generated UUID4 on the in-memory MonitoringRun;
+        # we don't assert its value, just its presence + match to the
+        # in-memory run returned to the caller.
+        assert skip.get("run_id") is not None
+        assert skip.get("run_id") == runs[0].run_id
+
+    @pytest.mark.asyncio
     async def test_mark_checked_failure_does_not_abort_cycle(self) -> None:
         sub_a = _make_subscription(subscription_id="sub-a")
         sub_b = _make_subscription(subscription_id="sub-b")

--- a/tests/unit/services/intelligence/monitoring/test_runner.py
+++ b/tests/unit/services/intelligence/monitoring/test_runner.py
@@ -18,7 +18,8 @@ Covers:
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -28,6 +29,9 @@ from src.services.intelligence.monitoring.models import (
     MonitoringRunStatus,
     ResearchSubscription,
     SubscriptionStatus,
+)
+from src.services.intelligence.monitoring.run_repository import (
+    MonitoringRunRepository,
 )
 from src.services.intelligence.monitoring.runner import MonitoringRunner
 
@@ -133,12 +137,16 @@ class TestFromPathsFactory:
     """
 
     @pytest.mark.asyncio
-    async def test_from_paths_constructs_full_runner(
+    async def test_from_paths_empty_db_returns_empty_list(
         self, tmp_path  # type: ignore[no-untyped-def]
     ) -> None:
         """A from_paths-constructed runner should run_once cleanly
         against an empty database and return an empty list (no
         subscriptions registered yet).
+
+        Renamed from ``test_from_paths_constructs_full_runner`` per
+        CLAUDE.md ``test_<function>_<scenario>`` naming convention
+        (PR #124 #N6).
         """
         from src.services.intelligence.monitoring.runner import MonitoringRunner
 
@@ -163,6 +171,11 @@ class TestFromPathsFactory:
         """Factory must initialize both the SubscriptionManager and the
         MonitoringRunRepository so the caller doesn't have to remember
         the construct-then-initialize idiom.
+
+        Verifies initialization via the public APIs (PR #124 #N7) so
+        the test does not couple to private ``_initialized`` flags --
+        a successful ``list_subscriptions`` / ``list_runs`` call only
+        works after both repos have applied migrations.
         """
         from src.services.intelligence.monitoring.run_repository import (
             MonitoringRunRepository,
@@ -180,9 +193,83 @@ class TestFromPathsFactory:
         )
         assert isinstance(runner._subscriptions, SubscriptionManager)
         assert isinstance(runner._run_repo, MonitoringRunRepository)
-        # Both are initialized -- internal flag is the cheapest check.
-        assert runner._subscriptions._initialized is True
-        assert runner._run_repo._initialized is True
+        # Behavioral check: both repos respond cleanly to a public
+        # read API. ``list_subscriptions`` and ``list_runs`` both raise
+        # RuntimeError("not initialized") if migrations did not run --
+        # so a quiet ``[]`` proves the factory completed initialize().
+        assert runner._subscriptions.list_subscriptions() == []
+        assert runner._run_repo.list_runs() == []
+
+    def test_from_paths_rejects_path_outside_approved_roots(self) -> None:
+        """Path safety must propagate through the factory (PR #124 #C1).
+
+        ``sanitize_storage_path`` is called inside both
+        ``SubscriptionManager`` and ``MonitoringRunRepository``
+        constructors; ``from_paths`` must NOT swallow the resulting
+        ``SecurityError`` -- traversal attempts have to fail loud at
+        the factory boundary so the Week-2 scheduler does not silently
+        construct a runner pointed at ``/etc/passwd``.
+        """
+        from src.utils.security import SecurityError
+
+        with pytest.raises(SecurityError):
+            MonitoringRunner.from_paths(
+                db_path=Path("/etc/passwd"),
+                registry=MagicMock(),
+                arxiv_provider=MagicMock(),
+            )
+
+    def test_from_paths_propagates_repo_initialize_failure(
+        self, tmp_path  # type: ignore[no-untyped-def]
+    ) -> None:
+        """If ``repo.initialize()`` raises after ``sub_mgr.initialize()``
+        succeeds, the failure must propagate cleanly (PR #124 #C2).
+
+        Partial construction is documented as recoverable -- migrations
+        on both repos are idempotent so re-calling ``from_paths`` is
+        safe -- but the failure itself must reach the caller, not be
+        swallowed.
+        """
+        db_path = tmp_path / "monitoring.db"
+        with patch.object(
+            MonitoringRunRepository, "initialize", side_effect=RuntimeError("boom")
+        ):
+            with pytest.raises(RuntimeError, match="boom"):
+                MonitoringRunner.from_paths(
+                    db_path=db_path,
+                    registry=MagicMock(),
+                    arxiv_provider=MagicMock(),
+                )
+
+    def test_from_paths_recovers_after_repo_initialize_failure(
+        self, tmp_path  # type: ignore[no-untyped-def]
+    ) -> None:
+        """A second call after a transient initialize() failure must
+        succeed cleanly (PR #124 #C2).
+
+        Migrations on both repos are idempotent, so the partial state
+        left behind by the first attempt does not poison the retry.
+        Pins the docstring's recovery contract.
+        """
+        db_path = tmp_path / "monitoring.db"
+        with patch.object(
+            MonitoringRunRepository,
+            "initialize",
+            side_effect=[RuntimeError("transient"), None],
+        ):
+            with pytest.raises(RuntimeError, match="transient"):
+                MonitoringRunner.from_paths(
+                    db_path=db_path,
+                    registry=MagicMock(),
+                    arxiv_provider=MagicMock(),
+                )
+            # Second call succeeds -- migrations are idempotent.
+            runner = MonitoringRunner.from_paths(
+                db_path=db_path,
+                registry=MagicMock(),
+                arxiv_provider=MagicMock(),
+            )
+        assert runner is not None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

**Stacked on PR #123** — must merge after #123 lands.

Addresses two more PR #119 self-review items that didn't fit into PR #123 (which focused on schema + concurrency safety):

- **#S6** — `MonitoringPaperAudit` + `MonitoringRunAudit` DTOs (3 reviewers convergent)
- **#S7** — `MonitoringRunner.from_paths(...)` convenience factory (architect-reviewer)

## Changes

### `MonitoringPaperAudit` / `MonitoringRunAudit` (#S6)
PR #119 had `MonitoringRunRepository._fetch_papers` fabricating `title=paper_id` placeholders when reading rows back — because `monitoring_papers` doesn't store titles (those live in the registry). Three reviewers convergently flagged this as a silent-corruption surface for Week-2's digest generator (#117) which would render arXiv IDs as paper titles.

This PR introduces:
- `MonitoringPaperAudit` — Pydantic V2 strict, `extra="forbid"`. Carries only the persisted columns (`paper_id`, `registered`, `relevance_score`, `relevance_reasoning`).
- `MonitoringRunAudit` — wraps a list of `MonitoringPaperAudit` + scalar metadata.
- `MonitoringRunRepository`:
  - **WRITE path** (`record_run`) accepts `MonitoringRun` (rich, in-memory)
  - **READ path** (`get_run`, `list_runs`) returns `MonitoringRunAudit` (narrow, persisted)

The richer `MonitoringPaperRecord` stays as the in-memory type produced by `ArxivMonitor.check` — pipeline isn't disturbed.

### `MonitoringRunner.from_paths` factory (#S7)
The Week-2 `MonitoringCheckJob(BaseJob)` (issue #117) shouldn't have to wire 4 collaborators by hand. The new classmethod:

```python
runner = MonitoringRunner.from_paths(
    db_path=db_path,
    registry=registry,
    arxiv_provider=arxiv_provider,
)
runs = await runner.run_once()
```

Eagerly initializes both `SubscriptionManager` and `MonitoringRunRepository` so callers don't have to remember the two-phase idiom.

## Verification
- ✅ `./verify.sh` passes: 4507 tests, 99.26% combined coverage
- ✅ All intelligence/monitoring modules at 100% coverage
- ✅ 9 new tests (2 for factory, 7 for audit DTO round-trips)
- ✅ Black/Flake8/Mypy clean
- ✅ Pre-push hook clean

## Why stacked
- This work depends on `MIGRATION_V3` schema (FK + status CHECK) from PR #123
- And on `record_run`'s `BEGIN IMMEDIATE` semantics from PR #123
- Keeping #123 focused on "schema + concurrency safety" and this PR on "model boundary + ergonomics" gives reviewers cleaner boundaries

## Remaining PR #119 review items (still tracked)
The original PR #119 self-review had 11 items. Disposition:
- ✅ #C1 (FK on monitoring_runs.subscription_id) — PR #123
- ✅ #C2 (BEGIN IMMEDIATE in record_run) — PR #123
- ✅ #S8 (status CHECK constraint) — PR #123
- ✅ #S9 (OperationalError retry) — PR #123
- ✅ #S6 (MonitoringPaperAudit DTO) — this PR
- ✅ #S7 (from_paths factory) — this PR
- ⏭️ #C3 (ResourceWarning regression test for repo) — TODO
- ⏭️ #C4 (started_at timezone round-trip assertion) — TODO
- ⏭️ #C5 (record_run.call_count == 2 assertion in failure tests) — TODO
- ⏭️ #S10 (consolidate unified_graph/time_series/migrations onto open_connection) — TODO (own scope, separate issue)
- ⏭️ #S11 (test_filter_by_user_passed_through behavioral isolation) — TODO

The 5 TODO items are smaller fixes that can be batched into a single follow-up PR. Will file once #123 + this PR have moved through review.

## Refs
- PR #119 (foundational, merged)
- PR #123 (schema + concurrency, this PR's base)
- Issue #114