### PR TITLE
feat(phase-9.2): BFS citation crawler + influence scorer (closes #127, #129)

### DIFF
--- a/src/services/intelligence/citation/__init__.py
+++ b/src/services/intelligence/citation/__init__.py
@@ -30,6 +30,14 @@ Wrapping them would require either widening the ABC or layering an
 adapter on top — both add coupling without saving meaningful code.
 """
 
+from src.services.intelligence.citation.crawler import (
+    MAX_API_CALLS_PER_CRAWL,
+    CitationCrawler,
+    CrawlConfig,
+    CrawlDirection,
+    CrawlResult,
+    sort_by_influence,
+)
 from src.services.intelligence.citation.graph_builder import (
     BuildForPaperRequest,
     CitationGraphBuilder,
@@ -65,4 +73,11 @@ __all__ = [
     "GraphBuildResult",
     "ProviderTag",
     "BuildForPaperRequest",
+    # Crawler (Issue #127)
+    "CitationCrawler",
+    "CrawlConfig",
+    "CrawlDirection",
+    "CrawlResult",
+    "MAX_API_CALLS_PER_CRAWL",
+    "sort_by_influence",
 ]

--- a/src/services/intelligence/citation/__init__.py
+++ b/src/services/intelligence/citation/__init__.py
@@ -34,7 +34,6 @@ from src.services.intelligence.citation.crawler import (
     MAX_API_CALLS_PER_CRAWL,
     CitationCrawler,
     CrawlConfig,
-    CrawlDirection,
     CrawlResult,
     sort_by_influence,
 )
@@ -54,6 +53,8 @@ from src.services.intelligence.citation.models import (
     CitationDirection,
     CitationEdge,
     CitationNode,
+    CrawlDirection,
+    LegacyCitationDirection,
     make_citation_edge_id,
     make_paper_node_id,
 )
@@ -66,9 +67,11 @@ from src.services.intelligence.citation.semantic_scholar_client import (
 
 __all__ = [
     # Models
-    "CitationDirection",
+    "CitationDirection",  # legacy alias for LegacyCitationDirection
+    "LegacyCitationDirection",
     "CitationEdge",
     "CitationNode",
+    "CrawlDirection",  # canonical crawler direction (FORWARD/BACKWARD/BOTH)
     "make_citation_edge_id",
     "make_paper_node_id",
     # Clients

--- a/src/services/intelligence/citation/__init__.py
+++ b/src/services/intelligence/citation/__init__.py
@@ -40,6 +40,7 @@ from src.services.intelligence.citation.crawler import (
 from src.services.intelligence.citation.influence_scorer import (
     DEFAULT_CACHE_TTL,
     MAX_GRAPH_NODES_FOR_HITS,
+    MAX_GRAPH_NODES_FOR_PAGERANK,
     InfluenceMetrics,
     InfluenceScorer,
 )
@@ -94,4 +95,5 @@ __all__ = [
     "InfluenceMetrics",
     "DEFAULT_CACHE_TTL",
     "MAX_GRAPH_NODES_FOR_HITS",
+    "MAX_GRAPH_NODES_FOR_PAGERANK",
 ]

--- a/src/services/intelligence/citation/__init__.py
+++ b/src/services/intelligence/citation/__init__.py
@@ -38,6 +38,12 @@ from src.services.intelligence.citation.crawler import (
     CrawlResult,
     sort_by_influence,
 )
+from src.services.intelligence.citation.influence_scorer import (
+    DEFAULT_CACHE_TTL,
+    MAX_GRAPH_NODES_FOR_HITS,
+    InfluenceMetrics,
+    InfluenceScorer,
+)
 from src.services.intelligence.citation.graph_builder import (
     BuildForPaperRequest,
     CitationGraphBuilder,
@@ -80,4 +86,9 @@ __all__ = [
     "CrawlResult",
     "MAX_API_CALLS_PER_CRAWL",
     "sort_by_influence",
+    # Influence Scorer (Issue #129)
+    "InfluenceScorer",
+    "InfluenceMetrics",
+    "DEFAULT_CACHE_TTL",
+    "MAX_GRAPH_NODES_FOR_HITS",
 ]

--- a/src/services/intelligence/citation/_id_validation.py
+++ b/src/services/intelligence/citation/_id_validation.py
@@ -1,0 +1,57 @@
+"""Canonical paper-ID validation constants for the citation package.
+
+Why two patterns?
+-----------------
+Provider IDs and canonical graph-node IDs have different character sets:
+
+``RAW_PROVIDER_ID_PATTERN``
+    Accepts the full character set that provider APIs return in their id
+    fields, including ``/`` (needed for DOIs, e.g. ``10.18653/v1/...``).
+    Used by:
+    - :mod:`semantic_scholar_client` — validates the raw S2 paper id before
+      it is used to construct an HTTP URL.
+    - :mod:`crawler` — validates the seed paper id supplied by the caller
+      (which may be a DOI or arXiv id with slashes).
+
+``CANONICAL_NODE_ID_PATTERN``
+    Accepts only characters that pass the storage-layer ``node_id`` regex
+    enforced by ``GraphNode``. Excludes ``/`` because slashes are scrubbed
+    to ``_`` by :func:`models._normalize_id_segment` before a node id is
+    constructed.  Used by:
+    - :class:`CitationNode` — validates ``paper_id`` (the graph node id,
+      which is always ``paper:{source}:{normalized_external_id}``).
+    - :class:`CitationEdge` — validates ``citing_paper_id`` /
+      ``cited_paper_id`` (same shape as CitationNode.paper_id).
+    - :mod:`influence_scorer` — validates the caller-supplied ``paper_id``
+      at the scorer boundary (by that point the id is already normalized).
+
+Single source of truth
+-----------------------
+Before this module existed the same two regexes were duplicated across
+``models.py``, ``crawler.py``, ``influence_scorer.py``, and
+``semantic_scholar_client.py``.  A single definition here lets all of them
+import the appropriate constant and ensures any future loosening or
+tightening is applied consistently.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Allow-list for raw provider IDs (before normalization).  Includes ``/``
+# so DOIs (``10.18653/v1/...``) and arXiv forms (``arxiv:1706.03762``)
+# are accepted.  ``://`` and ``..`` are still blocked by the separate
+# forbidden-substring checks in the callers that need SSRF protection.
+RAW_PROVIDER_ID_PATTERN: re.Pattern[str] = re.compile(r"^[A-Za-z0-9:./_\-]+$")
+
+# Allow-list for canonical graph-node IDs (post-normalization).  Excludes
+# ``/`` because the storage layer's ``node_id`` column rejects it and
+# :func:`models._normalize_id_segment` collapses slashes to ``_`` before
+# emitting a node id.
+CANONICAL_NODE_ID_PATTERN: re.Pattern[str] = re.compile(r"^[A-Za-z0-9:._-]+$")
+
+# Shared length cap used everywhere.  512 characters leaves comfortable
+# headroom for realistic provider IDs (S2 native hex = 64 chars, DOIs
+# rarely exceed ~100) while bounding worst-case URL length and rejecting
+# payload-stuffing attempts.
+PAPER_ID_MAX_LENGTH: int = 512

--- a/src/services/intelligence/citation/crawler.py
+++ b/src/services/intelligence/citation/crawler.py
@@ -47,19 +47,22 @@ expansion shape.
 from __future__ import annotations
 
 import asyncio
-import re
 from collections import deque
 from datetime import date
-from enum import Enum
 from pathlib import Path
 from typing import Optional
 
 import structlog
 from pydantic import BaseModel, ConfigDict, Field
 
+from src.services.intelligence.citation._id_validation import (
+    PAPER_ID_MAX_LENGTH as _PAPER_ID_MAX_LENGTH,
+    RAW_PROVIDER_ID_PATTERN as _PAPER_ID_PATTERN,
+)
 from src.services.intelligence.citation.models import (
     CitationEdge,
     CitationNode,
+    CrawlDirection,
 )
 from src.services.intelligence.citation.openalex_client import (
     OpenAlexCitationClient,
@@ -87,24 +90,11 @@ MAX_API_CALLS_PER_CRAWL = 1000
 _MAX_CONCURRENT_REQUESTS = 10
 
 
-# Strict allow-list mirroring the providers' own paper_id regex. We
-# re-validate at the crawler boundary so a bad seed is rejected before
-# any provider call (defense-in-depth).
-_PAPER_ID_PATTERN = re.compile(r"^[A-Za-z0-9:./_\-]+$")
-_PAPER_ID_MAX_LENGTH = 512
-
-
-class CrawlDirection(str, Enum):
-    """Direction of the BFS expansion (REQ-9.2.2).
-
-    - ``FORWARD``: follow papers that cite the current paper.
-    - ``BACKWARD``: follow papers that the current paper references.
-    - ``BOTH``: union of the two.
-    """
-
-    FORWARD = "forward"
-    BACKWARD = "backward"
-    BOTH = "both"
+# Strict allow-list and length cap imported from the canonical single
+# source of truth in _id_validation.py (H-A1).  The aliases above
+# (``_PAPER_ID_PATTERN`` and ``_PAPER_ID_MAX_LENGTH``) retain the
+# underscore-prefixed module-private names so existing call sites
+# inside this module need no further changes.
 
 
 class CrawlConfig(BaseModel):

--- a/src/services/intelligence/citation/crawler.py
+++ b/src/services/intelligence/citation/crawler.py
@@ -77,10 +77,22 @@ from src.storage.intelligence_graph import GraphStore, SQLiteGraphStore
 logger = structlog.get_logger(__name__)
 
 
-# Hard cap on the total number of provider calls a single ``crawl()`` may
-# issue. Defends against runaway expansion when the per-level cap and
-# depth cap are both set high. When this is hit the crawler emits a
-# single ``citation_crawl_budget_exhausted`` event and stops.
+# Default cap on the total number of provider calls a single ``crawl()``
+# may issue. Defends against runaway expansion when the per-level cap
+# and depth cap are both set high. When the cap is hit the crawler emits
+# a ``citation_crawl_budget_exhausted`` event and stops.
+#
+# The actual per-call value is read from ``CrawlConfig.max_api_calls``,
+# which defaults to this constant. Callers can pass a tighter (or wider,
+# up to 10_000) bound per crawl. (H-A4/H-A5)
+#
+# NOTE on metric semantics: the counter increments once per logical
+# direction of a paper expansion (one for backward refs, one for forward
+# cites). Each "logical call" may map to multiple HTTP requests inside
+# the provider client because S2/OpenAlex paginate references and
+# citations server-side. Budget granularity is coarse on purpose; for
+# tighter rate control rely on the provider client's built-in
+# ``RateLimiter``. (H-A4)
 MAX_API_CALLS_PER_CRAWL = 1000
 
 # Concurrency bound on in-flight provider requests within a single
@@ -111,6 +123,11 @@ class CrawlConfig(BaseModel):
     direction: CrawlDirection = Field(default=CrawlDirection.BOTH)
     filter_min_citations: int = Field(default=0, ge=0)
     filter_year_min: Optional[int] = Field(default=None, ge=1800, le=2100)
+    # Per-crawl override of the global ``MAX_API_CALLS_PER_CRAWL``
+    # default. Lets callers tighten (e.g., 50 for unit tests) or widen
+    # (up to 10_000 for one-off batch jobs) the budget without changing
+    # the module-level constant. (H-A4/H-A5)
+    max_api_calls: int = Field(default=MAX_API_CALLS_PER_CRAWL, ge=1, le=10_000)
 
 
 class CrawlResult(BaseModel):
@@ -292,13 +309,13 @@ class CitationCrawler:
             # paper. We may need 1 (single direction) or 2 (BOTH) calls;
             # check conservatively against 1 so we never make a partial
             # set of calls beyond the budget — see issue #127 acceptance.
-            if result.api_calls_made >= MAX_API_CALLS_PER_CRAWL:
+            if result.api_calls_made >= config.max_api_calls:
                 result.budget_exhausted = True
                 logger.warning(
                     "citation_crawl_budget_exhausted",
                     seed_paper_id=seed_paper_id,
                     api_calls_made=result.api_calls_made,
-                    budget=MAX_API_CALLS_PER_CRAWL,
+                    budget=config.max_api_calls,
                 )
                 break
 
@@ -308,6 +325,7 @@ class CitationCrawler:
                     direction=config.direction,
                     semaphore=semaphore,
                     counter=result,
+                    max_api_calls=config.max_api_calls,
                 )
             except _BudgetExhausted:
                 # Budget hit mid-expansion (BOTH directions). Mark and
@@ -319,7 +337,7 @@ class CitationCrawler:
                     "citation_crawl_budget_exhausted",
                     seed_paper_id=seed_paper_id,
                     api_calls_made=result.api_calls_made,
-                    budget=MAX_API_CALLS_PER_CRAWL,
+                    budget=config.max_api_calls,
                 )
                 break
             except APIError as exc:
@@ -460,6 +478,7 @@ class CitationCrawler:
         direction: CrawlDirection,
         semaphore: asyncio.Semaphore,
         counter: CrawlResult,
+        max_api_calls: int = MAX_API_CALLS_PER_CRAWL,
     ) -> _ExpandResult:
         """Fetch references / citations for one paper, applying budget.
 
@@ -490,7 +509,7 @@ class CitationCrawler:
         forward_edges: list[CitationEdge] = []
 
         if direction in (CrawlDirection.BACKWARD, CrawlDirection.BOTH):
-            if counter.api_calls_made >= MAX_API_CALLS_PER_CRAWL:
+            if counter.api_calls_made >= max_api_calls:
                 raise _BudgetExhausted()
             counter.api_calls_made += 1
             async with semaphore:
@@ -500,7 +519,7 @@ class CitationCrawler:
             backward_edges.extend(ref_edges)
 
         if direction in (CrawlDirection.FORWARD, CrawlDirection.BOTH):
-            if counter.api_calls_made >= MAX_API_CALLS_PER_CRAWL:
+            if counter.api_calls_made >= max_api_calls:
                 raise _BudgetExhausted()
             counter.api_calls_made += 1
             async with semaphore:

--- a/src/services/intelligence/citation/crawler.py
+++ b/src/services/intelligence/citation/crawler.py
@@ -1,0 +1,581 @@
+"""BFS citation chain crawler (Milestone 9.2 — REQ-9.2.2 / Issue #127).
+
+This module walks the citation graph **breadth-first** from a seed paper,
+expanding each visited paper's references / citations one provider hop
+at a time. Per spec Section 5.2:
+
+- Bounded by ``max_depth`` (1-3) and ``max_papers_per_level`` (10-200).
+- Direction filter: forward (papers citing the seed), backward
+  (papers cited by the seed), or both.
+- Ranking inside a level: ``influentialCitationCount`` DESC, then
+  ``citationCount`` DESC, then ``publication_date`` (year fallback)
+  DESC. Deterministic so re-runs are reproducible.
+- Per-crawl API budget: ``MAX_API_CALLS_PER_CRAWL`` (default 1000) —
+  emit a single ``citation_crawl_budget_exhausted`` event and stop.
+- Concurrency cap: ``asyncio.Semaphore(10)`` so a single crawl cannot
+  open more than ten in-flight provider requests at once.
+
+Failure semantics — codified from PR #124's silent-data-loss incident
+(see CLAUDE.md "Orchestration Patterns"):
+
+- **Per-paper provider failures** (``APIError`` from S2 / OpenAlex on
+  one node) are *fail-soft*: log ``citation_crawl_provider_failed_skipping_node``,
+  drop that node from the queue, and keep crawling. This is the
+  "Fail-Soft Boundary across independent peers" pattern — one bad
+  paper must not poison the entire crawl.
+- **Persistence failures** (``GraphStoreError`` on
+  ``add_nodes_batch`` / ``add_edges_batch``) are *fail-hard*: log
+  ``citation_crawl_persistence_failed_aborting`` and ABORT the entire
+  crawl immediately. No further API calls are made; no further nodes
+  are persisted. This preserves the "Checked Success" gating —
+  expanding a paper whose neighbors we could not persist would corrupt
+  the graph silently and leave dangling references.
+
+Reuse, not rebuild
+------------------
+The crawler **composes** the existing
+:class:`SemanticScholarCitationClient` and
+:class:`OpenAlexCitationClient` for per-paper expansion. It does not
+re-implement HTTP, caching, rate-limiting, SSRF defense, or paging.
+For persistence it goes directly to ``GraphStore.add_nodes_batch`` /
+``add_edges_batch`` (the bulk APIs the spec mandates), bypassing the
+``CitationGraphBuilder`` because the builder's depth=1 fallback /
+provider-tagging logic does not match BFS's "one paper at a time"
+expansion shape.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from collections import deque
+from datetime import date
+from enum import Enum
+from pathlib import Path
+from typing import Optional
+
+import structlog
+from pydantic import BaseModel, ConfigDict, Field
+
+from src.services.intelligence.citation.models import (
+    CitationEdge,
+    CitationNode,
+)
+from src.services.intelligence.citation.openalex_client import (
+    OpenAlexCitationClient,
+)
+from src.services.intelligence.citation.semantic_scholar_client import (
+    SemanticScholarCitationClient,
+)
+from src.services.intelligence.models import GraphStoreError
+from src.services.providers.base import APIError
+from src.storage.intelligence_graph import GraphStore, SQLiteGraphStore
+
+logger = structlog.get_logger(__name__)
+
+
+# Hard cap on the total number of provider calls a single ``crawl()`` may
+# issue. Defends against runaway expansion when the per-level cap and
+# depth cap are both set high. When this is hit the crawler emits a
+# single ``citation_crawl_budget_exhausted`` event and stops.
+MAX_API_CALLS_PER_CRAWL = 1000
+
+# Concurrency bound on in-flight provider requests within a single
+# crawl. The spec's per-level cap (50 by default) and depth cap (2) make
+# 10 a comfortable bound: high enough to amortize round-trips, low
+# enough to not overwhelm the provider's rate limiter.
+_MAX_CONCURRENT_REQUESTS = 10
+
+
+# Strict allow-list mirroring the providers' own paper_id regex. We
+# re-validate at the crawler boundary so a bad seed is rejected before
+# any provider call (defense-in-depth).
+_PAPER_ID_PATTERN = re.compile(r"^[A-Za-z0-9:./_\-]+$")
+_PAPER_ID_MAX_LENGTH = 512
+
+
+class CrawlDirection(str, Enum):
+    """Direction of the BFS expansion (REQ-9.2.2).
+
+    - ``FORWARD``: follow papers that cite the current paper.
+    - ``BACKWARD``: follow papers that the current paper references.
+    - ``BOTH``: union of the two.
+    """
+
+    FORWARD = "forward"
+    BACKWARD = "backward"
+    BOTH = "both"
+
+
+class CrawlConfig(BaseModel):
+    """Configuration for one ``CitationCrawler.crawl()`` invocation.
+
+    Defaults match the spec:
+    - depth=2, level cap=50, both directions, no citation/year filter.
+    """
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    max_depth: int = Field(default=2, ge=1, le=3)
+    max_papers_per_level: int = Field(default=50, ge=10, le=200)
+    direction: CrawlDirection = Field(default=CrawlDirection.BOTH)
+    filter_min_citations: int = Field(default=0, ge=0)
+    filter_year_min: Optional[int] = Field(default=None, ge=1800, le=2100)
+
+
+class CrawlResult(BaseModel):
+    """Outcome of one crawl. All counters are post-deduplication."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    papers_visited: int = Field(default=0, ge=0)
+    levels_reached: int = Field(default=0, ge=0)
+    edges_added: int = Field(default=0, ge=0)
+    dropped_by_filter: dict[str, int] = Field(default_factory=dict)
+    api_calls_made: int = Field(default=0, ge=0)
+    budget_exhausted: bool = Field(default=False)
+    persistence_aborted: bool = Field(default=False)
+
+
+def sort_by_influence(papers: list[CitationNode]) -> list[CitationNode]:
+    """Deterministic ranking for top-k selection within a BFS level.
+
+    Per spec REQ-9.2.2:
+    1. ``influentialCitationCount`` DESC (None treated as 0)
+    2. ``citationCount`` DESC
+    3. ``publication_date`` DESC, falling back to ``year`` (None / missing
+       treated as ``date.min`` so unknown-date papers sort last)
+    """
+
+    def _key(p: CitationNode) -> tuple[int, int, date]:
+        # publication_date is preferred; fall back to year-only papers
+        # by synthesising a Jan-1 date so the comparison stays
+        # well-typed. None / missing → date.min so the paper sorts last.
+        if p.publication_date is not None:
+            sort_date = p.publication_date
+        elif p.year is not None:
+            sort_date = date(p.year, 1, 1)
+        else:
+            sort_date = date.min
+        return (
+            p.influential_citation_count or 0,
+            p.citation_count or 0,
+            sort_date,
+        )
+
+    return sorted(papers, key=_key, reverse=True)
+
+
+class CitationCrawler:
+    """BFS citation chain crawler.
+
+    Constructor takes a :class:`GraphStore` and (at least one) provider
+    client. The :meth:`from_paths` factory wires the standard collaborators
+    for callers that just have a ``db_path``.
+    """
+
+    def __init__(
+        self,
+        store: GraphStore,
+        s2_client: Optional[SemanticScholarCitationClient] = None,
+        openalex_client: Optional[OpenAlexCitationClient] = None,
+    ) -> None:
+        if s2_client is None and openalex_client is None:
+            raise ValueError(
+                "CitationCrawler requires at least one provider client "
+                "(s2_client or openalex_client)"
+            )
+        self.store = store
+        self.s2_client = s2_client
+        self.openalex_client = openalex_client
+
+    @classmethod
+    def from_paths(
+        cls,
+        *,
+        db_path: Path | str,
+        s2_client: Optional[SemanticScholarCitationClient] = None,
+        openalex_client: Optional[OpenAlexCitationClient] = None,
+    ) -> "CitationCrawler":
+        """Convenience factory that initialises the SQLite graph store.
+
+        Mirrors :meth:`MonitoringRunner.from_paths` so CLI / scheduler
+        callers don't need to remember the two-phase
+        construct-then-initialize idiom.
+        """
+        if s2_client is None and openalex_client is None:
+            # Default wiring: build a Semantic Scholar client on demand.
+            # API key (if any) is read from the standard env var inside
+            # the client constructor.
+            s2_client = SemanticScholarCitationClient()
+        store = SQLiteGraphStore(db_path)
+        store.initialize()
+        return cls(
+            store=store,
+            s2_client=s2_client,
+            openalex_client=openalex_client,
+        )
+
+    async def crawl(self, seed_paper_id: str, config: CrawlConfig) -> CrawlResult:
+        """Walk the citation graph breadth-first from ``seed_paper_id``.
+
+        Args:
+            seed_paper_id: The provider-recognized paper id to start from
+                (validated against ``_PAPER_ID_PATTERN``).
+            config: Crawl configuration (depth, level cap, direction,
+                filters).
+
+        Returns:
+            A :class:`CrawlResult` summarising what happened.
+
+        Raises:
+            ValueError: If ``seed_paper_id`` fails the strict allow-list.
+        """
+        self._validate_seed(seed_paper_id)
+
+        result = CrawlResult()
+        visited: set[str] = {seed_paper_id}
+        # Track every node id we have already inserted (or attempted to
+        # insert) into the graph. Used to dedupe persistence batches
+        # across BFS layers — the seed re-appears as the ``seed_node``
+        # of every expansion, and shared neighbours can resurface across
+        # branches. Without this, ``add_nodes_batch`` would raise a
+        # UNIQUE-constraint error on the duplicate row and abort the
+        # crawl unnecessarily.
+        persisted_node_ids: set[str] = set()
+        # BFS queue stores (paper_id, depth_of_paper). The seed is at
+        # depth 0; its neighbours land at depth 1.
+        queue: deque[tuple[str, int]] = deque([(seed_paper_id, 0)])
+
+        semaphore = asyncio.Semaphore(_MAX_CONCURRENT_REQUESTS)
+        # Per-filter drop counters are surfaced in the result so ops can
+        # tell at a glance whether the filter was too aggressive.
+        dropped: dict[str, int] = {"min_citations": 0, "year_min": 0}
+
+        while queue:
+            paper_id, depth = queue.popleft()
+            # Per spec: process only nodes whose depth is strictly less
+            # than max_depth. The seed (depth 0) expands once when
+            # max_depth=1, twice when max_depth=2, etc.
+            if depth >= config.max_depth:
+                continue
+
+            # Budget check BEFORE issuing any provider call for this
+            # paper. We may need 1 (single direction) or 2 (BOTH) calls;
+            # check conservatively against 1 so we never make a partial
+            # set of calls beyond the budget — see issue #127 acceptance.
+            if result.api_calls_made >= MAX_API_CALLS_PER_CRAWL:
+                result.budget_exhausted = True
+                logger.warning(
+                    "citation_crawl_budget_exhausted",
+                    seed_paper_id=seed_paper_id,
+                    api_calls_made=result.api_calls_made,
+                    budget=MAX_API_CALLS_PER_CRAWL,
+                )
+                break
+
+            try:
+                expanded = await self._expand_paper(
+                    paper_id=paper_id,
+                    direction=config.direction,
+                    semaphore=semaphore,
+                    counter=result,
+                )
+            except _BudgetExhausted:
+                # Budget hit mid-expansion (BOTH directions). Mark and
+                # exit the BFS loop. We deliberately do NOT persist
+                # whatever partial neighbours came back — the caller's
+                # ``budget_exhausted=True`` is the contract.
+                result.budget_exhausted = True
+                logger.warning(
+                    "citation_crawl_budget_exhausted",
+                    seed_paper_id=seed_paper_id,
+                    api_calls_made=result.api_calls_made,
+                    budget=MAX_API_CALLS_PER_CRAWL,
+                )
+                break
+            except APIError as exc:
+                # Fail-soft: one paper's provider failure must not abort
+                # the whole crawl. Log and skip — the BFS continues with
+                # whatever's already in the queue.
+                logger.warning(
+                    "citation_crawl_provider_failed_skipping_node",
+                    seed_paper_id=seed_paper_id,
+                    paper_id=paper_id,
+                    error=str(exc),
+                )
+                continue
+
+            parent_node, related_nodes, edges = expanded
+
+            # Apply filters BEFORE ranking + capping. Per spec the
+            # min_citations / year_min filters are about culling
+            # low-signal candidates, not about influencing the top-k
+            # ordering of the survivors.
+            kept_nodes, kept_edges = self._apply_filters(
+                related_nodes, edges, config, dropped
+            )
+
+            # Rank survivors deterministically and cap to the level
+            # budget. Edges are filtered to the kept set so we never
+            # persist an edge whose target was dropped — that would
+            # produce an orphan reference at the storage layer.
+            ranked = sort_by_influence(kept_nodes)
+            top_k = ranked[: config.max_papers_per_level]
+            top_k_ids = {n.paper_id for n in top_k}
+            top_k_edges = [
+                e
+                for e in kept_edges
+                if (e.citing_paper_id in top_k_ids or e.cited_paper_id in top_k_ids)
+            ]
+
+            # Persist this layer. CHECKED SUCCESS: if persistence fails
+            # we MUST abort the whole crawl, not just skip the layer —
+            # otherwise the next BFS hop would expand a paper we never
+            # successfully wrote, leaving dangling edges.
+            #
+            # ``parent_node`` is the canonical CitationNode the API
+            # returned for the paper we're expanding. It must be
+            # included so its node row exists in the graph BEFORE the
+            # outgoing edges are inserted (FOREIGN KEY constraint). We
+            # dedupe via ``persisted_node_ids`` so re-encountering the
+            # parent across BFS layers does not raise a UNIQUE error.
+            persistence_ok = self._persist_layer(
+                paper_id=paper_id,
+                parent_node=parent_node,
+                related_nodes=top_k,
+                edges=top_k_edges,
+                seed_paper_id=seed_paper_id,
+                persisted_node_ids=persisted_node_ids,
+            )
+            if not persistence_ok:
+                result.persistence_aborted = True
+                break
+
+            # Update visited / queue with the kept nodes only. Counters
+            # below reflect what actually made it into the graph.
+            new_at_this_layer = 0
+            for node in top_k:
+                if node.paper_id in visited:
+                    continue
+                visited.add(node.paper_id)
+                queue.append((node.paper_id, depth + 1))
+                new_at_this_layer += 1
+
+            result.papers_visited += new_at_this_layer
+            result.levels_reached = max(result.levels_reached, depth + 1)
+            result.edges_added += len(top_k_edges)
+
+        result.dropped_by_filter = dropped
+        logger.info(
+            "citation_crawl_complete",
+            seed_paper_id=seed_paper_id,
+            papers_visited=result.papers_visited,
+            levels_reached=result.levels_reached,
+            edges_added=result.edges_added,
+            api_calls_made=result.api_calls_made,
+            budget_exhausted=result.budget_exhausted,
+            persistence_aborted=result.persistence_aborted,
+            dropped=dropped,
+        )
+        return result
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _validate_seed(seed_paper_id: str) -> None:
+        """Reject malformed seed ids before issuing any provider call.
+
+        The providers re-validate too; doing it here keeps the bad-id
+        error close to the caller and avoids burning a provider hit on
+        a guaranteed-to-fail request.
+        """
+        if not isinstance(seed_paper_id, str) or not seed_paper_id.strip():
+            raise ValueError("seed_paper_id must be a non-empty string")
+        if len(seed_paper_id) > _PAPER_ID_MAX_LENGTH:
+            raise ValueError(
+                f"seed_paper_id length {len(seed_paper_id)} exceeds max "
+                f"{_PAPER_ID_MAX_LENGTH}"
+            )
+        if not _PAPER_ID_PATTERN.match(seed_paper_id):
+            raise ValueError(
+                f"Invalid seed_paper_id format: {seed_paper_id!r}. "
+                "Allowed: alphanumeric, colon, period, slash, underscore, hyphen."
+            )
+
+    async def _expand_paper(
+        self,
+        paper_id: str,
+        direction: CrawlDirection,
+        semaphore: asyncio.Semaphore,
+        counter: CrawlResult,
+    ) -> tuple[Optional[CitationNode], list[CitationNode], list[CitationEdge]]:
+        """Fetch references / citations for one paper, applying budget.
+
+        Honors the BFS direction:
+        - BACKWARD → references only
+        - FORWARD → citations only
+        - BOTH → both, in that order
+
+        Each provider call is wrapped in the shared semaphore so the
+        in-flight count never exceeds ``_MAX_CONCURRENT_REQUESTS``.
+
+        Returns ``(parent_node, related_nodes, edges)`` where
+        ``parent_node`` is the canonical :class:`CitationNode` the
+        provider returned for ``paper_id``. The crawler must persist it
+        so outgoing edges have a valid FK target. ``parent_node`` is
+        ``None`` only when no provider call was made (e.g. an unknown
+        ``CrawlDirection`` value, defensive).
+        """
+        parent: Optional[CitationNode] = None
+        related: list[CitationNode] = []
+        edges: list[CitationEdge] = []
+
+        if direction in (CrawlDirection.BACKWARD, CrawlDirection.BOTH):
+            if counter.api_calls_made >= MAX_API_CALLS_PER_CRAWL:
+                raise _BudgetExhausted()
+            counter.api_calls_made += 1
+            async with semaphore:
+                seed, refs, ref_edges = await self._call_references(paper_id)
+            parent = seed
+            related.extend(refs)
+            edges.extend(ref_edges)
+
+        if direction in (CrawlDirection.FORWARD, CrawlDirection.BOTH):
+            if counter.api_calls_made >= MAX_API_CALLS_PER_CRAWL:
+                raise _BudgetExhausted()
+            counter.api_calls_made += 1
+            async with semaphore:
+                seed, cites, cite_edges = await self._call_citations(paper_id)
+            # FORWARD-only: parent is the citations seed. BOTH: keep the
+            # references seed (semantically identical paper; either is
+            # fine — the persistence layer will dedupe by node_id).
+            if parent is None:
+                parent = seed
+            related.extend(cites)
+            edges.extend(cite_edges)
+
+        return parent, related, edges
+
+    async def _call_references(
+        self, paper_id: str
+    ) -> tuple[CitationNode, list[CitationNode], list[CitationEdge]]:
+        """Dispatch to whichever provider is configured for references."""
+        client = self.s2_client or self.openalex_client
+        # Constructor enforced that at least one client is set.
+        assert client is not None
+        return await client.get_references(paper_id)
+
+    async def _call_citations(
+        self, paper_id: str
+    ) -> tuple[CitationNode, list[CitationNode], list[CitationEdge]]:
+        """Dispatch to whichever provider is configured for citations."""
+        client = self.s2_client or self.openalex_client
+        assert client is not None
+        return await client.get_citations(paper_id)
+
+    @staticmethod
+    def _apply_filters(
+        nodes: list[CitationNode],
+        edges: list[CitationEdge],
+        config: CrawlConfig,
+        dropped: dict[str, int],
+    ) -> tuple[list[CitationNode], list[CitationEdge]]:
+        """Drop nodes that fail min_citations / year_min; mirror to edges.
+
+        Per-filter drop counts are accumulated into ``dropped`` so the
+        crawl result can surface them.
+        """
+        kept_nodes: list[CitationNode] = []
+        for n in nodes:
+            if n.citation_count < config.filter_min_citations:
+                dropped["min_citations"] += 1
+                continue
+            if config.filter_year_min is not None:
+                # Papers without a known year are dropped when the
+                # filter is set, otherwise we can't honor the contract.
+                if n.year is None or n.year < config.filter_year_min:
+                    dropped["year_min"] += 1
+                    continue
+            kept_nodes.append(n)
+
+        kept_ids = {n.paper_id for n in kept_nodes}
+        kept_edges = [
+            e
+            for e in edges
+            if e.cited_paper_id in kept_ids or e.citing_paper_id in kept_ids
+        ]
+        return kept_nodes, kept_edges
+
+    def _persist_layer(
+        self,
+        paper_id: str,
+        parent_node: Optional[CitationNode],
+        related_nodes: list[CitationNode],
+        edges: list[CitationEdge],
+        seed_paper_id: str,
+        persisted_node_ids: set[str],
+    ) -> bool:
+        """Bulk-insert one layer's nodes + edges. Return False on failure.
+
+        Parent is included in the same batch as its related nodes so
+        the FK constraint on the outgoing edges is satisfied even on
+        the very first hop (the seed paper has not yet been written to
+        the graph at that point).
+
+        CHECKED SUCCESS gate: the caller must abort the BFS on a
+        ``False`` return value. We log the structured event here so the
+        audit trail is unambiguous (#127 + GEMINI.md §5).
+        """
+        # Build the dedup'd batch. Order matters: parent first so any
+        # related-node that happens to share the parent's id (rare but
+        # possible if a paper is in its own reference list) only
+        # appears once.
+        batch_nodes: list[CitationNode] = []
+        if parent_node is not None and parent_node.paper_id not in persisted_node_ids:
+            batch_nodes.append(parent_node)
+        for n in related_nodes:
+            if n.paper_id in persisted_node_ids:
+                continue
+            # The current batch may already contain this id if a node
+            # appears twice in the same level (e.g. references + citations
+            # under BOTH direction). Check the in-flight set too.
+            if any(b.paper_id == n.paper_id for b in batch_nodes):
+                continue
+            batch_nodes.append(n)
+
+        if not batch_nodes and not edges:
+            return True
+
+        graph_nodes = [n.to_graph_node() for n in batch_nodes]
+        graph_edges = [e.to_graph_edge() for e in edges]
+
+        try:
+            self.store.add_nodes_batch(graph_nodes)
+            self.store.add_edges_batch(graph_edges)
+        except GraphStoreError as exc:
+            logger.error(
+                "citation_crawl_persistence_failed_aborting",
+                seed_paper_id=seed_paper_id,
+                expanding_paper_id=paper_id,
+                node_count=len(graph_nodes),
+                edge_count=len(graph_edges),
+                error=str(exc),
+            )
+            return False
+
+        # Update the persisted set only after a successful batch.
+        for n in batch_nodes:
+            persisted_node_ids.add(n.paper_id)
+        return True
+
+
+class _BudgetExhausted(Exception):
+    """Internal signal: the crawl hit ``MAX_API_CALLS_PER_CRAWL``.
+
+    Raised inside ``_expand_paper`` and caught at the BFS loop so the
+    loop can exit cleanly with ``budget_exhausted=True``. Not part of
+    the public surface.
+    """

--- a/src/services/intelligence/citation/crawler.py
+++ b/src/services/intelligence/citation/crawler.py
@@ -137,6 +137,37 @@ class CrawlResult(BaseModel):
     persistence_aborted: bool = Field(default=False)
 
 
+class _ExpandResult:
+    """Internal DTO from ``_expand_paper``.
+
+    Keeps backward (references) and forward (citations) candidates
+    separate so the BFS loop can apply ``top_k`` per direction
+    independently (spec REQ-9.2.2 §574-592 — C-3 fix).
+    """
+
+    __slots__ = (
+        "parent_node",
+        "backward_nodes",
+        "backward_edges",
+        "forward_nodes",
+        "forward_edges",
+    )
+
+    def __init__(
+        self,
+        parent_node: Optional[CitationNode],
+        backward_nodes: list[CitationNode],
+        backward_edges: list[CitationEdge],
+        forward_nodes: list[CitationNode],
+        forward_edges: list[CitationEdge],
+    ) -> None:
+        self.parent_node = parent_node
+        self.backward_nodes = backward_nodes
+        self.backward_edges = backward_edges
+        self.forward_nodes = forward_nodes
+        self.forward_edges = forward_edges
+
+
 def sort_by_influence(papers: list[CitationNode]) -> list[CitationNode]:
     """Deterministic ranking for top-k selection within a BFS level.
 
@@ -249,8 +280,15 @@ class CitationCrawler:
 
         semaphore = asyncio.Semaphore(_MAX_CONCURRENT_REQUESTS)
         # Per-filter drop counters are surfaced in the result so ops can
-        # tell at a glance whether the filter was too aggressive.
-        dropped: dict[str, int] = {"min_citations": 0, "year_min": 0}
+        # tell at a glance whether the filter was too aggressive. We
+        # track separately for each direction so the ops team can see
+        # backward vs. forward attrition (C-3 fix).
+        dropped: dict[str, int] = {
+            "min_citations_backward": 0,
+            "year_min_backward": 0,
+            "min_citations_forward": 0,
+            "year_min_forward": 0,
+        }
 
         while queue:
             paper_id, depth = queue.popleft()
@@ -302,32 +340,53 @@ class CitationCrawler:
                     "citation_crawl_provider_failed_skipping_node",
                     seed_paper_id=seed_paper_id,
                     paper_id=paper_id,
-                    error=str(exc),
+                    error=repr(str(exc)[:512]),
                 )
                 continue
 
-            parent_node, related_nodes, edges = expanded
+            parent_node = expanded.parent_node
 
-            # Apply filters BEFORE ranking + capping. Per spec the
-            # min_citations / year_min filters are about culling
-            # low-signal candidates, not about influencing the top-k
-            # ordering of the survivors.
-            kept_nodes, kept_edges = self._apply_filters(
-                related_nodes, edges, config, dropped
-            )
+            # Apply filters + rank + cap INDEPENDENTLY per direction
+            # (spec REQ-9.2.2 §574-592, C-3 fix). Doing it on the union
+            # would let a direction with many candidates starve the other.
+            top_k: list[CitationNode] = []
+            top_k_edges: list[CitationEdge] = []
 
-            # Rank survivors deterministically and cap to the level
-            # budget. Edges are filtered to the kept set so we never
-            # persist an edge whose target was dropped — that would
-            # produce an orphan reference at the storage layer.
-            ranked = sort_by_influence(kept_nodes)
-            top_k = ranked[: config.max_papers_per_level]
-            top_k_ids = {n.paper_id for n in top_k}
-            top_k_edges = [
-                e
-                for e in kept_edges
-                if (e.citing_paper_id in top_k_ids or e.cited_paper_id in top_k_ids)
-            ]
+            if expanded.backward_nodes:
+                bw_kept, bw_kept_edges = self._apply_filters_directional(
+                    expanded.backward_nodes,
+                    expanded.backward_edges,
+                    config,
+                    dropped,
+                    prefix="backward",
+                )
+                bw_ranked = sort_by_influence(bw_kept)
+                bw_top = bw_ranked[: config.max_papers_per_level]
+                bw_ids = {n.paper_id for n in bw_top}
+                top_k.extend(bw_top)
+                top_k_edges.extend(
+                    e
+                    for e in bw_kept_edges
+                    if e.citing_paper_id in bw_ids or e.cited_paper_id in bw_ids
+                )
+
+            if expanded.forward_nodes:
+                fw_kept, fw_kept_edges = self._apply_filters_directional(
+                    expanded.forward_nodes,
+                    expanded.forward_edges,
+                    config,
+                    dropped,
+                    prefix="forward",
+                )
+                fw_ranked = sort_by_influence(fw_kept)
+                fw_top = fw_ranked[: config.max_papers_per_level]
+                fw_ids = {n.paper_id for n in fw_top}
+                top_k.extend(fw_top)
+                top_k_edges.extend(
+                    e
+                    for e in fw_kept_edges
+                    if e.citing_paper_id in fw_ids or e.cited_paper_id in fw_ids
+                )
 
             # Persist this layer. CHECKED SUCCESS: if persistence fails
             # we MUST abort the whole crawl, not just skip the layer —
@@ -411,7 +470,7 @@ class CitationCrawler:
         direction: CrawlDirection,
         semaphore: asyncio.Semaphore,
         counter: CrawlResult,
-    ) -> tuple[Optional[CitationNode], list[CitationNode], list[CitationEdge]]:
+    ) -> _ExpandResult:
         """Fetch references / citations for one paper, applying budget.
 
         Honors the BFS direction:
@@ -422,7 +481,12 @@ class CitationCrawler:
         Each provider call is wrapped in the shared semaphore so the
         in-flight count never exceeds ``_MAX_CONCURRENT_REQUESTS``.
 
-        Returns ``(parent_node, related_nodes, edges)`` where
+        Returns an :class:`_ExpandResult` that keeps BACKWARD (references)
+        and FORWARD (citations) candidates separate so the BFS loop can
+        apply ``top_k`` per direction independently (C-3 fix: spec
+        REQ-9.2.2 §574-592). Combining them before capping would allow
+        a direction with many high-quality candidates to starve the other.
+
         ``parent_node`` is the canonical :class:`CitationNode` the
         provider returned for ``paper_id``. The crawler must persist it
         so outgoing edges have a valid FK target. ``parent_node`` is
@@ -430,8 +494,10 @@ class CitationCrawler:
         ``CrawlDirection`` value, defensive).
         """
         parent: Optional[CitationNode] = None
-        related: list[CitationNode] = []
-        edges: list[CitationEdge] = []
+        backward_nodes: list[CitationNode] = []
+        backward_edges: list[CitationEdge] = []
+        forward_nodes: list[CitationNode] = []
+        forward_edges: list[CitationEdge] = []
 
         if direction in (CrawlDirection.BACKWARD, CrawlDirection.BOTH):
             if counter.api_calls_made >= MAX_API_CALLS_PER_CRAWL:
@@ -440,8 +506,8 @@ class CitationCrawler:
             async with semaphore:
                 seed, refs, ref_edges = await self._call_references(paper_id)
             parent = seed
-            related.extend(refs)
-            edges.extend(ref_edges)
+            backward_nodes.extend(refs)
+            backward_edges.extend(ref_edges)
 
         if direction in (CrawlDirection.FORWARD, CrawlDirection.BOTH):
             if counter.api_calls_made >= MAX_API_CALLS_PER_CRAWL:
@@ -454,10 +520,16 @@ class CitationCrawler:
             # fine — the persistence layer will dedupe by node_id).
             if parent is None:
                 parent = seed
-            related.extend(cites)
-            edges.extend(cite_edges)
+            forward_nodes.extend(cites)
+            forward_edges.extend(cite_edges)
 
-        return parent, related, edges
+        return _ExpandResult(
+            parent_node=parent,
+            backward_nodes=backward_nodes,
+            backward_edges=backward_edges,
+            forward_nodes=forward_nodes,
+            forward_edges=forward_edges,
+        )
 
     async def _call_references(
         self, paper_id: str
@@ -477,27 +549,75 @@ class CitationCrawler:
         return await client.get_citations(paper_id)
 
     @staticmethod
+    def _apply_filters_directional(
+        nodes: list[CitationNode],
+        edges: list[CitationEdge],
+        config: CrawlConfig,
+        dropped: dict[str, int],
+        prefix: str,
+    ) -> tuple[list[CitationNode], list[CitationEdge]]:
+        """Drop nodes that fail min_citations / year_min; mirror to edges.
+
+        Per-filter drop counts are accumulated into ``dropped`` under
+        direction-specific keys (``{prefix}_min_citations`` /
+        ``{prefix}_year_min``) so ops can diagnose backward vs. forward
+        attrition independently (C-3 fix).
+
+        Args:
+            nodes: Candidate nodes for this direction.
+            edges: All edges associated with this direction's candidates.
+            config: Crawl configuration (filters).
+            dropped: Running drop counters dict (mutated in-place).
+            prefix: ``"backward"`` or ``"forward"``.
+        """
+        min_cit_key = f"min_citations_{prefix}"
+        year_min_key = f"year_min_{prefix}"
+        kept_nodes: list[CitationNode] = []
+        for n in nodes:
+            if n.citation_count < config.filter_min_citations:
+                dropped[min_cit_key] = dropped.get(min_cit_key, 0) + 1
+                continue
+            if config.filter_year_min is not None:
+                # Papers without a known year are dropped when the
+                # filter is set, otherwise we can't honor the contract.
+                if n.year is None or n.year < config.filter_year_min:
+                    dropped[year_min_key] = dropped.get(year_min_key, 0) + 1
+                    continue
+            kept_nodes.append(n)
+
+        kept_ids = {n.paper_id for n in kept_nodes}
+        kept_edges = [
+            e
+            for e in edges
+            if e.cited_paper_id in kept_ids or e.citing_paper_id in kept_ids
+        ]
+        return kept_nodes, kept_edges
+
+    @staticmethod
     def _apply_filters(
         nodes: list[CitationNode],
         edges: list[CitationEdge],
         config: CrawlConfig,
         dropped: dict[str, int],
     ) -> tuple[list[CitationNode], list[CitationEdge]]:
-        """Drop nodes that fail min_citations / year_min; mirror to edges.
+        """Legacy single-direction filter (kept for backward compatibility).
 
-        Per-filter drop counts are accumulated into ``dropped`` so the
-        crawl result can surface them.
+        Delegates to ``_apply_filters_directional`` with prefix ``""``.
+        ``dropped`` keys will be ``"min_citations_"`` / ``"year_min_"``
+        which are not standard; call sites inside ``crawl()`` use the
+        directional variant directly. This shim exists so any test or
+        caller that patches ``_apply_filters`` still works.
         """
+        min_cit_key = "min_citations"
+        year_min_key = "year_min"
         kept_nodes: list[CitationNode] = []
         for n in nodes:
             if n.citation_count < config.filter_min_citations:
-                dropped["min_citations"] += 1
+                dropped[min_cit_key] = dropped.get(min_cit_key, 0) + 1
                 continue
             if config.filter_year_min is not None:
-                # Papers without a known year are dropped when the
-                # filter is set, otherwise we can't honor the contract.
                 if n.year is None or n.year < config.filter_year_min:
-                    dropped["year_min"] += 1
+                    dropped[year_min_key] = dropped.get(year_min_key, 0) + 1
                     continue
             kept_nodes.append(n)
 

--- a/src/services/intelligence/citation/influence_scorer.py
+++ b/src/services/intelligence/citation/influence_scorer.py
@@ -39,7 +39,6 @@ Failure semantics
 from __future__ import annotations
 
 import asyncio
-import re
 import sqlite3
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
@@ -48,6 +47,10 @@ from typing import Optional
 import structlog
 from pydantic import BaseModel, ConfigDict, Field
 
+from src.services.intelligence.citation._id_validation import (
+    CANONICAL_NODE_ID_PATTERN,
+    PAPER_ID_MAX_LENGTH,
+)
 from src.services.intelligence.models import EdgeType, NodeType
 from src.storage.intelligence_graph import (
     GraphAlgorithms,
@@ -81,10 +84,12 @@ DEFAULT_CACHE_TTL = timedelta(days=7)
 _HITS_MAX_ITERATIONS = 100
 _HITS_EPSILON = 1e-6
 
-# Strict allow-list mirroring the providers' / crawler's paper_id
-# pattern. Defense-in-depth at the scorer boundary.
-_PAPER_ID_PATTERN = re.compile(r"^[A-Za-z0-9:._-]+$")
-_PAPER_ID_MAX_LENGTH = 512
+# Strict allow-list imported from the canonical single source of truth
+# in _id_validation.py (H-A1). The scorer validates the post-normalization
+# canonical node-id pattern (no slashes — those were scrubbed by
+# _normalize_id_segment when the CitationNode was built).
+_PAPER_ID_PATTERN = CANONICAL_NODE_ID_PATTERN
+_PAPER_ID_MAX_LENGTH = PAPER_ID_MAX_LENGTH
 
 
 class InfluenceMetrics(BaseModel):

--- a/src/services/intelligence/citation/influence_scorer.py
+++ b/src/services/intelligence/citation/influence_scorer.py
@@ -71,6 +71,14 @@ logger = structlog.get_logger(__name__)
 # Phase-9 corpora.
 MAX_GRAPH_NODES_FOR_HITS = 10_000
 
+# Hard cap on the graph size for which PageRank is computed (H-S2).
+# PageRank is O(N × iterations) and fast in practice, but an
+# attacker-controlled corpus could insert thousands of nodes to cause
+# a CPU-stall. 50K is intentionally generous — 5× the HITS cap and
+# well above realistic Phase-9 corpora — but still provides a
+# safety bound against runaway expansion.
+MAX_GRAPH_NODES_FOR_PAGERANK = 50_000
+
 # Cached InfluenceMetrics rows are returned without recomputation if
 # their ``computed_at`` is within this window. Spec REQ-9.2.4 calls for
 # 7 days; tests pass smaller values via the constructor.
@@ -255,17 +263,29 @@ class InfluenceScorer:
         is wrapped in ``asyncio.to_thread`` so its O(N*iter) inner loop
         does not stall the event loop.
         """
-        # PageRank delegation. Single source of truth.
-        pagerank = await asyncio.to_thread(
-            GraphAlgorithms.pagerank,
-            self.store,
-            edge_types=[EdgeType.CITES.value],
-            damping=0.85,
-            node_type=NodeType.PAPER,
-        )
+        # Query node count once; shared by both the PageRank and HITS gates
+        # so we only pay for the COUNT(*) query once per invocation.
+        node_count = self.store.get_node_count(node_type=NodeType.PAPER)
+
+        # PageRank gate (H-S2): skip on oversize graphs to bound CPU.
+        if node_count > MAX_GRAPH_NODES_FOR_PAGERANK:
+            logger.warning(
+                "influence_scorer_pagerank_skipped_oversize_graph",
+                node_count=node_count,
+                limit=MAX_GRAPH_NODES_FOR_PAGERANK,
+            )
+            pagerank: dict[str, float] = {}
+        else:
+            # PageRank delegation. Single source of truth.
+            pagerank = await asyncio.to_thread(
+                GraphAlgorithms.pagerank,
+                self.store,
+                edge_types=[EdgeType.CITES.value],
+                damping=0.85,
+                node_type=NodeType.PAPER,
+            )
 
         # HITS — skipped on oversize graphs.
-        node_count = self.store.get_node_count(node_type=NodeType.PAPER)
         if node_count > MAX_GRAPH_NODES_FOR_HITS:
             logger.warning(
                 "influence_scorer_hits_skipped_oversize_graph",

--- a/src/services/intelligence/citation/influence_scorer.py
+++ b/src/services/intelligence/citation/influence_scorer.py
@@ -1,0 +1,489 @@
+"""Citation influence scorer (Milestone 9.2 — REQ-9.2.4 / Issue #129).
+
+Computes per-paper influence metrics over the citation graph:
+
+- ``citation_count`` — direct from the stored CitationNode.
+- ``citation_velocity`` — citations per year since publication.
+- ``pagerank_score`` — delegated to
+  :func:`GraphAlgorithms.pagerank` (the single source of truth for
+  PageRank in this codebase). We never reimplement PageRank here.
+- ``hub_score`` / ``authority_score`` — HITS power iteration on the
+  citation adjacency matrix. Skipped (zeros) when the graph exceeds
+  ``MAX_GRAPH_NODES_FOR_HITS`` to bound CPU.
+
+Persistence
+-----------
+Results are cached in the ``citation_influence_metrics`` table
+introduced by V4 of the migration manager. ``compute_for_paper`` checks
+the cache first; if the row's ``computed_at`` is within ``CACHE_TTL``
+(7 days), the cached row is returned and the expensive PageRank /
+HITS work is skipped. ``compute_for_graph`` is the bulk variant: a
+single PageRank invocation covers all requested nodes, then the rows
+are upserted in one ``BEGIN IMMEDIATE`` transaction so partial-write
+recovery is straightforward.
+
+Failure semantics
+-----------------
+- HITS skip on oversize graph emits
+  ``influence_scorer_hits_skipped_oversize_graph`` (audit-write so ops
+  can grep) and returns hub/authority = 0.0. PageRank still runs.
+- Missing publication date emits
+  ``influence_scorer_velocity_skipped_missing_date`` and returns
+  velocity = 0.0.
+- Cache write failures DO NOT cause the API call to fail — the
+  computed metrics are still returned to the caller. The cache miss
+  is logged via ``influence_scorer_cache_write_failed`` so ops can
+  investigate disk pressure / migration drift.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import sqlite3
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+
+import structlog
+from pydantic import BaseModel, ConfigDict, Field
+
+from src.services.intelligence.models import EdgeType, NodeType
+from src.storage.intelligence_graph import (
+    GraphAlgorithms,
+    SQLiteGraphStore,
+    open_connection,
+)
+
+logger = structlog.get_logger(__name__)
+
+
+# Hard cap on the graph size for which HITS is computed inline. Above
+# this threshold we skip HITS (returning 0.0 for hub/authority) to
+# bound CPU; PageRank is still computed because GraphAlgorithms.pagerank
+# uses a fixed-iteration count and scales linearly. 10K nodes is the
+# documented soft cap for the SQLite-backed graph (see
+# MigrationManager.NODE_COUNT_WARNING_THRESHOLD = 75K) — well below the
+# point where SQLite becomes the bottleneck, well above realistic
+# Phase-9 corpora.
+MAX_GRAPH_NODES_FOR_HITS = 10_000
+
+# Cached InfluenceMetrics rows are returned without recomputation if
+# their ``computed_at`` is within this window. Spec REQ-9.2.4 calls for
+# 7 days; tests pass smaller values via the constructor.
+DEFAULT_CACHE_TTL = timedelta(days=7)
+
+# HITS convergence parameters. Standard values for power iteration —
+# 100 iterations is well above what HITS needs to converge on a
+# realistic citation graph (typically <30), and 1e-6 is the precision
+# at which downstream consumers (recommender) cannot tell the
+# difference.
+_HITS_MAX_ITERATIONS = 100
+_HITS_EPSILON = 1e-6
+
+# Strict allow-list mirroring the providers' / crawler's paper_id
+# pattern. Defense-in-depth at the scorer boundary.
+_PAPER_ID_PATTERN = re.compile(r"^[A-Za-z0-9:._-]+$")
+_PAPER_ID_MAX_LENGTH = 512
+
+
+class InfluenceMetrics(BaseModel):
+    """Influence metrics for a single paper (REQ-9.2.4)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    paper_id: str = Field(..., min_length=1, max_length=512)
+    citation_count: int = Field(default=0, ge=0)
+    citation_velocity: float = Field(default=0.0, ge=0.0)
+    pagerank_score: float = Field(default=0.0, ge=0.0, le=1.0)
+    hub_score: float = Field(default=0.0, ge=0.0)
+    authority_score: float = Field(default=0.0, ge=0.0)
+    computed_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class InfluenceScorer:
+    """Compute and cache per-paper influence metrics.
+
+    Caching contract: ``compute_for_paper`` consults the
+    ``citation_influence_metrics`` table first. Rows whose
+    ``computed_at`` is within :data:`CACHE_TTL` are returned verbatim
+    (PageRank / HITS NOT re-invoked). Older rows are recomputed and
+    upserted.
+    """
+
+    def __init__(
+        self,
+        store: SQLiteGraphStore,
+        *,
+        cache_ttl: timedelta = DEFAULT_CACHE_TTL,
+        now: Optional[datetime] = None,
+    ) -> None:
+        """Initialise the scorer.
+
+        Args:
+            store: A ``SQLiteGraphStore`` whose schema is at V4 or later.
+                We rely on ``citation_influence_metrics`` (V4) and on
+                ``GraphAlgorithms``-friendly read primitives
+                (``_list_node_ids``, ``_list_edges_by_types``).
+            cache_ttl: How long a cached row remains valid. Default is
+                7 days per spec.
+            now: Injectable "current time" for tests. Defaults to
+                ``datetime.now(timezone.utc)`` evaluated on each lookup.
+        """
+        self.store = store
+        self.cache_ttl = cache_ttl
+        self._now_override = now
+
+    @classmethod
+    def from_paths(
+        cls,
+        *,
+        db_path: Path | str,
+        cache_ttl: timedelta = DEFAULT_CACHE_TTL,
+    ) -> "InfluenceScorer":
+        """Convenience factory mirroring CitationCrawler.from_paths."""
+        store = SQLiteGraphStore(db_path)
+        store.initialize()
+        return cls(store=store, cache_ttl=cache_ttl)
+
+    def _now(self) -> datetime:
+        """Return the current UTC time, honoring the test override."""
+        if self._now_override is not None:
+            return self._now_override
+        return datetime.now(timezone.utc)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def compute_for_paper(self, paper_id: str) -> InfluenceMetrics:
+        """Compute (or return cached) influence metrics for one paper.
+
+        Cache hit: returns the stored row without invoking PageRank.
+        Cache miss: runs PageRank + HITS over the whole graph, writes
+        the row, and returns the computed metrics.
+
+        Raises:
+            ValueError: If ``paper_id`` is malformed.
+        """
+        self._validate_paper_id(paper_id)
+
+        cached = self._read_cache(paper_id)
+        if cached is not None and self._is_fresh(cached.computed_at):
+            return cached
+
+        # Cache miss → compute over the whole graph (PageRank is
+        # graph-global; computing it for one node alone would be
+        # nonsensical). HITS is also global; skipped on oversize.
+        all_metrics = await self._compute_metrics_for_graph(target_ids={paper_id})
+        metrics = all_metrics.get(
+            paper_id,
+            InfluenceMetrics(paper_id=paper_id, computed_at=self._now()),
+        )
+        self._write_cache([metrics])
+        return metrics
+
+    async def compute_for_graph(self, node_ids: list[str]) -> list[InfluenceMetrics]:
+        """Bulk compute metrics for a set of papers.
+
+        One PageRank invocation; one HITS invocation; one batched
+        upsert. Returns metrics in the same order as ``node_ids``.
+
+        Raises:
+            ValueError: If any ``node_id`` is malformed.
+        """
+        for nid in node_ids:
+            self._validate_paper_id(nid)
+        if not node_ids:
+            return []
+
+        target_set = set(node_ids)
+        computed = await self._compute_metrics_for_graph(target_ids=target_set)
+        # Ensure every requested id has a row; missing ones get a
+        # baseline-zero metric so callers don't have to special-case
+        # "node not in graph yet".
+        out: list[InfluenceMetrics] = []
+        for nid in node_ids:
+            metrics = computed.get(
+                nid,
+                InfluenceMetrics(paper_id=nid, computed_at=self._now()),
+            )
+            out.append(metrics)
+        self._write_cache(out)
+        return out
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _validate_paper_id(paper_id: str) -> None:
+        if not isinstance(paper_id, str) or not paper_id.strip():
+            raise ValueError("paper_id must be a non-empty string")
+        if len(paper_id) > _PAPER_ID_MAX_LENGTH:
+            raise ValueError(
+                f"paper_id length {len(paper_id)} exceeds max "
+                f"{_PAPER_ID_MAX_LENGTH}"
+            )
+        if not _PAPER_ID_PATTERN.match(paper_id):
+            raise ValueError(
+                f"Invalid paper_id format: {paper_id!r}. "
+                "Allowed: alphanumeric, colons, periods, hyphens, underscores."
+            )
+
+    def _is_fresh(self, computed_at: datetime) -> bool:
+        """True iff ``computed_at`` is within the TTL window."""
+        return self._now() - computed_at < self.cache_ttl
+
+    async def _compute_metrics_for_graph(
+        self, target_ids: set[str]
+    ) -> dict[str, InfluenceMetrics]:
+        """Run PageRank + HITS over the graph; assemble per-paper metrics.
+
+        Only nodes in ``target_ids`` end up in the returned dict — the
+        graph-global computations cover every node, but we project to
+        the requested subset to keep the cache write batch small.
+
+        PageRank delegates to ``GraphAlgorithms.pagerank`` (the single
+        source of truth for PageRank in this codebase). HITS is
+        implemented inline because no shared algorithm exists yet — and
+        is wrapped in ``asyncio.to_thread`` so its O(N*iter) inner loop
+        does not stall the event loop.
+        """
+        # PageRank delegation. Single source of truth.
+        pagerank = await asyncio.to_thread(
+            GraphAlgorithms.pagerank,
+            self.store,
+            edge_types=[EdgeType.CITES.value],
+            damping=0.85,
+            node_type=NodeType.PAPER,
+        )
+
+        # HITS — skipped on oversize graphs.
+        node_count = self.store.get_node_count(node_type=NodeType.PAPER)
+        if node_count > MAX_GRAPH_NODES_FOR_HITS:
+            logger.warning(
+                "influence_scorer_hits_skipped_oversize_graph",
+                node_count=node_count,
+                limit=MAX_GRAPH_NODES_FOR_HITS,
+            )
+            hub_scores: dict[str, float] = {}
+            authority_scores: dict[str, float] = {}
+        else:
+            hub_scores, authority_scores = await asyncio.to_thread(self._compute_hits)
+
+        out: dict[str, InfluenceMetrics] = {}
+        for paper_id in target_ids:
+            node = self.store.get_node(paper_id)
+            citation_count = self._extract_citation_count(node)
+            velocity = self._compute_velocity(node, paper_id)
+            # PageRank scores from GraphAlgorithms can mathematically
+            # exceed 1.0 for tiny graphs (e.g. a single isolated node
+            # gets 1.0/n = 1.0 + (1-d)/n adjustments per iter). Clamp to
+            # [0.0, 1.0] for the InfluenceMetrics contract; the relative
+            # ordering is preserved.
+            pr = min(1.0, max(0.0, pagerank.get(paper_id, 0.0)))
+            out[paper_id] = InfluenceMetrics(
+                paper_id=paper_id,
+                citation_count=citation_count,
+                citation_velocity=velocity,
+                pagerank_score=pr,
+                hub_score=hub_scores.get(paper_id, 0.0),
+                authority_score=authority_scores.get(paper_id, 0.0),
+                computed_at=self._now(),
+            )
+        return out
+
+    def _compute_hits(self) -> tuple[dict[str, float], dict[str, float]]:
+        """HITS power iteration on the CITES adjacency.
+
+        Convergence: max ``_HITS_MAX_ITERATIONS`` iterations or
+        per-iteration delta below ``_HITS_EPSILON`` (whichever first).
+        Empty graphs return ({}, {}).
+        """
+        node_ids = self.store._list_node_ids(node_type=NodeType.PAPER)
+        if not node_ids:
+            return {}, {}
+
+        edges = self.store._list_edges_by_types([EdgeType.CITES.value])
+        node_set = set(node_ids)
+        # incoming[v] = list of u where u -> v (citing -> cited)
+        # outgoing[u] = list of v where u -> v
+        incoming: dict[str, list[str]] = {nid: [] for nid in node_ids}
+        outgoing: dict[str, list[str]] = {nid: [] for nid in node_ids}
+        for source, target in edges:
+            if source in node_set and target in node_set:
+                outgoing[source].append(target)
+                incoming[target].append(source)
+
+        hubs: dict[str, float] = {nid: 1.0 for nid in node_ids}
+        authorities: dict[str, float] = {nid: 1.0 for nid in node_ids}
+
+        for _ in range(_HITS_MAX_ITERATIONS):
+            # Authority update: a(v) = sum of h(u) for all u -> v
+            new_authorities: dict[str, float] = {}
+            for nid in node_ids:
+                new_authorities[nid] = sum(hubs[u] for u in incoming[nid])
+            # Hub update: h(u) = sum of a(v) for all u -> v
+            new_hubs: dict[str, float] = {}
+            for nid in node_ids:
+                new_hubs[nid] = sum(new_authorities[v] for v in outgoing[nid])
+
+            # L2 normalize to prevent score blow-up.
+            auth_norm = self._l2_norm(new_authorities)
+            hub_norm = self._l2_norm(new_hubs)
+            if auth_norm > 0:
+                new_authorities = {k: v / auth_norm for k, v in new_authorities.items()}
+            if hub_norm > 0:
+                new_hubs = {k: v / hub_norm for k, v in new_hubs.items()}
+
+            # Convergence check on max delta across either vector.
+            delta = max(
+                max(abs(new_authorities[nid] - authorities[nid]) for nid in node_ids),
+                max(abs(new_hubs[nid] - hubs[nid]) for nid in node_ids),
+            )
+            authorities = new_authorities
+            hubs = new_hubs
+            if delta < _HITS_EPSILON:
+                break
+
+        return hubs, authorities
+
+    @staticmethod
+    def _l2_norm(scores: dict[str, float]) -> float:
+        """L2 norm of a score vector."""
+        total: float = sum(v * v for v in scores.values())
+        return float(total**0.5)
+
+    def _compute_velocity(
+        self, node, paper_id: str  # noqa: ANN001  - GraphNode | None
+    ) -> float:
+        """Citations per year since publication.
+
+        Returns 0.0 (with audit-trail log event) when the publication
+        date / year is unknown — there is no defensible velocity to
+        report in that case, but downstream consumers don't want to
+        special-case None.
+        """
+        if node is None:
+            return 0.0
+        props = node.properties or {}
+        # Prefer publication_date (full date), fall back to year-only.
+        pub_date_str = props.get("publication_date")
+        year = props.get("year")
+        citation_count = int(props.get("citation_count") or 0)
+
+        pub_date: Optional[date] = None
+        if pub_date_str:
+            try:
+                pub_date = date.fromisoformat(pub_date_str)
+            except (TypeError, ValueError):
+                pub_date = None
+        if pub_date is None and year is not None:
+            try:
+                pub_date = date(int(year), 1, 1)
+            except (TypeError, ValueError):
+                pub_date = None
+
+        if pub_date is None:
+            logger.warning(
+                "influence_scorer_velocity_skipped_missing_date",
+                paper_id=paper_id,
+            )
+            return 0.0
+
+        today = self._now().date()
+        # Whole years only — fractional years would make the metric
+        # noisier than it deserves, and the spec says "per year".
+        years_since = max(1, today.year - pub_date.year)
+        return citation_count / years_since
+
+    @staticmethod
+    def _extract_citation_count(node) -> int:  # noqa: ANN001 - GraphNode | None
+        """Pull citation_count out of a node's properties dict."""
+        if node is None:
+            return 0
+        return int((node.properties or {}).get("citation_count") or 0)
+
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
+
+    def _read_cache(self, paper_id: str) -> Optional[InfluenceMetrics]:
+        """Read a cached metrics row by paper_id; None if absent."""
+        with open_connection(self.store.db_path) as conn:
+            cursor = conn.execute(
+                """
+                SELECT paper_id, citation_count, citation_velocity,
+                       pagerank_score, hub_score, authority_score,
+                       computed_at
+                FROM citation_influence_metrics
+                WHERE paper_id = ?
+                """,
+                (paper_id,),
+            )
+            row = cursor.fetchone()
+        if row is None:
+            return None
+        return InfluenceMetrics(
+            paper_id=row["paper_id"],
+            citation_count=row["citation_count"],
+            citation_velocity=row["citation_velocity"],
+            pagerank_score=row["pagerank_score"],
+            hub_score=row["hub_score"],
+            authority_score=row["authority_score"],
+            computed_at=datetime.fromisoformat(row["computed_at"]),
+        )
+
+    def _write_cache(self, rows: list[InfluenceMetrics]) -> None:
+        """Upsert metrics rows in a single BEGIN IMMEDIATE transaction.
+
+        Failure here is logged but does NOT propagate — the computed
+        metrics are still returned to the caller. The next read will
+        see the cache miss and recompute.
+        """
+        if not rows:
+            return
+        payload = [
+            (
+                m.paper_id,
+                m.citation_count,
+                m.citation_velocity,
+                m.pagerank_score,
+                m.hub_score,
+                m.authority_score,
+                m.computed_at.isoformat(),
+            )
+            for m in rows
+        ]
+        try:
+            with open_connection(self.store.db_path) as conn:
+                conn.execute("BEGIN IMMEDIATE")
+                conn.executemany(
+                    """
+                    INSERT INTO citation_influence_metrics (
+                        paper_id, citation_count, citation_velocity,
+                        pagerank_score, hub_score, authority_score,
+                        computed_at
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(paper_id) DO UPDATE SET
+                        citation_count = excluded.citation_count,
+                        citation_velocity = excluded.citation_velocity,
+                        pagerank_score = excluded.pagerank_score,
+                        hub_score = excluded.hub_score,
+                        authority_score = excluded.authority_score,
+                        computed_at = excluded.computed_at
+                    """,
+                    payload,
+                )
+                conn.commit()
+        except sqlite3.Error as exc:
+            # Audit-write the failure path so ops can grep for cache
+            # write outages. Returning the in-memory metrics preserves
+            # observability for the caller.
+            logger.error(
+                "influence_scorer_cache_write_failed",
+                row_count=len(rows),
+                error=str(exc),
+            )

--- a/src/services/intelligence/citation/models.py
+++ b/src/services/intelligence/citation/models.py
@@ -33,6 +33,9 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from src.services.intelligence.citation._id_validation import (
+    CANONICAL_NODE_ID_PATTERN,
+)
 from src.services.intelligence.models import (
     EdgeType,
     GraphEdge,
@@ -103,16 +106,47 @@ def make_citation_edge_id(citing_id: str, cited_id: str) -> str:
     return f"edge:cites:{digest}"
 
 
-class CitationDirection(str, Enum):
-    """Direction of citation traversal for the graph builder.
+class LegacyCitationDirection(str, Enum):
+    """Direction of citation traversal for the graph builder (legacy).
 
     - ``OUT``: outgoing — the seed paper's *references* (what it cites).
     - ``IN``: incoming — papers that *cite* the seed.
     - ``BOTH``: both directions (one round-trip per side).
+
+    .. deprecated::
+        This enum is the legacy graph-builder direction. New code that
+        operates the BFS crawler should use :class:`CrawlDirection` which
+        uses ``FORWARD`` / ``BACKWARD`` / ``BOTH`` to match the spec
+        vocabulary (REQ-9.2.2). ``CitationDirection`` is kept as an alias
+        for backward compatibility with ``graph_builder.py`` callers.
     """
 
     OUT = "out"
     IN = "in"
+    BOTH = "both"
+
+
+# Backward-compatible alias so all existing callers (graph_builder.py,
+# tests, public __init__.py) continue to work without changes.
+CitationDirection = LegacyCitationDirection
+
+
+class CrawlDirection(str, Enum):
+    """Direction of the BFS expansion (REQ-9.2.2 §574-592) — canonical enum.
+
+    This is the single source of truth for crawler direction across the
+    citation package. The legacy :class:`LegacyCitationDirection` (aliased
+    as ``CitationDirection``) uses OUT/IN semantics for the depth=1 graph
+    builder; this enum uses FORWARD/BACKWARD per the spec vocabulary.
+
+    - ``FORWARD``: follow papers that *cite* the current paper (incoming).
+    - ``BACKWARD``: follow papers that the current paper *references*
+      (outgoing — what the paper cites).
+    - ``BOTH``: union of the two (one provider call per direction).
+    """
+
+    FORWARD = "forward"
+    BACKWARD = "backward"
     BOTH = "both"
 
 
@@ -221,11 +255,13 @@ class CitationNode(BaseModel):
 
         We re-validate here so callers fail at model construction time
         with a meaningful error, rather than at the SQLite boundary.
+        Uses the canonical post-normalization pattern from
+        :mod:`_id_validation` (single source of truth — H-A1).
         """
         v = v.strip()
         if not v:
             raise ValueError("paper_id cannot be empty")
-        if not re.match(r"^[A-Za-z0-9:._-]+$", v):
+        if not CANONICAL_NODE_ID_PATTERN.match(v):
             raise ValueError(
                 f"Invalid paper_id format: {v!r}. "
                 "Allowed: alphanumeric, colons, periods, hyphens, underscores."
@@ -334,7 +370,7 @@ class CitationEdge(BaseModel):
         v = v.strip()
         if not v:
             raise ValueError("Citation paper ids cannot be empty")
-        if not re.match(r"^[A-Za-z0-9:._-]+$", v):
+        if not CANONICAL_NODE_ID_PATTERN.match(v):
             raise ValueError(
                 f"Invalid citation paper id: {v!r}. "
                 "Allowed: alphanumeric, colons, periods, hyphens, underscores."

--- a/src/services/intelligence/citation/models.py
+++ b/src/services/intelligence/citation/models.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 import hashlib
 import re
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from enum import Enum
 from typing import Any
 
@@ -194,6 +194,21 @@ class CitationNode(BaseModel):
         default=None,
         description="Optional precomputed influence score (e.g. PageRank).",
     )
+    influential_citation_count: int | None = Field(
+        default=None,
+        ge=0,
+        description=(
+            "Semantic Scholar 'influentialCitationCount' metric. None when the "
+            "source does not provide it (e.g. OpenAlex)."
+        ),
+    )
+    publication_date: date | None = Field(
+        default=None,
+        description=(
+            "Full publication date when known. Optional: many providers only "
+            "report year-precision; in those cases use 'year' instead."
+        ),
+    )
     fetched_at: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),
         description="When this record was fetched from the source.",
@@ -253,6 +268,10 @@ class CitationNode(BaseModel):
             properties["year"] = self.year
         if self.influence_score is not None:
             properties["influence_score"] = self.influence_score
+        if self.influential_citation_count is not None:
+            properties["influential_citation_count"] = self.influential_citation_count
+        if self.publication_date is not None:
+            properties["publication_date"] = self.publication_date.isoformat()
 
         return GraphNode(
             node_id=self.paper_id,

--- a/src/services/intelligence/citation/openalex_client.py
+++ b/src/services/intelligence/citation/openalex_client.py
@@ -34,7 +34,7 @@ import json
 import logging
 import os
 import re
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from email.utils import parsedate_to_datetime
 from pathlib import Path
 from typing import Any, Optional, cast
@@ -84,6 +84,7 @@ _OPENALEX_WORK_SELECT = ",".join(
         "doi",
         "title",
         "publication_year",
+        "publication_date",
         "cited_by_count",
         "referenced_works",
         "referenced_works_count",
@@ -770,6 +771,22 @@ class OpenAlexCitationClient:
 
         title = payload.get("title") or "Unknown Title"
 
+        # ``publication_date`` is an ISO-8601 date string (e.g. "2023-06-01")
+        # returned by OpenAlex when the exact date is known. Parse to ``date``
+        # so downstream consumers (crawler ranking, influence scorer) avoid
+        # re-parsing. Malformed or absent values degrade gracefully to None.
+        pub_date_raw = payload.get("publication_date")
+        publication_date: date | None = None
+        if isinstance(pub_date_raw, str) and pub_date_raw:
+            try:
+                publication_date = date.fromisoformat(pub_date_raw)
+            except ValueError:
+                logger.warning(
+                    "openalex_citation_malformed_publication_date",
+                    paper_id=oa_id,
+                    raw_value=pub_date_raw,
+                )
+
         return CitationNode(
             paper_id=make_paper_node_id("openalex", oa_id),
             external_ids=external_ids,
@@ -777,6 +794,7 @@ class OpenAlexCitationClient:
             year=payload.get("publication_year"),
             citation_count=int(payload.get("cited_by_count") or 0),
             reference_count=int(payload.get("referenced_works_count") or 0),
+            publication_date=publication_date,
         )
 
     @staticmethod

--- a/src/services/intelligence/citation/semantic_scholar_client.py
+++ b/src/services/intelligence/citation/semantic_scholar_client.py
@@ -29,7 +29,7 @@ import hashlib
 import json
 import os
 import re
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from email.utils import parsedate_to_datetime
 from pathlib import Path
 from typing import Any, Optional, cast
@@ -111,6 +111,7 @@ _S2_PAPER_FIELDS = ",".join(
         "citationCount",
         "influentialCitationCount",
         "referenceCount",
+        "publicationDate",
     ]
 )
 
@@ -599,6 +600,23 @@ class SemanticScholarCitationClient:
         influential_raw = payload.get("influentialCitationCount")
         influential = int(influential_raw) if influential_raw is not None else None
 
+        # ``publicationDate`` is an ISO-8601 date string (e.g. "2023-06-01")
+        # returned by S2 when the exact publication date is known. We parse it
+        # to a ``date`` object so the crawler's ranking and the influence scorer
+        # can use it without re-parsing.  Malformed or absent values are
+        # gracefully degraded to None — the crawler falls back to year-only.
+        pub_date_raw = payload.get("publicationDate")
+        publication_date: date | None = None
+        if isinstance(pub_date_raw, str) and pub_date_raw:
+            try:
+                publication_date = date.fromisoformat(pub_date_raw)
+            except ValueError:
+                logger.warning(
+                    "s2_citation_malformed_publication_date",
+                    paper_id=str(s2_id),
+                    raw_value=pub_date_raw,
+                )
+
         return CitationNode(
             paper_id=make_paper_node_id("s2", str(s2_id)),
             external_ids=external_ids,
@@ -607,6 +625,7 @@ class SemanticScholarCitationClient:
             citation_count=int(payload.get("citationCount") or 0),
             reference_count=int(payload.get("referenceCount") or 0),
             influential_citation_count=influential,
+            publication_date=publication_date,
         )
 
     @staticmethod

--- a/src/services/intelligence/citation/semantic_scholar_client.py
+++ b/src/services/intelligence/citation/semantic_scholar_client.py
@@ -28,7 +28,6 @@ import asyncio
 import hashlib
 import json
 import os
-import re
 from datetime import date, datetime, timezone
 from email.utils import parsedate_to_datetime
 from pathlib import Path
@@ -39,6 +38,10 @@ import aiohttp
 import diskcache
 import structlog
 
+from src.services.intelligence.citation._id_validation import (
+    PAPER_ID_MAX_LENGTH as _PAPER_ID_MAX_LENGTH,
+    RAW_PROVIDER_ID_PATTERN as _PAPER_ID_PATTERN,
+)
 from src.services.intelligence.citation.models import (
     CitationEdge,
     CitationNode,
@@ -73,13 +76,9 @@ _DEFAULT_MAX_RESULTS = 200
 # URL construction. ``A-Za-z0-9`` matches ASCII only — unicode
 # letters/digits are deliberately rejected because S2 ids are ASCII
 # and a unicode lookalike could obscure an injection vector.
-_PAPER_ID_PATTERN = re.compile(r"^[A-Za-z0-9:./_\-]+$")
-
-# Hard cap on paper-id length. S2 ids never exceed ~70 characters in
-# practice (a SHA-256 hex is 64); 512 leaves comfortable headroom while
-# bounding worst-case URL length and rejecting payload-stuffing
-# attempts that pad otherwise-legal characters into the megabyte range.
-_PAPER_ID_MAX_LENGTH = 512
+# Imported from _id_validation.py as the canonical single source of
+# truth (H-A1); ``_PAPER_ID_PATTERN`` and ``_PAPER_ID_MAX_LENGTH`` are
+# module-private aliases that preserve the existing call-site names.
 
 # Substrings that look benign under the allow-list above (they only
 # use permitted characters) but that signal an SSRF / traversal payload

--- a/src/services/intelligence/citation/semantic_scholar_client.py
+++ b/src/services/intelligence/citation/semantic_scholar_client.py
@@ -592,6 +592,13 @@ class SemanticScholarCitationClient:
 
         title = payload.get("title") or "Unknown Title"
 
+        # ``influentialCitationCount`` is None when S2 has not computed
+        # the metric yet (very recent papers); we forward None so the
+        # crawler's ``sort_by_influence`` ranking falls back to
+        # ``citation_count`` cleanly.
+        influential_raw = payload.get("influentialCitationCount")
+        influential = int(influential_raw) if influential_raw is not None else None
+
         return CitationNode(
             paper_id=make_paper_node_id("s2", str(s2_id)),
             external_ids=external_ids,
@@ -599,6 +606,7 @@ class SemanticScholarCitationClient:
             year=payload.get("year"),
             citation_count=int(payload.get("citationCount") or 0),
             reference_count=int(payload.get("referenceCount") or 0),
+            influential_citation_count=influential,
         )
 
     @staticmethod

--- a/src/storage/intelligence_graph/migrations.py
+++ b/src/storage/intelligence_graph/migrations.py
@@ -353,11 +353,70 @@ MIGRATION_V3_MONITORING_RUNS_FK = Migration(
 )
 
 
+# Schema version 4: Citation influence metrics cache.
+# Phase 9.2 — REQ-9.2.4 / Issue #129.
+#
+# Stores the result of one InfluenceScorer.compute_for_paper() call
+# keyed by paper_id. The 7-day TTL enforced by InfluenceScorer reads
+# the ``computed_at`` column on lookup; this migration provides only
+# the persistence shape, no expiration logic.
+#
+# Schema notes
+# ------------
+# - ``paper_id`` PRIMARY KEY: each paper has at most one current score
+#   row. Recompute UPSERTs (INSERT ... ON CONFLICT REPLACE) so the row
+#   reflects the latest snapshot, never a stale one.
+# - All score columns are REAL and nullable. PageRank always populates;
+#   HITS may be skipped on oversize graphs (returns 0.0 / 0.0). We
+#   store the actual zero rather than NULL so downstream consumers
+#   don't need to disambiguate "skipped" vs "not yet computed".
+# - ``citation_count`` is INTEGER and required (it is the input to
+#   PageRank, not a derived metric, so a missing value would be a bug).
+# - ``computed_at`` ISO-8601 string consistent with the rest of the
+#   intelligence schema (V1-V3 all use ISO-8601 TEXT). The 7-day TTL
+#   is enforced in Python — the DB merely persists the value.
+# - ``version`` defaults to 1 and is reserved for forward-compatible
+#   schema evolution (future hub/authority variants, weighted
+#   PageRank, etc.) without forcing a V5 migration on day one.
+#
+# Indexes: ``computed_at`` to accelerate TTL sweeps the future cleanup
+# job (Phase 10) will need; ``pagerank_score DESC`` for the "top
+# influential papers" query patterns the recommender (#REQ-9.2.5)
+# will issue.
+MIGRATION_V4_CITATION_INFLUENCE_METRICS = Migration(
+    version=4,
+    name="citation_influence_metrics",
+    description=(
+        "Add citation_influence_metrics table for InfluenceScorer cache "
+        "(REQ-9.2.4 / Issue #129)."
+    ),
+    up="""
+    CREATE TABLE IF NOT EXISTS citation_influence_metrics (
+        paper_id TEXT PRIMARY KEY,
+        citation_count INTEGER NOT NULL DEFAULT 0,
+        citation_velocity REAL NOT NULL DEFAULT 0.0,
+        pagerank_score REAL NOT NULL DEFAULT 0.0,
+        hub_score REAL NOT NULL DEFAULT 0.0,
+        authority_score REAL NOT NULL DEFAULT 0.0,
+        computed_at TEXT NOT NULL,
+        version INTEGER NOT NULL DEFAULT 1
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_citation_influence_metrics_computed
+        ON citation_influence_metrics(computed_at);
+
+    CREATE INDEX IF NOT EXISTS idx_citation_influence_metrics_pagerank
+        ON citation_influence_metrics(pagerank_score DESC);
+    """,
+)
+
+
 # All migrations in order
 ALL_MIGRATIONS: list[Migration] = [
     MIGRATION_V1_INITIAL,
     MIGRATION_V2_MONITORING_RUNS,
     MIGRATION_V3_MONITORING_RUNS_FK,
+    MIGRATION_V4_CITATION_INFLUENCE_METRICS,
 ]
 
 

--- a/tests/unit/services/intelligence/citation/test_crawler.py
+++ b/tests/unit/services/intelligence/citation/test_crawler.py
@@ -573,6 +573,7 @@ async def test_crawl_provider_failure_skips_node(
     ]
     assert len(skip_events) == 1
     assert skip_events[0].get("paper_id") == b.paper_id
+    # H-S1: error is repr(str(exc)[:512]) — check message content is present
     assert "boom on b" in skip_events[0].get("error", "")
 
 
@@ -809,6 +810,38 @@ async def test_crawl_persist_layer_no_op_when_empty(crawler):
     )
     assert ok is True
     assert persisted == set()
+
+
+# ---------------------------------------------------------------------------
+# H-S1: Error message truncation in fail-soft provider path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_crawl_provider_error_is_truncated_in_log(crawler, s2_client):
+    """A long provider error string must be truncated to ≤512 chars in the log."""
+    long_error = "X" * 10_000  # way over 512 chars
+
+    async def refs_fail(paper_id, *args, **kwargs):
+        raise APIError(long_error)
+
+    s2_client.get_references.side_effect = refs_fail
+
+    config = CrawlConfig(max_depth=1, direction=CrawlDirection.BACKWARD)
+    with structlog.testing.capture_logs() as logs:
+        await crawler.crawl("seed", config)
+
+    fail_events = [
+        e
+        for e in logs
+        if e.get("event") == "citation_crawl_provider_failed_skipping_node"
+    ]
+    assert len(fail_events) == 1
+    # repr(str(exc)[:512]) is at most repr("X"*512) = "'XXX...'" (514 chars)
+    # but the inner str slice is guaranteed ≤512 chars.
+    logged_error = fail_events[0].get("error", "")
+    # The repr wrapper adds surrounding quotes, but the inner content is ≤512
+    assert len(logged_error) <= 520  # repr overhead is at most ~8 chars
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/intelligence/citation/test_crawler.py
+++ b/tests/unit/services/intelligence/citation/test_crawler.py
@@ -499,7 +499,8 @@ async def test_crawl_filter_min_citations(crawler, s2_client, store):
     result = await crawler.crawl("seed", config)
 
     assert result.papers_visited == 2
-    assert result.dropped_by_filter["min_citations"] == 2
+    # C-3: dropped counters are now per-direction (backward here)
+    assert result.dropped_by_filter["min_citations_backward"] == 2
     for k in keepers:
         assert store.get_node(k.paper_id) is not None
     for d in droppers:
@@ -521,7 +522,8 @@ async def test_crawl_filter_year_min(crawler, s2_client, store):
     result = await crawler.crawl("seed", config)
 
     assert result.papers_visited == 1
-    assert result.dropped_by_filter["year_min"] == 2
+    # C-3: dropped counters are now per-direction (backward here)
+    assert result.dropped_by_filter["year_min_backward"] == 2
     assert store.get_node(new_paper.paper_id) is not None
     assert store.get_node(old_paper.paper_id) is None
     assert store.get_node(no_year.paper_id) is None
@@ -807,3 +809,81 @@ async def test_crawl_persist_layer_no_op_when_empty(crawler):
     )
     assert ok is True
     assert persisted == set()
+
+
+# ---------------------------------------------------------------------------
+# C-3: Per-direction top_k (spec REQ-9.2.2 §574-592)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_crawl_both_direction_applies_top_k_per_direction(store, s2_client):
+    """Each direction gets its own top_k cap, not a shared cap on the union.
+
+    100 refs + 100 cites per expansion, max_papers_per_level=50 → exactly
+    50 backward nodes AND 50 forward nodes should be visited (100 total),
+    not 50 total split across both directions.
+    """
+    crawler = CitationCrawler(store=store, s2_client=s2_client)
+
+    bw_nodes = [_node(f"bw{i}", citation_count=i) for i in range(100)]
+    fw_nodes = [_node(f"fw{i}", citation_count=i) for i in range(100)]
+
+    async def fake_get_references(paper_id, *args, **kwargs):
+        seed = _node("seed")
+        return seed, bw_nodes, [_edge(seed, n) for n in bw_nodes]
+
+    async def fake_get_citations(paper_id, *args, **kwargs):
+        seed = _node("seed")
+        return seed, fw_nodes, [_edge(n, seed) for n in fw_nodes]
+
+    s2_client.get_references.side_effect = fake_get_references
+    s2_client.get_citations.side_effect = fake_get_citations
+
+    config = CrawlConfig(
+        max_depth=1,
+        max_papers_per_level=50,
+        direction=CrawlDirection.BOTH,
+    )
+    result = await crawler.crawl("seed", config)
+
+    # 50 backward + 50 forward = 100 papers visited (not 50 total)
+    assert result.papers_visited == 100
+
+
+@pytest.mark.asyncio
+async def test_crawl_both_direction_starvation_regression(store, s2_client):
+    """Backward direction must not be starved when forward has many candidates.
+
+    backward=5 candidates, forward=200 candidates, max_papers_per_level=50.
+    Under the old union-then-cap logic all 5 backward candidates would be
+    dropped (the top-50 from the 205-paper union would all be forward).
+    Under the per-direction cap, all 5 backward candidates are preserved.
+    """
+    crawler = CitationCrawler(store=store, s2_client=s2_client)
+
+    # 5 backward nodes with high citation counts so they'd normally rank well
+    bw_nodes = [_node(f"bw{i}", citation_count=1000 + i) for i in range(5)]
+    # 200 forward nodes with even higher citation counts to starve backward
+    fw_nodes = [_node(f"fw{i}", citation_count=2000 + i) for i in range(200)]
+
+    async def fake_get_references(paper_id, *args, **kwargs):
+        seed = _node("seed")
+        return seed, bw_nodes, [_edge(seed, n) for n in bw_nodes]
+
+    async def fake_get_citations(paper_id, *args, **kwargs):
+        seed = _node("seed")
+        return seed, fw_nodes, [_edge(n, seed) for n in fw_nodes]
+
+    s2_client.get_references.side_effect = fake_get_references
+    s2_client.get_citations.side_effect = fake_get_citations
+
+    config = CrawlConfig(
+        max_depth=1,
+        max_papers_per_level=50,
+        direction=CrawlDirection.BOTH,
+    )
+    result = await crawler.crawl("seed", config)
+
+    # All 5 backward nodes must have been visited; 50 forward nodes
+    assert result.papers_visited == 55  # 5 backward + 50 forward

--- a/tests/unit/services/intelligence/citation/test_crawler.py
+++ b/tests/unit/services/intelligence/citation/test_crawler.py
@@ -387,6 +387,26 @@ def test_sort_by_influence_handles_none_influential_as_zero():
     assert ranked[0].paper_id.endswith("a")
 
 
+def test_sort_by_influence_all_keys_equal_is_stable():
+    """H-T4: when ALL three sort keys are identical, ordering is stable.
+
+    Python's ``sorted`` is documented as stable; pin the contract here so a
+    future migration to an unstable backend (e.g. NumPy) trips this test.
+    """
+    inputs = [
+        _node(
+            f"id{i}",
+            influential_citation_count=10,
+            citation_count=50,
+            publication_date=date(2022, 6, 1),
+        )
+        for i in range(5)
+    ]
+    ranked = sort_by_influence(inputs)
+    # Stable sort preserves input order when all keys match.
+    assert [n.paper_id for n in ranked] == [n.paper_id for n in inputs]
+
+
 # ---------------------------------------------------------------------------
 # Visited dedupe
 # ---------------------------------------------------------------------------
@@ -428,8 +448,7 @@ async def test_crawl_visited_dedupe(crawler, s2_client, store):
 
 @pytest.mark.asyncio
 async def test_crawl_budget_cap_emits_event_and_stops(crawler, s2_client, monkeypatch):
-    """Cap MAX_API_CALLS_PER_CRAWL=2 → crawl stops after 2 calls + emits event."""
-    monkeypatch.setattr(crawler_module, "MAX_API_CALLS_PER_CRAWL", 2)
+    """Cap max_api_calls=2 → crawl stops after 2 calls + emits event."""
     # Ensure the production logger picks up the patched processor swap
     # used by capture_logs (see CLAUDE.md: cache_logger_on_first_use=True).
     monkeypatch.setattr(crawler_module, "logger", structlog.get_logger())
@@ -446,7 +465,9 @@ async def test_crawl_budget_cap_emits_event_and_stops(crawler, s2_client, monkey
     }
     _wire_references(s2_client, mapping)
 
-    config = CrawlConfig(max_depth=3, direction=CrawlDirection.BACKWARD)
+    config = CrawlConfig(
+        max_depth=3, direction=CrawlDirection.BACKWARD, max_api_calls=2
+    )
     with structlog.testing.capture_logs() as logs:
         result = await crawler.crawl("seed", config)
 
@@ -459,16 +480,50 @@ async def test_crawl_budget_cap_emits_event_and_stops(crawler, s2_client, monkey
 
 
 @pytest.mark.asyncio
+async def test_crawl_per_call_max_api_calls_overrides_module_default(
+    store, s2_client, monkeypatch
+):
+    """H-A4/H-A5: ``CrawlConfig.max_api_calls`` overrides the module
+    default per crawl. A caller can tighten the budget without mutating
+    the global constant.
+    """
+    # Module default stays at the production value of 1000; we override
+    # via the config field, not via monkeypatch.
+    monkeypatch.setattr(crawler_module, "logger", structlog.get_logger())
+
+    children = [_node(f"L1_{i}") for i in range(5)]
+    _wire_references(s2_client, {"seed": children})
+
+    crawler = CitationCrawler(store=store, s2_client=s2_client)
+    config = CrawlConfig(
+        max_depth=2,
+        direction=CrawlDirection.BACKWARD,
+        max_api_calls=1,  # tight per-call budget; module default is 1000
+    )
+    with structlog.testing.capture_logs() as logs:
+        result = await crawler.crawl("seed", config)
+
+    # One call (the seed expansion) consumes the entire budget.
+    assert result.budget_exhausted is True
+    assert result.api_calls_made == 1
+    budget_events = [
+        e for e in logs if e.get("event") == "citation_crawl_budget_exhausted"
+    ]
+    assert len(budget_events) == 1
+    # Audit field reflects the per-call budget, not the module default.
+    assert budget_events[0]["budget"] == 1
+
+
+@pytest.mark.asyncio
 async def test_crawl_budget_cap_mid_both_direction(store, s2_client, monkeypatch):
     """BOTH direction: budget hit between BACKWARD and FORWARD on same paper."""
-    monkeypatch.setattr(crawler_module, "MAX_API_CALLS_PER_CRAWL", 1)
     monkeypatch.setattr(crawler_module, "logger", structlog.get_logger())
 
     _wire_references(s2_client, {"seed": [_node("a")]})
     _wire_citations(s2_client, {"seed": [_node("b")]})
 
     crawler = CitationCrawler(store=store, s2_client=s2_client)
-    config = CrawlConfig(max_depth=1, direction=CrawlDirection.BOTH)
+    config = CrawlConfig(max_depth=1, direction=CrawlDirection.BOTH, max_api_calls=1)
     with structlog.testing.capture_logs() as logs:
         result = await crawler.crawl("seed", config)
 
@@ -753,14 +808,25 @@ def test_crawl_result_defaults():
 
 @pytest.mark.asyncio
 async def test_crawl_budget_zero_blocks_first_call(crawler, monkeypatch):
-    """MAX=0 → budget check fires before the first BACKWARD call too."""
-    monkeypatch.setattr(crawler_module, "MAX_API_CALLS_PER_CRAWL", 0)
+    """max_api_calls=1 → budget check fires before the second BACKWARD call too.
+
+    NOTE: ``max_api_calls`` has Field(ge=1) so the minimum bound we can pass
+    is 1, not 0. With max_api_calls=1 and BACKWARD direction, the first call
+    succeeds and consumes the budget; any subsequent expansion is blocked.
+    """
     monkeypatch.setattr(crawler_module, "logger", structlog.get_logger())
-    config = CrawlConfig(max_depth=1, direction=CrawlDirection.BACKWARD)
+    # Wire seed → 3 children; with max_api_calls=1 we expand the seed
+    # (1 call) then hit budget on the first L1 child.
+    children = [_node(f"L1_{i}") for i in range(3)]
+    s2 = crawler.s2_client
+    _wire_references(s2, {"seed": children})
+    config = CrawlConfig(
+        max_depth=2, direction=CrawlDirection.BACKWARD, max_api_calls=1
+    )
     with structlog.testing.capture_logs() as logs:
         result = await crawler.crawl("seed", config)
     assert result.budget_exhausted is True
-    assert result.api_calls_made == 0
+    assert result.api_calls_made == 1
     assert any(e.get("event") == "citation_crawl_budget_exhausted" for e in logs)
 
 
@@ -780,11 +846,14 @@ async def test_crawl_both_dedupes_node_appearing_in_refs_and_cites(
 
 
 @pytest.mark.asyncio
-async def test_expand_paper_backward_branch_budget_exhausted(crawler, monkeypatch):
-    """Direct test: budget hit on the BACKWARD-only entry to _expand_paper."""
+async def test_expand_paper_backward_branch_budget_exhausted(crawler):
+    """Direct test: budget hit on the BACKWARD-only entry to _expand_paper.
+
+    Pass ``max_api_calls=0`` directly to the helper (it's a parameter, not
+    a global anymore — see H-A4/H-A5).
+    """
     from src.services.intelligence.citation.crawler import _BudgetExhausted
 
-    monkeypatch.setattr(crawler_module, "MAX_API_CALLS_PER_CRAWL", 0)
     counter = CrawlResult()
     sem = asyncio.Semaphore(1)
     with pytest.raises(_BudgetExhausted):
@@ -793,6 +862,7 @@ async def test_expand_paper_backward_branch_budget_exhausted(crawler, monkeypatc
             direction=CrawlDirection.BACKWARD,
             semaphore=sem,
             counter=counter,
+            max_api_calls=0,
         )
 
 

--- a/tests/unit/services/intelligence/citation/test_crawler.py
+++ b/tests/unit/services/intelligence/citation/test_crawler.py
@@ -1,0 +1,809 @@
+"""Tests for CitationCrawler (Issue #127, REQ-9.2.2)."""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from datetime import date
+from pathlib import Path
+from typing import Optional
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import structlog
+import structlog.testing
+
+from src.services.intelligence.citation import crawler as crawler_module
+from src.services.intelligence.citation.crawler import (
+    CitationCrawler,
+    CrawlConfig,
+    CrawlDirection,
+    CrawlResult,
+    sort_by_influence,
+)
+from src.services.intelligence.citation.models import (
+    CitationEdge,
+    CitationNode,
+    make_paper_node_id,
+)
+from src.services.intelligence.citation.openalex_client import (
+    OpenAlexCitationClient,
+)
+from src.services.intelligence.citation.semantic_scholar_client import (
+    SemanticScholarCitationClient,
+)
+from src.services.intelligence.models import GraphStoreError
+from src.services.providers.base import APIError
+from src.storage.intelligence_graph import SQLiteGraphStore
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+def _node(
+    raw_id: str,
+    *,
+    citation_count: int = 0,
+    influential_citation_count: Optional[int] = None,
+    year: Optional[int] = None,
+    publication_date: Optional[date] = None,
+    title: Optional[str] = None,
+) -> CitationNode:
+    return CitationNode(
+        paper_id=make_paper_node_id("s2", raw_id),
+        title=title or f"Paper {raw_id}",
+        external_ids={"s2": raw_id},
+        citation_count=citation_count,
+        influential_citation_count=influential_citation_count,
+        year=year,
+        publication_date=publication_date,
+    )
+
+
+def _edge(citing: CitationNode, cited: CitationNode) -> CitationEdge:
+    return CitationEdge(
+        citing_paper_id=citing.paper_id,
+        cited_paper_id=cited.paper_id,
+        source="semantic_scholar",
+    )
+
+
+@pytest.fixture
+def temp_db():
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        path = Path(f.name)
+    yield path
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+
+
+@pytest.fixture
+def store(temp_db):
+    s = SQLiteGraphStore(temp_db)
+    s.initialize()
+    return s
+
+
+@pytest.fixture
+def s2_client():
+    return AsyncMock(spec=SemanticScholarCitationClient)
+
+
+@pytest.fixture
+def oa_client():
+    return AsyncMock(spec=OpenAlexCitationClient)
+
+
+@pytest.fixture
+def crawler(store, s2_client):
+    return CitationCrawler(store=store, s2_client=s2_client)
+
+
+def _wire_references(client, mapping: dict[str, list[CitationNode]]) -> None:
+    """Configure ``client.get_references`` to return per-id results."""
+
+    async def _impl(paper_id, *args, **kwargs):
+        seed = _node(paper_id.split(":")[-1] if ":" in paper_id else paper_id)
+        related = mapping.get(paper_id, [])
+        edges = [_edge(seed, n) for n in related]
+        return seed, related, edges
+
+    client.get_references.side_effect = _impl
+
+
+def _wire_citations(client, mapping: dict[str, list[CitationNode]]) -> None:
+    """Configure ``client.get_citations`` to return per-id results."""
+
+    async def _impl(paper_id, *args, **kwargs):
+        seed = _node(paper_id.split(":")[-1] if ":" in paper_id else paper_id)
+        related = mapping.get(paper_id, [])
+        edges = [_edge(n, seed) for n in related]
+        return seed, related, edges
+
+    client.get_citations.side_effect = _impl
+
+
+# ---------------------------------------------------------------------------
+# Constructor / factory
+# ---------------------------------------------------------------------------
+
+
+def test_constructor_requires_at_least_one_client(store):
+    with pytest.raises(ValueError, match="at least one provider"):
+        CitationCrawler(store=store)
+
+
+def test_from_paths_factory_initialises_store(temp_db, s2_client):
+    c = CitationCrawler.from_paths(db_path=temp_db, s2_client=s2_client)
+    assert isinstance(c.store, SQLiteGraphStore)
+    assert c.s2_client is s2_client
+
+
+def test_from_paths_factory_defaults_to_s2_client(temp_db, monkeypatch):
+    """When no client is provided, the factory builds a default S2 client."""
+    monkeypatch.setenv("SEMANTIC_SCHOLAR_API_KEY", "test-key")
+    c = CitationCrawler.from_paths(db_path=temp_db)
+    assert isinstance(c.s2_client, SemanticScholarCitationClient)
+
+
+def test_from_paths_factory_accepts_only_openalex(temp_db, oa_client):
+    c = CitationCrawler.from_paths(
+        db_path=temp_db, s2_client=None, openalex_client=oa_client
+    )
+    assert c.s2_client is None
+    assert c.openalex_client is oa_client
+
+
+# ---------------------------------------------------------------------------
+# Seed validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_crawl_invalid_seed_id_raises(crawler):
+    with pytest.raises(ValueError, match="Invalid seed_paper_id"):
+        await crawler.crawl("bad seed!", CrawlConfig())
+
+
+@pytest.mark.asyncio
+async def test_crawl_empty_seed_id_raises(crawler):
+    with pytest.raises(ValueError, match="non-empty"):
+        await crawler.crawl("   ", CrawlConfig())
+
+
+@pytest.mark.asyncio
+async def test_crawl_oversized_seed_id_raises(crawler):
+    with pytest.raises(ValueError, match="exceeds max"):
+        await crawler.crawl("a" * 600, CrawlConfig())
+
+
+@pytest.mark.asyncio
+async def test_crawl_non_string_seed_id_raises(crawler):
+    with pytest.raises(ValueError, match="non-empty string"):
+        await crawler.crawl(None, CrawlConfig())  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Empty / zero-neighbour case
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_crawl_seed_with_zero_neighbors_returns_empty_result(crawler, s2_client):
+    _wire_references(s2_client, {"seed1": []})
+    _wire_citations(s2_client, {"seed1": []})
+
+    result = await crawler.crawl("seed1", CrawlConfig())
+    assert isinstance(result, CrawlResult)
+    assert result.papers_visited == 0
+    assert result.edges_added == 0
+    assert result.api_calls_made == 2  # one per direction (BOTH)
+    assert result.budget_exhausted is False
+    assert result.persistence_aborted is False
+
+
+# ---------------------------------------------------------------------------
+# Depth gating
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_crawl_depth_limit(crawler, s2_client, store):
+    """max_depth=2: the seed expands → its children expand → grandchildren do NOT."""
+    seed_refs = [_node("L1")]
+    l1_refs = [_node("L2")]
+    l2_refs = [_node("L3")]  # this should never be visited
+    _wire_references(
+        s2_client,
+        {
+            "seed": seed_refs,
+            seed_refs[0].paper_id: l1_refs,
+            l1_refs[0].paper_id: l2_refs,
+        },
+    )
+
+    config = CrawlConfig(max_depth=2, direction=CrawlDirection.BACKWARD)
+    result = await crawler.crawl("seed", config)
+
+    # Two papers visited (L1, L2). L3 must not appear.
+    assert result.papers_visited == 2
+    assert result.levels_reached == 2
+    assert store.get_node(l1_refs[0].paper_id) is not None
+    assert store.get_node(l2_refs[0].paper_id) is None
+
+
+@pytest.mark.asyncio
+async def test_crawl_max_depth_one_visits_only_first_layer(crawler, s2_client):
+    seed_refs = [_node("L1a"), _node("L1b")]
+    l1a_refs = [_node("L2a")]
+    _wire_references(
+        s2_client,
+        {
+            "seed": seed_refs,
+            seed_refs[0].paper_id: l1a_refs,
+        },
+    )
+
+    config = CrawlConfig(max_depth=1, direction=CrawlDirection.BACKWARD)
+    result = await crawler.crawl("seed", config)
+
+    assert result.papers_visited == 2  # both L1 nodes
+    assert result.levels_reached == 1
+    # Only the seed got expanded, not L1a → exactly 1 API call.
+    assert result.api_calls_made == 1
+
+
+# ---------------------------------------------------------------------------
+# Direction filtering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_crawl_direction_forward_only(crawler, s2_client):
+    """FORWARD: only get_citations is called; get_references is never invoked."""
+    cites = [_node("citer1")]
+    _wire_citations(s2_client, {"seed": cites})
+
+    config = CrawlConfig(max_depth=1, direction=CrawlDirection.FORWARD)
+    result = await crawler.crawl("seed", config)
+
+    assert result.papers_visited == 1
+    s2_client.get_citations.assert_awaited()
+    s2_client.get_references.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_crawl_direction_backward_only(crawler, s2_client):
+    refs = [_node("ref1")]
+    _wire_references(s2_client, {"seed": refs})
+
+    config = CrawlConfig(max_depth=1, direction=CrawlDirection.BACKWARD)
+    result = await crawler.crawl("seed", config)
+
+    assert result.papers_visited == 1
+    s2_client.get_references.assert_awaited()
+    s2_client.get_citations.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_crawl_direction_both(crawler, s2_client):
+    refs = [_node("ref1")]
+    cites = [_node("citer1")]
+    _wire_references(s2_client, {"seed": refs})
+    _wire_citations(s2_client, {"seed": cites})
+
+    config = CrawlConfig(max_depth=1, direction=CrawlDirection.BOTH)
+    result = await crawler.crawl("seed", config)
+
+    assert result.papers_visited == 2
+    s2_client.get_references.assert_awaited()
+    s2_client.get_citations.assert_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Top-K + ranking
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_crawl_top_k_per_level(crawler, s2_client, store):
+    """100 candidates with max_papers_per_level=50 → only top 50 by influence."""
+    candidates = [
+        _node(f"c{i}", influential_citation_count=i, citation_count=i)
+        for i in range(100)
+    ]
+    _wire_references(s2_client, {"seed": candidates})
+
+    config = CrawlConfig(
+        max_depth=1,
+        max_papers_per_level=50,
+        direction=CrawlDirection.BACKWARD,
+    )
+    result = await crawler.crawl("seed", config)
+    assert result.papers_visited == 50
+    # Top 50 by influential_citation_count = ids 50..99
+    for i in range(50, 100):
+        assert store.get_node(make_paper_node_id("s2", f"c{i}")) is not None
+    for i in range(0, 50):
+        assert store.get_node(make_paper_node_id("s2", f"c{i}")) is None
+
+
+def test_sort_by_influence_ranking_exact():
+    """Pin the (influential, citations, date) ordering precisely."""
+    a = _node(
+        "a",
+        influential_citation_count=10,
+        citation_count=100,
+        publication_date=date(2020, 1, 1),
+    )
+    b = _node(
+        "b",
+        influential_citation_count=10,
+        citation_count=200,
+        publication_date=date(2019, 1, 1),
+    )
+    c = _node(
+        "c",
+        influential_citation_count=20,
+        citation_count=5,
+        publication_date=date(2010, 1, 1),
+    )
+    d = _node(
+        "d",
+        influential_citation_count=10,
+        citation_count=200,
+        publication_date=date(2021, 1, 1),
+    )
+    # Year-only fallback (no publication_date) should be treated as Jan-1.
+    e = _node("e", influential_citation_count=5, citation_count=300, year=2023)
+    # Missing year + missing date → date.min, sorts last among same scores.
+    f = _node("f", influential_citation_count=5, citation_count=300)
+
+    ranked = sort_by_influence([a, b, c, d, e, f])
+    # Expected order:
+    # c (influential=20)
+    # then influential=10 group, ordered by citations desc, date desc:
+    #   d (200, 2021), b (200, 2019), a (100, 2020)
+    # then influential=5 group, ordered by citations desc, date desc:
+    #   e (300, 2023-1-1), f (300, date.min)
+    assert [n.paper_id.split(":")[-1] for n in ranked] == [
+        "c",
+        "d",
+        "b",
+        "a",
+        "e",
+        "f",
+    ]
+
+
+def test_sort_by_influence_handles_none_influential_as_zero():
+    a = _node("a", influential_citation_count=None, citation_count=10)
+    b = _node("b", influential_citation_count=0, citation_count=5)
+    ranked = sort_by_influence([a, b])
+    # Both have influential=0 → tiebreak on citations desc → a first.
+    assert ranked[0].paper_id.endswith("a")
+
+
+# ---------------------------------------------------------------------------
+# Visited dedupe
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_crawl_visited_dedupe(crawler, s2_client, store):
+    """The same paper appearing as a neighbour in two chains is visited once."""
+    shared = _node("shared")
+    a = _node("a")
+    b = _node("b")
+    _wire_references(
+        s2_client,
+        {
+            "seed": [a, b],
+            a.paper_id: [shared],
+            b.paper_id: [shared],
+        },
+    )
+
+    config = CrawlConfig(max_depth=2, direction=CrawlDirection.BACKWARD)
+    result = await crawler.crawl("seed", config)
+
+    # a, b, shared = 3 unique nodes.
+    assert result.papers_visited == 3
+    # ``shared`` was returned by both a and b but is only enqueued once.
+    # After a's expansion adds it (depth=2), b's expansion finds it
+    # already-visited and doesn't re-enqueue. depth=2 is at the cap so
+    # ``shared`` is never expanded itself — verify by checking
+    # get_references was called for seed, a, b only (3 calls).
+    refs_calls = s2_client.get_references.await_count
+    assert refs_calls == 3
+
+
+# ---------------------------------------------------------------------------
+# Budget cap
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_crawl_budget_cap_emits_event_and_stops(crawler, s2_client, monkeypatch):
+    """Cap MAX_API_CALLS_PER_CRAWL=2 → crawl stops after 2 calls + emits event."""
+    monkeypatch.setattr(crawler_module, "MAX_API_CALLS_PER_CRAWL", 2)
+    # Ensure the production logger picks up the patched processor swap
+    # used by capture_logs (see CLAUDE.md: cache_logger_on_first_use=True).
+    monkeypatch.setattr(crawler_module, "logger", structlog.get_logger())
+
+    # Seed → 5 children, each with their own children. With BACKWARD only
+    # and budget=2, we expand seed (1 call) + L1[0] (2 calls), then exit.
+    children = [_node(f"L1_{i}") for i in range(5)]
+    grandchildren = [_node(f"L2_{i}") for i in range(3)]
+    mapping = {
+        "seed": children,
+        children[0].paper_id: grandchildren,
+        children[1].paper_id: grandchildren,
+        children[2].paper_id: grandchildren,
+    }
+    _wire_references(s2_client, mapping)
+
+    config = CrawlConfig(max_depth=3, direction=CrawlDirection.BACKWARD)
+    with structlog.testing.capture_logs() as logs:
+        result = await crawler.crawl("seed", config)
+
+    assert result.budget_exhausted is True
+    assert result.api_calls_made == 2
+    # Expanded only seed + first L1.
+    assert s2_client.get_references.await_count == 2
+    events = [e.get("event") for e in logs]
+    assert "citation_crawl_budget_exhausted" in events
+
+
+@pytest.mark.asyncio
+async def test_crawl_budget_cap_mid_both_direction(store, s2_client, monkeypatch):
+    """BOTH direction: budget hit between BACKWARD and FORWARD on same paper."""
+    monkeypatch.setattr(crawler_module, "MAX_API_CALLS_PER_CRAWL", 1)
+    monkeypatch.setattr(crawler_module, "logger", structlog.get_logger())
+
+    _wire_references(s2_client, {"seed": [_node("a")]})
+    _wire_citations(s2_client, {"seed": [_node("b")]})
+
+    crawler = CitationCrawler(store=store, s2_client=s2_client)
+    config = CrawlConfig(max_depth=1, direction=CrawlDirection.BOTH)
+    with structlog.testing.capture_logs() as logs:
+        result = await crawler.crawl("seed", config)
+
+    # First call (BACKWARD) succeeds; FORWARD hits budget.
+    assert result.budget_exhausted is True
+    assert result.api_calls_made == 1
+    # No persistence happened because budget hit before we tried to
+    # finalise the layer.
+    assert any(e.get("event") == "citation_crawl_budget_exhausted" for e in logs)
+
+
+# ---------------------------------------------------------------------------
+# Filters
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_crawl_filter_min_citations(crawler, s2_client, store):
+    keepers = [_node("k1", citation_count=10), _node("k2", citation_count=20)]
+    droppers = [_node("d1", citation_count=0), _node("d2", citation_count=4)]
+    _wire_references(s2_client, {"seed": keepers + droppers})
+
+    config = CrawlConfig(
+        max_depth=1,
+        direction=CrawlDirection.BACKWARD,
+        filter_min_citations=5,
+    )
+    result = await crawler.crawl("seed", config)
+
+    assert result.papers_visited == 2
+    assert result.dropped_by_filter["min_citations"] == 2
+    for k in keepers:
+        assert store.get_node(k.paper_id) is not None
+    for d in droppers:
+        assert store.get_node(d.paper_id) is None
+
+
+@pytest.mark.asyncio
+async def test_crawl_filter_year_min(crawler, s2_client, store):
+    new_paper = _node("new", year=2022, citation_count=1)
+    old_paper = _node("old", year=2010, citation_count=1)
+    no_year = _node("noyear", citation_count=1)  # year=None
+    _wire_references(s2_client, {"seed": [new_paper, old_paper, no_year]})
+
+    config = CrawlConfig(
+        max_depth=1,
+        direction=CrawlDirection.BACKWARD,
+        filter_year_min=2020,
+    )
+    result = await crawler.crawl("seed", config)
+
+    assert result.papers_visited == 1
+    assert result.dropped_by_filter["year_min"] == 2
+    assert store.get_node(new_paper.paper_id) is not None
+    assert store.get_node(old_paper.paper_id) is None
+    assert store.get_node(no_year.paper_id) is None
+
+
+# ---------------------------------------------------------------------------
+# Failure semantics — provider failure (fail-soft)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_crawl_provider_failure_skips_node(
+    crawler, s2_client, store, monkeypatch
+):
+    monkeypatch.setattr(crawler_module, "logger", structlog.get_logger())
+
+    # Seed expands fine; one of its children raises on expansion.
+    a = _node("a")
+    b = _node("b")
+    a_refs = [_node("a_ref")]
+
+    async def refs_impl(paper_id, *args, **kwargs):
+        if paper_id == "seed":
+            return (
+                _node("seed"),
+                [a, b],
+                [_edge(_node("seed"), a), _edge(_node("seed"), b)],
+            )
+        if paper_id == a.paper_id:
+            return _node("a"), a_refs, [_edge(a, a_refs[0])]
+        if paper_id == b.paper_id:
+            raise APIError("boom on b")
+        return _node(paper_id), [], []
+
+    s2_client.get_references.side_effect = refs_impl
+
+    config = CrawlConfig(max_depth=2, direction=CrawlDirection.BACKWARD)
+    with structlog.testing.capture_logs() as logs:
+        result = await crawler.crawl("seed", config)
+
+    # a + b at L1, a_ref at L2 = 3 visited despite b's failure.
+    assert result.papers_visited == 3
+    skip_events = [
+        e
+        for e in logs
+        if e.get("event") == "citation_crawl_provider_failed_skipping_node"
+    ]
+    assert len(skip_events) == 1
+    assert skip_events[0].get("paper_id") == b.paper_id
+    assert "boom on b" in skip_events[0].get("error", "")
+
+
+# ---------------------------------------------------------------------------
+# Failure semantics — persistence failure (fail-hard, abort)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_crawl_persistence_failure_aborts_cycle(s2_client, monkeypatch):
+    """Persistence error must abort BFS and skip subsequent API calls."""
+    # Real store wrapped in a Mock so add_nodes_batch raises on first call.
+    fake_store = MagicMock()
+    fake_store.add_nodes_batch.side_effect = GraphStoreError("disk full")
+    fake_store.add_edges_batch = MagicMock()
+
+    monkeypatch.setattr(crawler_module, "logger", structlog.get_logger())
+
+    # Seed → two children, each with their own children. We must NOT
+    # see any get_references call for the children after persistence
+    # fails on the seed's expansion.
+    a = _node("a")
+    b = _node("b")
+    _wire_references(
+        s2_client,
+        {
+            "seed": [a, b],
+            a.paper_id: [_node("aa")],
+            b.paper_id: [_node("bb")],
+        },
+    )
+
+    crawler = CitationCrawler(store=fake_store, s2_client=s2_client)
+    config = CrawlConfig(max_depth=3, direction=CrawlDirection.BACKWARD)
+    with structlog.testing.capture_logs() as logs:
+        result = await crawler.crawl("seed", config)
+
+    assert result.persistence_aborted is True
+    abort_events = [
+        e
+        for e in logs
+        if e.get("event") == "citation_crawl_persistence_failed_aborting"
+    ]
+    assert len(abort_events) == 1
+    assert "disk full" in abort_events[0].get("error", "")
+    # Critical: only the seed's expansion happened. Children were NOT
+    # expanded. This is the negative-path test required by GEMINI.md §5.
+    assert s2_client.get_references.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_crawl_persistence_edge_failure_aborts(s2_client, monkeypatch):
+    """Edge insert failure (after node insert succeeds) also aborts."""
+    fake_store = MagicMock()
+    fake_store.add_nodes_batch = MagicMock()
+    fake_store.add_edges_batch.side_effect = GraphStoreError("fk violation")
+
+    monkeypatch.setattr(crawler_module, "logger", structlog.get_logger())
+
+    _wire_references(
+        s2_client,
+        {
+            "seed": [_node("a")],
+            make_paper_node_id("s2", "a"): [_node("aa")],
+        },
+    )
+
+    crawler = CitationCrawler(store=fake_store, s2_client=s2_client)
+    config = CrawlConfig(max_depth=3, direction=CrawlDirection.BACKWARD)
+    result = await crawler.crawl("seed", config)
+    assert result.persistence_aborted is True
+    assert s2_client.get_references.await_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Concurrency
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_crawl_concurrency_bound_via_semaphore(store, s2_client):
+    """In-flight provider calls must never exceed _MAX_CONCURRENT_REQUESTS."""
+    in_flight = 0
+    peak = 0
+    lock = asyncio.Lock()
+
+    async def slow_refs(paper_id, *args, **kwargs):
+        nonlocal in_flight, peak
+        async with lock:
+            in_flight += 1
+            peak = max(peak, in_flight)
+        # Yield enough times to allow other coroutines to enter.
+        await asyncio.sleep(0)
+        async with lock:
+            in_flight -= 1
+        return _node(paper_id), [], []
+
+    s2_client.get_references.side_effect = slow_refs
+    s2_client.get_citations.side_effect = slow_refs
+
+    crawler = CitationCrawler(store=store, s2_client=s2_client)
+    # Build a wide first layer so many expansions are queued.
+    children = [_node(f"c{i}") for i in range(30)]
+
+    async def seed_refs(paper_id, *args, **kwargs):
+        if paper_id == "seed":
+            return _node("seed"), children, []
+        return _node(paper_id), [], []
+
+    s2_client.get_references.side_effect = seed_refs
+
+    # First trigger the wide expansion, then re-wire to slow_refs and
+    # spawn many concurrent gathers manually for the bound check.
+    config = CrawlConfig(max_depth=1, direction=CrawlDirection.BACKWARD)
+    await crawler.crawl("seed", config)
+
+    # Now exercise the semaphore directly via _expand_paper.
+    s2_client.get_references.side_effect = slow_refs
+    counter = CrawlResult()
+    sem = asyncio.Semaphore(crawler_module._MAX_CONCURRENT_REQUESTS)
+    await asyncio.gather(
+        *[
+            crawler._expand_paper(
+                paper_id=f"p{i}",
+                direction=CrawlDirection.BACKWARD,
+                semaphore=sem,
+                counter=counter,
+            )
+            for i in range(50)
+        ]
+    )
+    assert peak <= crawler_module._MAX_CONCURRENT_REQUESTS
+    assert peak > 0  # sanity: we did exercise concurrency
+
+
+# ---------------------------------------------------------------------------
+# Misc
+# ---------------------------------------------------------------------------
+
+
+def test_crawl_config_defaults_match_spec():
+    cfg = CrawlConfig()
+    assert cfg.max_depth == 2
+    assert cfg.max_papers_per_level == 50
+    assert cfg.direction == CrawlDirection.BOTH
+    assert cfg.filter_min_citations == 0
+    assert cfg.filter_year_min is None
+
+
+def test_crawl_config_rejects_extra_fields():
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        CrawlConfig(max_depth=2, foo="bar")
+
+
+def test_crawl_config_validates_bounds():
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        CrawlConfig(max_depth=0)
+    with pytest.raises(ValidationError):
+        CrawlConfig(max_depth=4)
+    with pytest.raises(ValidationError):
+        CrawlConfig(max_papers_per_level=5)
+    with pytest.raises(ValidationError):
+        CrawlConfig(max_papers_per_level=300)
+
+
+def test_crawl_result_defaults():
+    r = CrawlResult()
+    assert r.papers_visited == 0
+    assert r.dropped_by_filter == {}
+    assert r.budget_exhausted is False
+    assert r.persistence_aborted is False
+
+
+@pytest.mark.asyncio
+async def test_crawl_budget_zero_blocks_first_call(crawler, monkeypatch):
+    """MAX=0 → budget check fires before the first BACKWARD call too."""
+    monkeypatch.setattr(crawler_module, "MAX_API_CALLS_PER_CRAWL", 0)
+    monkeypatch.setattr(crawler_module, "logger", structlog.get_logger())
+    config = CrawlConfig(max_depth=1, direction=CrawlDirection.BACKWARD)
+    with structlog.testing.capture_logs() as logs:
+        result = await crawler.crawl("seed", config)
+    assert result.budget_exhausted is True
+    assert result.api_calls_made == 0
+    assert any(e.get("event") == "citation_crawl_budget_exhausted" for e in logs)
+
+
+@pytest.mark.asyncio
+async def test_crawl_both_dedupes_node_appearing_in_refs_and_cites(
+    crawler, s2_client, store
+):
+    """A paper that is both a reference and a citer appears once in the graph."""
+    shared = _node("shared")
+    _wire_references(s2_client, {"seed": [shared]})
+    _wire_citations(s2_client, {"seed": [shared]})
+
+    config = CrawlConfig(max_depth=1, direction=CrawlDirection.BOTH)
+    result = await crawler.crawl("seed", config)
+    assert result.papers_visited == 1  # ``shared`` counted once
+    assert store.get_node(shared.paper_id) is not None
+
+
+@pytest.mark.asyncio
+async def test_expand_paper_backward_branch_budget_exhausted(crawler, monkeypatch):
+    """Direct test: budget hit on the BACKWARD-only entry to _expand_paper."""
+    from src.services.intelligence.citation.crawler import _BudgetExhausted
+
+    monkeypatch.setattr(crawler_module, "MAX_API_CALLS_PER_CRAWL", 0)
+    counter = CrawlResult()
+    sem = asyncio.Semaphore(1)
+    with pytest.raises(_BudgetExhausted):
+        await crawler._expand_paper(
+            paper_id="x",
+            direction=CrawlDirection.BACKWARD,
+            semaphore=sem,
+            counter=counter,
+        )
+
+
+@pytest.mark.asyncio
+async def test_crawl_persist_layer_no_op_when_empty(crawler):
+    """Direct call to _persist_layer with empty inputs is a true no-op."""
+    persisted: set[str] = set()
+    ok = crawler._persist_layer(
+        paper_id="seed",
+        parent_node=None,
+        related_nodes=[],
+        edges=[],
+        seed_paper_id="seed",
+        persisted_node_ids=persisted,
+    )
+    assert ok is True
+    assert persisted == set()

--- a/tests/unit/services/intelligence/citation/test_influence_scorer.py
+++ b/tests/unit/services/intelligence/citation/test_influence_scorer.py
@@ -661,3 +661,45 @@ def test_hits_runs_all_iterations_without_convergence(store, monkeypatch):
     # still return well-formed score vectors.
     assert set(hubs.keys()) == {a.paper_id, b.paper_id}
     assert set(authorities.keys()) == {a.paper_id, b.paper_id}
+
+
+# ---------------------------------------------------------------------------
+# H-S2: PageRank node-count gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pagerank_skipped_when_graph_exceeds_limit(store, monkeypatch):
+    """PageRank must be skipped and an audit event emitted when graph is too large.
+
+    Monkeypatch MAX_GRAPH_NODES_FOR_PAGERANK to 2, insert 3 nodes, verify the
+    warning is logged and the returned pagerank_score is 0.0 (empty dict fallback).
+    """
+    # Lower the limit so 3 nodes trip it.
+    monkeypatch.setattr(scorer_module, "MAX_GRAPH_NODES_FOR_PAGERANK", 2)
+
+    a = _node("a", year=2020)
+    b = _node("b", year=2020)
+    c = _node("c", year=2020)
+    _persist_chain(store, a, b)
+    # Insert c separately (no edge needed — we just need the node count to hit 3)
+    store.add_nodes_batch([c.to_graph_node()])
+
+    s = InfluenceScorer(store=store)
+    with structlog.testing.capture_logs() as logs:
+        metrics_list = await s.compute_for_graph([a.paper_id, b.paper_id, c.paper_id])
+
+    # The PageRank skip event must have been emitted.
+    skip_events = [
+        e
+        for e in logs
+        if e.get("event") == "influence_scorer_pagerank_skipped_oversize_graph"
+    ]
+    assert len(skip_events) == 1
+    assert skip_events[0]["node_count"] == 3
+    assert skip_events[0]["limit"] == 2
+
+    # All metrics must still be returned (with pagerank_score == 0.0).
+    assert len(metrics_list) == 3
+    for m in metrics_list:
+        assert m.pagerank_score == 0.0

--- a/tests/unit/services/intelligence/citation/test_influence_scorer.py
+++ b/tests/unit/services/intelligence/citation/test_influence_scorer.py
@@ -323,7 +323,7 @@ async def test_citation_velocity_missing_publication_date_returns_zero_with_even
     store, monkeypatch
 ):
     monkeypatch.setattr(scorer_module, "logger", structlog.get_logger())
-    n = _node("nd", citation_count=10)  # no year, no publication_date
+    n = _node("no_date", citation_count=10)  # no year, no publication_date
     _persist_chain(store, n)
 
     s = InfluenceScorer(store=store)

--- a/tests/unit/services/intelligence/citation/test_influence_scorer.py
+++ b/tests/unit/services/intelligence/citation/test_influence_scorer.py
@@ -1,0 +1,663 @@
+"""Tests for InfluenceScorer (Issue #129, REQ-9.2.4)."""
+
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import structlog
+import structlog.testing
+
+from src.services.intelligence.citation import influence_scorer as scorer_module
+from src.services.intelligence.citation.influence_scorer import (
+    DEFAULT_CACHE_TTL,
+    MAX_GRAPH_NODES_FOR_HITS,
+    InfluenceMetrics,
+    InfluenceScorer,
+)
+from src.services.intelligence.citation.models import (
+    CitationEdge,
+    CitationNode,
+    make_paper_node_id,
+)
+from src.services.intelligence.models import EdgeType
+from src.storage.intelligence_graph import SQLiteGraphStore
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def temp_db():
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        path = Path(f.name)
+    yield path
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+
+
+@pytest.fixture
+def store(temp_db):
+    s = SQLiteGraphStore(temp_db)
+    s.initialize()
+    return s
+
+
+def _node(
+    raw_id: str,
+    *,
+    citation_count: int = 0,
+    year: int | None = None,
+    publication_date: date | None = None,
+) -> CitationNode:
+    return CitationNode(
+        paper_id=make_paper_node_id("s2", raw_id),
+        title=f"Paper {raw_id}",
+        external_ids={"s2": raw_id},
+        citation_count=citation_count,
+        year=year,
+        publication_date=publication_date,
+    )
+
+
+def _persist_chain(store, *citation_nodes):
+    """Insert the given nodes and an A → B → C chain of CITES edges."""
+    for n in citation_nodes:
+        store.add_node(
+            n.paper_id, n.to_graph_node().node_type, n.to_graph_node().properties
+        )
+    for i in range(len(citation_nodes) - 1):
+        edge = CitationEdge(
+            citing_paper_id=citation_nodes[i].paper_id,
+            cited_paper_id=citation_nodes[i + 1].paper_id,
+            source="s2",
+        ).to_graph_edge()
+        store.add_edge(
+            edge.edge_id,
+            edge.source_id,
+            edge.target_id,
+            edge.edge_type,
+            edge.properties,
+        )
+
+
+def _frozen_scorer(store, now: datetime, cache_ttl=DEFAULT_CACHE_TTL):
+    return InfluenceScorer(store=store, cache_ttl=cache_ttl, now=now)
+
+
+# ---------------------------------------------------------------------------
+# Constructor / factory
+# ---------------------------------------------------------------------------
+
+
+def test_from_paths_factory_initialises_store(temp_db):
+    s = InfluenceScorer.from_paths(db_path=temp_db)
+    assert isinstance(s.store, SQLiteGraphStore)
+    assert s.cache_ttl == DEFAULT_CACHE_TTL
+
+
+def test_constructor_accepts_custom_now(store):
+    fixed = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    s = InfluenceScorer(store=store, now=fixed)
+    assert s._now() == fixed
+
+
+def test_now_defaults_to_real_clock(store):
+    s = InfluenceScorer(store=store)
+    # Just check we get a real datetime within reason.
+    assert isinstance(s._now(), datetime)
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invalid_paper_id_raises_value_error(store):
+    s = InfluenceScorer(store=store)
+    with pytest.raises(ValueError, match="Invalid paper_id"):
+        await s.compute_for_paper("bad space id")
+
+
+@pytest.mark.asyncio
+async def test_empty_paper_id_raises(store):
+    s = InfluenceScorer(store=store)
+    with pytest.raises(ValueError, match="non-empty"):
+        await s.compute_for_paper("   ")
+
+
+@pytest.mark.asyncio
+async def test_oversized_paper_id_raises(store):
+    s = InfluenceScorer(store=store)
+    with pytest.raises(ValueError, match="exceeds max"):
+        await s.compute_for_paper("a" * 600)
+
+
+@pytest.mark.asyncio
+async def test_non_string_paper_id_raises(store):
+    s = InfluenceScorer(store=store)
+    with pytest.raises(ValueError, match="non-empty string"):
+        await s.compute_for_paper(None)  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_compute_for_graph_validates_each_id(store):
+    s = InfluenceScorer(store=store)
+    with pytest.raises(ValueError):
+        await s.compute_for_graph(["paper:s2:ok", "bad space"])
+
+
+# ---------------------------------------------------------------------------
+# PageRank delegation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pagerank_delegates_to_graph_algorithms(store):
+    """Verify GraphAlgorithms.pagerank is the single source of truth."""
+    a = _node("a", citation_count=1, year=2020)
+    _persist_chain(store, a)
+    s = InfluenceScorer(store=store)
+
+    with patch.object(
+        scorer_module.GraphAlgorithms,
+        "pagerank",
+        wraps=scorer_module.GraphAlgorithms.pagerank,
+    ) as mock_pr:
+        await s.compute_for_paper(a.paper_id)
+    mock_pr.assert_called_once()
+    # Verify the edge_types argument is the typed enum value.
+    _, kwargs = mock_pr.call_args
+    assert kwargs.get("edge_types") == [EdgeType.CITES.value]
+
+
+@pytest.mark.asyncio
+async def test_pagerank_isolated_node_returns_baseline_score(store):
+    """An isolated node still gets a non-zero PageRank baseline."""
+    iso = _node("iso", year=2020)
+    _persist_chain(store, iso)  # one node, no edges
+    s = InfluenceScorer(store=store)
+    metrics = await s.compute_for_paper(iso.paper_id)
+    # PageRank baseline = 1/n; for a single node, n=1, so score=1.0
+    # after clamp.
+    assert 0.0 < metrics.pagerank_score <= 1.0
+
+
+@pytest.mark.asyncio
+async def test_pagerank_simple_chain_a_b_c_known_values(store):
+    """A → B → C with damping=0.85: rank_C > rank_B > rank_A."""
+    a = _node("a", citation_count=0, year=2020)
+    b = _node("b", citation_count=1, year=2020)
+    c = _node("c", citation_count=1, year=2020)
+    _persist_chain(store, a, b, c)
+
+    s = InfluenceScorer(store=store)
+    metrics_a = await s.compute_for_paper(a.paper_id)
+    metrics_b = await s.compute_for_paper(b.paper_id)
+    metrics_c = await s.compute_for_paper(c.paper_id)
+
+    # In a chain, the deepest node (C) gets the highest PageRank
+    # because it accumulates all upstream rank.
+    assert metrics_c.pagerank_score > metrics_b.pagerank_score
+    assert metrics_b.pagerank_score > metrics_a.pagerank_score
+
+
+# ---------------------------------------------------------------------------
+# HITS
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hits_authority_higher_than_hub_for_cited_paper(store):
+    """In an A → B graph, B has high authority, A has high hub score."""
+    a = _node("a", year=2020)
+    b = _node("b", year=2020)
+    _persist_chain(store, a, b)
+
+    s = InfluenceScorer(store=store)
+    metrics_a = await s.compute_for_paper(a.paper_id)
+    metrics_b = await s.compute_for_paper(b.paper_id)
+
+    assert metrics_b.authority_score > metrics_a.authority_score
+    assert metrics_a.hub_score > metrics_b.hub_score
+
+
+@pytest.mark.asyncio
+async def test_hits_convergence_within_max_iter(store):
+    """HITS converges quickly on small graphs (<<100 iters)."""
+    nodes = [_node(f"n{i}", year=2020) for i in range(5)]
+    _persist_chain(store, *nodes)
+    s = InfluenceScorer(store=store)
+    # Should not raise / hang. Convergence is internal; the smoke test
+    # is that compute_for_graph returns sensible metrics for all nodes.
+    out = await s.compute_for_graph([n.paper_id for n in nodes])
+    assert len(out) == 5
+    # All scores should be normalised → sum of squares ≈ 1.
+    auth_sq = sum(m.authority_score**2 for m in out)
+    assert 0.99 < auth_sq < 1.01
+
+
+@pytest.mark.asyncio
+async def test_hits_skipped_for_oversize_graph_logs_event(store, monkeypatch):
+    """Above MAX_GRAPH_NODES_FOR_HITS, HITS is skipped (logs event)."""
+    monkeypatch.setattr(scorer_module, "MAX_GRAPH_NODES_FOR_HITS", 1)
+    monkeypatch.setattr(scorer_module, "logger", structlog.get_logger())
+
+    a = _node("a", citation_count=1, year=2020)
+    b = _node("b", citation_count=1, year=2020)
+    _persist_chain(store, a, b)
+    s = InfluenceScorer(store=store)
+
+    with structlog.testing.capture_logs() as logs:
+        metrics = await s.compute_for_paper(a.paper_id)
+
+    # PageRank still ran (non-zero), but HITS was skipped.
+    assert metrics.pagerank_score > 0
+    assert metrics.hub_score == 0.0
+    assert metrics.authority_score == 0.0
+    skip_events = [
+        e
+        for e in logs
+        if e.get("event") == "influence_scorer_hits_skipped_oversize_graph"
+    ]
+    assert len(skip_events) >= 1
+    assert skip_events[0].get("limit") == 1
+
+
+def test_hits_empty_graph_returns_empty(store):
+    s = InfluenceScorer(store=store)
+    hubs, authorities = s._compute_hits()
+    assert hubs == {}
+    assert authorities == {}
+
+
+# ---------------------------------------------------------------------------
+# Velocity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_citation_velocity_known_paper_fixed_date_math(store):
+    """citations / years_since_publication, with frozen 'now'."""
+    n = _node("v", citation_count=100, publication_date=date(2020, 1, 1))
+    _persist_chain(store, n)
+    fixed_now = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    s = _frozen_scorer(store, fixed_now)
+    metrics = await s.compute_for_paper(n.paper_id)
+    # 5 years between 2020 and 2025 → 100/5 = 20.
+    assert metrics.citation_velocity == 20.0
+
+
+@pytest.mark.asyncio
+async def test_citation_velocity_year_only_fallback(store):
+    n = _node("y", citation_count=10, year=2020)
+    _persist_chain(store, n)
+    fixed_now = datetime(2022, 6, 1, tzinfo=timezone.utc)
+    s = _frozen_scorer(store, fixed_now)
+    metrics = await s.compute_for_paper(n.paper_id)
+    # 2022 - 2020 = 2 years → 10/2 = 5.0
+    assert metrics.citation_velocity == 5.0
+
+
+@pytest.mark.asyncio
+async def test_citation_velocity_same_year_clamps_to_one(store):
+    """Papers from the current year still get a velocity (years=max(1,0))."""
+    n = _node("recent", citation_count=5, year=2025)
+    _persist_chain(store, n)
+    fixed_now = datetime(2025, 6, 1, tzinfo=timezone.utc)
+    s = _frozen_scorer(store, fixed_now)
+    metrics = await s.compute_for_paper(n.paper_id)
+    assert metrics.citation_velocity == 5.0
+
+
+@pytest.mark.asyncio
+async def test_citation_velocity_missing_publication_date_returns_zero_with_event(
+    store, monkeypatch
+):
+    monkeypatch.setattr(scorer_module, "logger", structlog.get_logger())
+    n = _node("nd", citation_count=10)  # no year, no publication_date
+    _persist_chain(store, n)
+
+    s = InfluenceScorer(store=store)
+    with structlog.testing.capture_logs() as logs:
+        metrics = await s.compute_for_paper(n.paper_id)
+
+    assert metrics.citation_velocity == 0.0
+    skip_events = [
+        e
+        for e in logs
+        if e.get("event") == "influence_scorer_velocity_skipped_missing_date"
+    ]
+    assert len(skip_events) == 1
+    assert skip_events[0].get("paper_id") == n.paper_id
+
+
+@pytest.mark.asyncio
+async def test_citation_velocity_unknown_node_returns_zero(store):
+    """A paper id with no node row in the graph yields zero velocity."""
+    s = InfluenceScorer(store=store)
+    # Node was never persisted, but compute_for_paper should still
+    # return a baseline metric.
+    out = await s.compute_for_paper(make_paper_node_id("s2", "ghost"))
+    assert out.citation_velocity == 0.0
+    assert out.citation_count == 0
+
+
+def test_velocity_helper_handles_invalid_publication_date(store):
+    """Corrupt publication_date string in properties is ignored, fallback to year."""
+    s = InfluenceScorer(store=store, now=datetime(2025, 1, 1, tzinfo=timezone.utc))
+
+    class _FakeNode:
+        properties = {
+            "publication_date": "not-a-date",
+            "year": 2020,
+            "citation_count": 4,
+        }
+
+    # 2025 - 2020 = 5 years → 4/5 = 0.8
+    assert s._compute_velocity(_FakeNode(), "x") == pytest.approx(0.8)
+
+
+def test_velocity_helper_handles_invalid_year(store):
+    s = InfluenceScorer(store=store, now=datetime(2025, 1, 1, tzinfo=timezone.utc))
+
+    class _FakeNode:
+        properties = {"year": "not-a-year", "citation_count": 4}
+
+    assert s._compute_velocity(_FakeNode(), "x") == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Cache TTL
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_persistence_cache_hit_within_ttl(store):
+    """Second call within TTL reuses cached row; PageRank not re-invoked."""
+    n = _node("c1", citation_count=5, year=2020)
+    _persist_chain(store, n)
+
+    fixed_now = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    s = _frozen_scorer(store, fixed_now)
+
+    first = await s.compute_for_paper(n.paper_id)
+
+    # Patch GraphAlgorithms.pagerank: if the second call invokes it,
+    # we'll know.
+    with patch.object(scorer_module.GraphAlgorithms, "pagerank") as mock_pr:
+        second = await s.compute_for_paper(n.paper_id)
+    mock_pr.assert_not_called()
+    # Cached values returned verbatim.
+    assert second.pagerank_score == first.pagerank_score
+    assert second.citation_velocity == first.citation_velocity
+    assert second.computed_at == first.computed_at
+
+
+@pytest.mark.asyncio
+async def test_persistence_cache_miss_after_ttl_recomputes(store):
+    n = _node("c2", citation_count=5, year=2020)
+    _persist_chain(store, n)
+
+    initial_now = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    s_initial = _frozen_scorer(store, initial_now)
+    first = await s_initial.compute_for_paper(n.paper_id)
+    assert first.computed_at == initial_now
+
+    # Advance "now" past the 7-day TTL.
+    later = initial_now + DEFAULT_CACHE_TTL + timedelta(seconds=1)
+    s_later = _frozen_scorer(store, later)
+    with patch.object(
+        scorer_module.GraphAlgorithms,
+        "pagerank",
+        wraps=scorer_module.GraphAlgorithms.pagerank,
+    ) as mock_pr:
+        second = await s_later.compute_for_paper(n.paper_id)
+    mock_pr.assert_called_once()
+    assert second.computed_at == later
+
+
+@pytest.mark.asyncio
+async def test_persistence_cache_miss_when_no_row(store):
+    """Compute path runs when no cache row exists yet."""
+    n = _node("c3", citation_count=2, year=2020)
+    _persist_chain(store, n)
+    s = InfluenceScorer(store=store)
+    metrics = await s.compute_for_paper(n.paper_id)
+    assert metrics.citation_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Bulk path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_compute_for_graph_bulk_efficient(store):
+    """One PageRank invocation covers all requested nodes."""
+    nodes = [_node(f"b{i}", citation_count=i, year=2020) for i in range(5)]
+    _persist_chain(store, *nodes)
+    s = InfluenceScorer(store=store)
+
+    with patch.object(
+        scorer_module.GraphAlgorithms,
+        "pagerank",
+        wraps=scorer_module.GraphAlgorithms.pagerank,
+    ) as mock_pr:
+        out = await s.compute_for_graph([n.paper_id for n in nodes])
+
+    mock_pr.assert_called_once()
+    assert len(out) == 5
+    assert {m.paper_id for m in out} == {n.paper_id for n in nodes}
+
+
+@pytest.mark.asyncio
+async def test_compute_for_graph_empty_input(store):
+    s = InfluenceScorer(store=store)
+    assert await s.compute_for_graph([]) == []
+
+
+@pytest.mark.asyncio
+async def test_compute_for_graph_includes_unknown_node_with_zeros(store):
+    n = _node("known", citation_count=2, year=2020)
+    _persist_chain(store, n)
+    s = InfluenceScorer(store=store)
+
+    ghost_id = make_paper_node_id("s2", "ghost")
+    out = await s.compute_for_graph([n.paper_id, ghost_id])
+    assert len(out) == 2
+    ghost = next(m for m in out if m.paper_id == ghost_id)
+    assert ghost.citation_count == 0
+    assert ghost.citation_velocity == 0.0
+
+
+@pytest.mark.asyncio
+async def test_compute_for_paper_unknown_node_returns_baseline(store):
+    """compute_for_paper for an unknown id returns baseline metrics."""
+    s = InfluenceScorer(store=store)
+    out = await s.compute_for_paper(make_paper_node_id("s2", "ghost2"))
+    assert out.citation_count == 0
+    # PageRank dict will not contain ghost → 0.0
+    assert out.pagerank_score == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Cache write failure (audit)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cache_write_failure_logs_event_but_returns_metrics(store, monkeypatch):
+    monkeypatch.setattr(scorer_module, "logger", structlog.get_logger())
+    n = _node("cw", citation_count=1, year=2020)
+    _persist_chain(store, n)
+
+    s = InfluenceScorer(store=store)
+
+    def _raise(*args, **kwargs):
+        raise sqlite3.OperationalError("disk full")
+
+    # Patch open_connection inside the scorer module so the cache write
+    # path raises but the read path stays untouched (it ran before).
+    call_count = {"n": 0}
+    real_open = scorer_module.open_connection
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def fake_open(path):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            with real_open(path) as c:
+                yield c
+        else:
+            raise sqlite3.OperationalError("disk full")
+
+    monkeypatch.setattr(scorer_module, "open_connection", fake_open)
+
+    with structlog.testing.capture_logs() as logs:
+        metrics = await s.compute_for_paper(n.paper_id)
+    # Caller still receives in-memory metrics.
+    assert metrics.paper_id == n.paper_id
+    assert any(e.get("event") == "influence_scorer_cache_write_failed" for e in logs)
+
+
+def test_write_cache_no_op_on_empty_input(store):
+    s = InfluenceScorer(store=store)
+    # Should not raise and should not open any connection.
+    s._write_cache([])
+
+
+# ---------------------------------------------------------------------------
+# InfluenceMetrics model
+# ---------------------------------------------------------------------------
+
+
+def test_influence_metrics_defaults():
+    m = InfluenceMetrics(paper_id="paper:s2:x")
+    assert m.citation_count == 0
+    assert m.citation_velocity == 0.0
+    assert m.pagerank_score == 0.0
+    assert m.hub_score == 0.0
+    assert m.authority_score == 0.0
+    assert isinstance(m.computed_at, datetime)
+
+
+def test_influence_metrics_pagerank_clamped_to_one():
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        InfluenceMetrics(paper_id="paper:s2:x", pagerank_score=1.5)
+
+
+def test_influence_metrics_rejects_extra_fields():
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        InfluenceMetrics(paper_id="paper:s2:x", foo=1)
+
+
+# ---------------------------------------------------------------------------
+# PageRank score clamp
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pagerank_score_clamped_to_one(store, monkeypatch):
+    """If GraphAlgorithms.pagerank returns >1.0, the scorer clamps to 1.0."""
+    n = _node("p", citation_count=1, year=2020)
+    _persist_chain(store, n)
+
+    def fake_pagerank(*args, **kwargs):
+        return {n.paper_id: 5.0}  # pathological
+
+    monkeypatch.setattr(scorer_module.GraphAlgorithms, "pagerank", fake_pagerank)
+
+    s = InfluenceScorer(store=store)
+    metrics = await s.compute_for_paper(n.paper_id)
+    assert metrics.pagerank_score == 1.0
+
+
+@pytest.mark.asyncio
+async def test_pagerank_score_clamped_to_zero(store, monkeypatch):
+    n = _node("pn", citation_count=1, year=2020)
+    _persist_chain(store, n)
+
+    def fake_pagerank(*args, **kwargs):
+        return {n.paper_id: -0.1}
+
+    monkeypatch.setattr(scorer_module.GraphAlgorithms, "pagerank", fake_pagerank)
+
+    s = InfluenceScorer(store=store)
+    metrics = await s.compute_for_paper(n.paper_id)
+    assert metrics.pagerank_score == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Constants surface
+# ---------------------------------------------------------------------------
+
+
+def test_module_constants():
+    assert MAX_GRAPH_NODES_FOR_HITS == 10_000
+    assert DEFAULT_CACHE_TTL == timedelta(days=7)
+
+
+def test_hits_filters_edges_to_unknown_nodes(store, monkeypatch):
+    """An edge whose source/target is not in the queried node set is dropped.
+
+    This exercises the filter branch in _compute_hits — covers the
+    false branch of `if source in node_set and target in node_set:`.
+    """
+    a = _node("a", year=2020)
+    b = _node("b", year=2020)
+    _persist_chain(store, a, b)
+
+    s = InfluenceScorer(store=store)
+    # Inject a phantom edge into the algorithm input by patching
+    # _list_edges_by_types to return an extra (ghost, ghost) tuple that
+    # is not in the node_set.
+    real_list_edges = s.store._list_edges_by_types
+
+    def fake_list_edges(types):
+        edges = list(real_list_edges(types))
+        edges.append(("paper:s2:ghost1", "paper:s2:ghost2"))
+        edges.append(("paper:s2:ghost1", a.paper_id))  # only target valid
+        edges.append((a.paper_id, "paper:s2:ghost2"))  # only source valid
+        return edges
+
+    monkeypatch.setattr(s.store, "_list_edges_by_types", fake_list_edges)
+    hubs, authorities = s._compute_hits()
+    # Only the valid a -> b edge contributed; ghost edges were filtered.
+    assert authorities[b.paper_id] > 0
+    assert "paper:s2:ghost1" not in hubs
+
+
+def test_hits_runs_all_iterations_without_convergence(store, monkeypatch):
+    """Force HITS to skip the early-break: convergence threshold = -inf.
+
+    Covers the loop-exit-without-break branch of the for/range loop.
+    """
+    a = _node("a", year=2020)
+    b = _node("b", year=2020)
+    _persist_chain(store, a, b)
+
+    # Cap iterations at 1 so we exit the loop normally (no break) and
+    # set epsilon to -1 so the convergence test never fires.
+    monkeypatch.setattr(scorer_module, "_HITS_MAX_ITERATIONS", 1)
+    monkeypatch.setattr(scorer_module, "_HITS_EPSILON", -1.0)
+
+    s = InfluenceScorer(store=store)
+    hubs, authorities = s._compute_hits()
+    # We exited via "all iterations done" (no break). The function must
+    # still return well-formed score vectors.
+    assert set(hubs.keys()) == {a.paper_id, b.paper_id}
+    assert set(authorities.keys()) == {a.paper_id, b.paper_id}

--- a/tests/unit/services/intelligence/citation/test_models.py
+++ b/tests/unit/services/intelligence/citation/test_models.py
@@ -466,3 +466,49 @@ def test_citation_edge_to_graph_edge_omits_none_properties():
     assert "is_influential" not in g.properties
     assert g.properties["section"] == "Intro"
     assert g.properties["source"] == "semantic_scholar"
+
+
+# ---------------------------------------------------------------------------
+# CitationNode.to_graph_node — influential_citation_count + publication_date
+# (C-1: bring models.py to ≥99% coverage; covers lines 272 + 274)
+# ---------------------------------------------------------------------------
+
+
+def test_citation_node_to_graph_node_includes_influential_citation_count():
+    """ICC=42 must appear in graph properties."""
+    node = CitationNode(
+        paper_id="paper:s2:abc",
+        title="ICC Paper",
+        influential_citation_count=42,
+    )
+    props = node.to_graph_node().properties
+    assert props["influential_citation_count"] == 42
+
+
+def test_citation_node_to_graph_node_omits_influential_citation_count_when_none():
+    """ICC=None must NOT appear in graph properties."""
+    node = CitationNode(paper_id="paper:s2:abc", title="ICC None Paper")
+    # influential_citation_count defaults to None
+    props = node.to_graph_node().properties
+    assert "influential_citation_count" not in props
+
+
+def test_citation_node_to_graph_node_includes_publication_date_iso_string():
+    """publication_date set to date(2023, 6, 1) must appear as '2023-06-01'."""
+    from datetime import date
+
+    node = CitationNode(
+        paper_id="paper:s2:abc",
+        title="Dated Paper",
+        publication_date=date(2023, 6, 1),
+    )
+    props = node.to_graph_node().properties
+    assert props["publication_date"] == "2023-06-01"
+
+
+def test_citation_node_to_graph_node_omits_publication_date_when_none():
+    """publication_date=None must NOT appear in graph properties."""
+    node = CitationNode(paper_id="paper:s2:abc", title="Undated Paper")
+    # publication_date defaults to None
+    props = node.to_graph_node().properties
+    assert "publication_date" not in props

--- a/tests/unit/services/intelligence/citation/test_models.py
+++ b/tests/unit/services/intelligence/citation/test_models.py
@@ -12,6 +12,8 @@ from src.services.intelligence.citation.models import (
     CitationDirection,
     CitationEdge,
     CitationNode,
+    CrawlDirection,
+    LegacyCitationDirection,
     _normalize_id_segment,
     make_citation_edge_id,
     make_paper_node_id,
@@ -512,3 +514,30 @@ def test_citation_node_to_graph_node_omits_publication_date_when_none():
     # publication_date defaults to None
     props = node.to_graph_node().properties
     assert "publication_date" not in props
+
+
+# ---------------------------------------------------------------------------
+# CrawlDirection enum — canonical values (C-4)
+# ---------------------------------------------------------------------------
+
+
+def test_crawl_direction_enum_values():
+    """Pin canonical CrawlDirection enum values per spec REQ-9.2.2."""
+    assert CrawlDirection.FORWARD.value == "forward"
+    assert CrawlDirection.BACKWARD.value == "backward"
+    assert CrawlDirection.BOTH.value == "both"
+
+
+def test_crawl_direction_is_distinct_from_citation_direction():
+    """CrawlDirection and CitationDirection are different enum classes."""
+    assert CrawlDirection is not CitationDirection
+    assert CrawlDirection is not LegacyCitationDirection
+
+
+def test_citation_direction_backward_compat_alias():
+    """CitationDirection is the backward-compat alias for LegacyCitationDirection."""
+    assert CitationDirection is LegacyCitationDirection
+    # Original OUT/IN/BOTH values are intact
+    assert CitationDirection.OUT.value == "out"
+    assert CitationDirection.IN.value == "in"
+    assert CitationDirection.BOTH.value == "both"

--- a/tests/unit/services/intelligence/citation/test_openalex_client.py
+++ b/tests/unit/services/intelligence/citation/test_openalex_client.py
@@ -1451,3 +1451,61 @@ async def test_transient_failure_then_retry_success(client):
 
 def test_base_url_is_openalex_root():
     assert OpenAlexCitationClient.BASE_URL == "https://api.openalex.org"
+
+
+# ---------------------------------------------------------------------------
+# _payload_to_node: publication_date parsing (C-2 — OpenAlex mirror)
+# ---------------------------------------------------------------------------
+
+
+def test_payload_to_node_with_publication_date(client):
+    """publication_date ISO string is parsed to date(2023, 6, 1)."""
+    from datetime import date
+
+    payload = {
+        "id": "https://openalex.org/W999",
+        "title": "Dated Work",
+        "publication_year": 2023,
+        "publication_date": "2023-06-01",
+        "cited_by_count": 20,
+        "referenced_works_count": 5,
+        "ids": {"openalex": "https://openalex.org/W999"},
+    }
+    node = client._payload_to_node(payload)
+    assert node.publication_date == date(2023, 6, 1)
+
+
+def test_payload_to_node_without_publication_date(client):
+    """Absent publication_date field results in publication_date=None."""
+    payload = {
+        "id": "https://openalex.org/W999",
+        "title": "No Date Work",
+        "publication_year": 2022,
+        "cited_by_count": 10,
+        "referenced_works_count": 2,
+        "ids": {"openalex": "https://openalex.org/W999"},
+    }
+    node = client._payload_to_node(payload)
+    assert node.publication_date is None
+
+
+def test_payload_to_node_with_malformed_publication_date(client):
+    """Malformed publication_date string gracefully degrades to None."""
+    import structlog.testing
+
+    payload = {
+        "id": "https://openalex.org/W999",
+        "title": "Bad Date Work",
+        "publication_year": 2021,
+        "publication_date": "not-a-date",
+        "cited_by_count": 3,
+        "referenced_works_count": 0,
+        "ids": {"openalex": "https://openalex.org/W999"},
+    }
+    with structlog.testing.capture_logs() as logs:
+        node = client._payload_to_node(payload)
+    assert node.publication_date is None
+    warning_events = [e for e in logs if e.get("log_level") == "warning"]
+    assert any(
+        "malformed_publication_date" in e.get("event", "") for e in warning_events
+    )

--- a/tests/unit/services/intelligence/citation/test_semantic_scholar_client.py
+++ b/tests/unit/services/intelligence/citation/test_semantic_scholar_client.py
@@ -1450,3 +1450,85 @@ def test_rate_limit_error_accepts_retry_after():
     """
     err = RateLimitError("slow down", retry_after=42.5)
     assert err.retry_after == 42.5
+
+
+# ---------------------------------------------------------------------------
+# _payload_to_node: publication_date parsing (C-2) + ICC assertions (H-T5)
+# ---------------------------------------------------------------------------
+
+
+def test_payload_to_node_with_publication_date(client):
+    """publicationDate ISO string is parsed to date(2023, 6, 1)."""
+    from datetime import date
+
+    payload = {
+        "paperId": "s2abc",
+        "title": "Dated Paper",
+        "year": 2023,
+        "citationCount": 10,
+        "referenceCount": 2,
+        "publicationDate": "2023-06-01",
+    }
+    node = client._payload_to_node(payload)
+    assert node.publication_date == date(2023, 6, 1)
+
+
+def test_payload_to_node_without_publication_date(client):
+    """Absent publicationDate field results in publication_date=None."""
+    payload = {
+        "paperId": "s2abc",
+        "title": "No Date Paper",
+        "year": 2022,
+        "citationCount": 5,
+        "referenceCount": 1,
+    }
+    node = client._payload_to_node(payload)
+    assert node.publication_date is None
+
+
+def test_payload_to_node_with_malformed_publication_date(client, caplog):
+    """Malformed publicationDate string gracefully degrades to None."""
+    import structlog.testing
+
+    payload = {
+        "paperId": "s2abc",
+        "title": "Bad Date Paper",
+        "year": 2021,
+        "citationCount": 3,
+        "referenceCount": 0,
+        "publicationDate": "not-a-date",
+    }
+    with structlog.testing.capture_logs() as logs:
+        node = client._payload_to_node(payload)
+    assert node.publication_date is None
+    warning_events = [e for e in logs if e.get("log_level") == "warning"]
+    assert any(
+        "malformed_publication_date" in e.get("event", "") for e in warning_events
+    )
+
+
+def test_payload_to_node_with_influential_citation_count(client):
+    """influentialCitationCount=42 is forwarded to CitationNode."""
+    payload = {
+        "paperId": "s2icc",
+        "title": "ICC Paper",
+        "year": 2020,
+        "citationCount": 100,
+        "referenceCount": 5,
+        "influentialCitationCount": 42,
+    }
+    node = client._payload_to_node(payload)
+    assert node.influential_citation_count == 42
+
+
+def test_payload_to_node_without_influential_citation_count(client):
+    """Absent influentialCitationCount results in None."""
+    payload = {
+        "paperId": "s2icc",
+        "title": "No ICC Paper",
+        "year": 2019,
+        "citationCount": 50,
+        "referenceCount": 3,
+    }
+    node = client._payload_to_node(payload)
+    assert node.influential_citation_count is None

--- a/tests/unit/storage/intelligence_graph/test_migrations.py
+++ b/tests/unit/storage/intelligence_graph/test_migrations.py
@@ -22,6 +22,7 @@ from src.storage.intelligence_graph.migrations import (
     MIGRATION_V1_INITIAL,
     MIGRATION_V2_MONITORING_RUNS,
     MIGRATION_V3_MONITORING_RUNS_FK,
+    MIGRATION_V4_CITATION_INFLUENCE_METRICS,
 )
 from src.utils.security import SecurityError
 
@@ -1175,3 +1176,106 @@ class TestMigrationV4CitationInfluenceMetrics:
         manager.migrate()
         applied_versions = {m["version"] for m in manager.get_applied_migrations()}
         assert 4 in applied_versions
+
+    def test_migrate_v4_preserves_data_inserted_under_v3_schema(
+        self, temp_db: Path
+    ) -> None:
+        """H-T1: V4 isolation upgrade test.
+
+        Apply V1+V2+V3 only, insert known rows into ``nodes`` and
+        ``monitoring_runs``, then apply V4 in isolation. V4 must (a)
+        create the ``citation_influence_metrics`` table and (b) not
+        disturb any pre-existing rows in other tables. Mirrors the V3
+        regression guard at ``test_migrate_v3_preserves_data_inserted_under_v2_schema``.
+        """
+        manager = MigrationManager(temp_db)
+        # Apply only V1 + V2 + V3 -- stop short of V4.
+        conn = manager._get_connection()
+        try:
+            manager._ensure_migrations_table(conn)
+            manager.apply_migration(conn, MIGRATION_V1_INITIAL)
+            manager.apply_migration(conn, MIGRATION_V2_MONITORING_RUNS)
+            manager.apply_migration(conn, MIGRATION_V3_MONITORING_RUNS_FK)
+        finally:
+            conn.close()
+
+        # Insert a node + a subscription + a monitoring_runs row under V3 shape.
+        with open_connection(temp_db) as conn:
+            conn.execute(
+                """
+                INSERT INTO nodes (
+                    node_id, node_type, properties, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    "paper:s2:abc",
+                    "paper",
+                    "{}",
+                    "2024-06-01T00:00:00+00:00",
+                    "2024-06-01T00:00:00+00:00",
+                ),
+            )
+            conn.execute(
+                """
+                INSERT INTO subscriptions (
+                    subscription_id, user_id, name, config
+                ) VALUES (?, ?, ?, ?)
+                """,
+                ("sub-v3-1", "alice", "V3 Sub", "{}"),
+            )
+            conn.execute(
+                """
+                INSERT INTO monitoring_runs (
+                    run_id, subscription_id, user_id,
+                    started_at, finished_at, status, error,
+                    papers_found, papers_new
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    "run-v3-1",
+                    "sub-v3-1",
+                    "alice",
+                    "2024-06-01T00:00:00+00:00",
+                    "2024-06-01T00:01:00+00:00",
+                    "success",
+                    None,
+                    5,
+                    2,
+                ),
+            )
+            conn.commit()
+
+        # Now apply V4 in isolation -- must (a) create the new table
+        # (b) not destroy anything that was already there.
+        conn = manager._get_connection()
+        try:
+            manager._ensure_migrations_table(conn)
+            manager.apply_migration(conn, MIGRATION_V4_CITATION_INFLUENCE_METRICS)
+        finally:
+            conn.close()
+
+        with open_connection(temp_db) as conn:
+            # (a) New table now exists
+            cursor = conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name='citation_influence_metrics'"
+            )
+            assert cursor.fetchone() is not None
+
+            # (b) V3 rows survive intact
+            node_row = conn.execute(
+                "SELECT node_id, node_type FROM nodes WHERE node_id = ?",
+                ("paper:s2:abc",),
+            ).fetchone()
+            assert node_row is not None
+            assert node_row["node_type"] == "paper"
+
+            run_row = conn.execute(
+                "SELECT run_id, status, papers_found, papers_new "
+                "FROM monitoring_runs WHERE run_id = ?",
+                ("run-v3-1",),
+            ).fetchone()
+            assert run_row is not None
+            assert run_row["status"] == "success"
+            assert run_row["papers_found"] == 5
+            assert run_row["papers_new"] == 2

--- a/tests/unit/storage/intelligence_graph/test_migrations.py
+++ b/tests/unit/storage/intelligence_graph/test_migrations.py
@@ -1112,3 +1112,66 @@ class TestMigrationV3MonitoringRunsFk:
             "V3 not recorded in schema_migrations -- migrate() will "
             "redundantly re-apply on every startup"
         )
+
+
+class TestMigrationV4CitationInfluenceMetrics:
+    """Tests for MIGRATION_V4_CITATION_INFLUENCE_METRICS (Issue #129)."""
+
+    def test_migrate_v4_creates_citation_influence_metrics_table(
+        self, temp_db: Path
+    ) -> None:
+        manager = MigrationManager(temp_db)
+        manager.migrate()
+        with open_connection(temp_db) as conn:
+            cursor = conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name='citation_influence_metrics'"
+            )
+            assert cursor.fetchone() is not None
+
+    def test_migrate_v4_table_has_expected_columns(self, temp_db: Path) -> None:
+        manager = MigrationManager(temp_db)
+        manager.migrate()
+        with open_connection(temp_db) as conn:
+            cursor = conn.execute("PRAGMA table_info(citation_influence_metrics)")
+            cols = {row["name"] for row in cursor.fetchall()}
+        assert cols == {
+            "paper_id",
+            "citation_count",
+            "citation_velocity",
+            "pagerank_score",
+            "hub_score",
+            "authority_score",
+            "computed_at",
+            "version",
+        }
+
+    def test_migrate_v4_paper_id_is_primary_key(self, temp_db: Path) -> None:
+        manager = MigrationManager(temp_db)
+        manager.migrate()
+        with open_connection(temp_db) as conn:
+            cursor = conn.execute("PRAGMA table_info(citation_influence_metrics)")
+            pk_cols = [row["name"] for row in cursor.fetchall() if row["pk"] == 1]
+        assert pk_cols == ["paper_id"]
+
+    def test_migrate_v4_unique_constraint_on_paper_id(self, temp_db: Path) -> None:
+        manager = MigrationManager(temp_db)
+        manager.migrate()
+        with open_connection(temp_db) as conn:
+            conn.execute(
+                "INSERT INTO citation_influence_metrics "
+                "(paper_id, computed_at) VALUES (?, ?)",
+                ("paper:s2:dup", "2025-01-01T00:00:00+00:00"),
+            )
+            with pytest.raises(sqlite3.IntegrityError):
+                conn.execute(
+                    "INSERT INTO citation_influence_metrics "
+                    "(paper_id, computed_at) VALUES (?, ?)",
+                    ("paper:s2:dup", "2025-01-02T00:00:00+00:00"),
+                )
+
+    def test_migrate_v4_records_version(self, temp_db: Path) -> None:
+        manager = MigrationManager(temp_db)
+        manager.migrate()
+        applied_versions = {m["version"] for m in manager.get_applied_migrations()}
+        assert 4 in applied_versions


### PR DESCRIPTION
## Summary

Implements two tightly-coupled Phase 9.2 deliverables — the crawler builds the citation graph that the scorer ranks:

- **Issue #127 (REQ-9.2.2): BFS Citation Chain Crawler** — `src/services/intelligence/citation/crawler.py`
  - `CitationCrawler` walks the citation graph breadth-first using `collections.deque` + `popleft()`
  - `CrawlConfig` (max_depth 1-3, max_papers_per_level 10-200, direction, filters); `CrawlResult` with per-filter drop counts and budget telemetry
  - Per-level top-k via deterministic `sort_by_influence` (influentialCitationCount DESC, citationCount DESC, publication_date DESC)
  - `MAX_API_CALLS_PER_CRAWL = 1000` budget; `asyncio.Semaphore(10)` concurrency cap
  - Composes the existing `SemanticScholarCitationClient` / `OpenAlexCitationClient` (no rebuild)

- **Issue #129 (REQ-9.2.4): Influence Scorer** — `src/services/intelligence/citation/influence_scorer.py`
  - `compute_for_paper` / `compute_for_graph` with 7-day TTL cache (V4 migration adds `citation_influence_metrics` table)
  - PageRank delegated to `GraphAlgorithms.pagerank` (single source of truth — never reimplemented)
  - HITS power iteration (max 100 iters, ε=1e-6); skipped above `MAX_GRAPH_NODES_FOR_HITS = 10_000`
  - CPU-bound paths wrapped in `asyncio.to_thread`

## Failure semantics (PR #124 follow-through)

Both modules follow the Orchestration Patterns codified in `CLAUDE.md` after PR #124's silent-data-loss incident:

- **Crawler — Checked Success gating**: persistence failure (`GraphStoreError` on `add_nodes_batch` / `add_edges_batch`) ABORTS the entire crawl. Subsequent API calls are NOT made. `test_crawl_persistence_failure_aborts_cycle` pins this with the negative-path `mock.assert_not_called()` check (`s2_client.get_references.await_count == 1`) that GEMINI.md §5 requires.
- **Crawler — Fail-Soft Boundary across independent peers**: per-paper `APIError` from a provider logs `citation_crawl_provider_failed_skipping_node` and continues with the remaining queue.
- **Scorer — Audit-write the failure paths**: HITS-skip emits `influence_scorer_hits_skipped_oversize_graph`; missing publication date emits `influence_scorer_velocity_skipped_missing_date`; cache-write failure emits `influence_scorer_cache_write_failed` (but does NOT propagate — caller still receives in-memory metrics).

## Schema changes

- New V4 migration: `citation_influence_metrics` table (paper_id PRIMARY KEY, citation metrics, computed_at TEXT for TTL, version reserved for future evolution). Indexes on `computed_at` and `pagerank_score DESC` for the recommender (#REQ-9.2.5).
- `CitationNode` gains optional `influential_citation_count: int | None` and `publication_date: date | None` fields. `SemanticScholarCitationClient._payload_to_node` populates the former from the `influentialCitationCount` field it was already requesting.

## Test plan

- [x] **Coverage**: `crawler.py` 100% line+branch; `influence_scorer.py` 100% line+branch; `migrations.py` 100% line+branch
- [x] **Test count**: 78 new tests (34 crawler + 39 scorer + 5 V4 migration)
- [x] **Project total**: 4,830 tests passed; project-wide coverage 99.28% (≥99% gate)
- [x] **Lint/types**: Black, Flake8, Mypy clean (`./verify.sh` exits 0)
- [x] **No `# pragma: no cover` added**: per project rules

Closes #127
Closes #129