### PR TITLE
docs: codify Git/Repo Cleanup, Debugging Principles, Test Authoring Conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -803,6 +803,22 @@ The project includes a comprehensive verification script that runs all required 
 
 ---
 
+## Debugging Principles
+
+### Verification Before Action
+
+Before "fixing" any failure — formatting drift, lint changes, CI red, mysterious test failures — **verify the root cause first** rather than reformatting or editing files reflexively. Common false leads:
+
+- **Tool version mismatch** — the local tool may differ from CI's pinned version. Check `pyproject.toml` / CI workflow before "fixing" diff output that may simply be the local tool emitting a newer style.
+- **Config drift** — verify the config the failure is blamed on is actually the one being read at runtime. Trace the code path (e.g., grep for `os.getenv`, `Field(default=...)`, the constructor that reads it) before changing config values.
+- **Silently-skipped local checks** — `verify.sh` may skip a gate if the underlying tool isn't installed locally (e.g., `codespell` was silently absent in PR #132 reviews — local "all green" while CI flagged a real spelling error). Don't conclude "it passes locally" without confirming each gate actually ran.
+- **Side-effect interactions** — global state can make a test "fail mysteriously" when run in a different order. Example: `cache_logger_on_first_use=True` in structlog freezes the bound logger at first call, so `capture_logs()` won't see events from already-bound loggers. Investigate the interaction before patching the test.
+- **Symptom ≠ cause** — a Pydantic validation error in test setup may be flagging that production validators were tightened correctly; the right fix is updating the fixture, not loosening the validator.
+
+When in doubt: read the failing tool's actual output end-to-end, then trace the code path it indicts. Do not assume the symptom names the cause.
+
+---
+
 ## Coding Standards
 
 ### Security Standards (CRITICAL)
@@ -863,6 +879,18 @@ The project includes a comprehensive verification script that runs all required 
   - Pre-commit hook should reject commits with coverage <99%
   - CI/CD pipeline must fail on coverage <99%
   - Pull requests require coverage proof in description
+
+### Test Authoring Conventions
+
+Before writing or modifying tests, **read the target module first** to confirm:
+
+1. **Exact attribute names** — internal naming may differ from intuition (e.g., `_registry` vs `_paper_registry`, `_run_repo` vs `_runs_repository`). A test that monkey-patches the wrong attribute name silently no-ops.
+2. **Correct API signatures** — verify keyword names (e.g., `corpus_dir` vs `data_dir`), method-vs-property (`.stats` vs `.get_stats()`), and async-vs-sync.
+3. **Valid input values** — Pydantic validators reject empty strings, out-of-range numbers, malformed identifiers. Check the model's validators before passing test fixtures.
+4. **Established fixture patterns** — many shared fixtures live in `tests/conftest.py` or per-package `conftest.py`. Don't recreate them inline.
+5. **structlog event capture** — the project uses `structlog.testing.capture_logs()`, NOT pytest's `caplog`. With `cache_logger_on_first_use=True` configured in `src/utils/logging.py`, you may also need `monkeypatch.setattr(target_module, "logger", structlog.get_logger())` *before* entering `capture_logs()` — otherwise the cached production logger ignores the processor swap. See `tests/unit/test_scheduling/test_monitoring_check_job.py` for the canonical pattern.
+
+Use Read/Grep on the source before drafting patches. A test built on assumed APIs is debt that surfaces later as flaky tests or vacuous coverage (assertions that pass without exercising the production branch they target).
 
 ## Key Implementation Details
 
@@ -945,6 +973,28 @@ google-generativeai  # or anthropic
 marker-pdf
 pyyaml              # for config file parsing
 ```
+
+## Git/Repo Cleanup Workflow
+
+After PRs are merged, perform these steps in order:
+
+1. **Sync main:** `git checkout main && git pull --ff-only origin main`
+2. **Prune stale remote-tracking refs:** `git fetch --prune`
+3. **Delete merged local branches:** `git branch -d <merged-branch>` (lowercase `-d` — fails safely if not actually merged; never use `-D` without explicit user confirmation per the [Dangerous Operations](#%EF%B8%8F-dangerous-operations---user-confirmation-required) table)
+4. **Worktree removal:** follow the [Git Worktree Protection Protocol](#-git-worktree-protection-protocol-non-negotiable). Use `git wt-remove <path>` and obtain explicit user confirmation before removing each worktree. **The instruction "clean up repo" does NOT auto-authorize worktree removal.**
+
+### Files That MUST NOT Be Deleted Without Explicit User Confirmation
+
+Regardless of cleanup context (post-merge sweep, "tidy up", "remove unused"), the following files/directories are reference and governance documents whose presence elsewhere in the repo may not be obvious:
+
+- `CLAUDE.md`, `GEMINI.md` — implementer + reviewer guidance (this file and its peer)
+- `CODE_REVIEW_AGENT.md` — review-agent contract
+- `DESIGN_DOC_*.md` — architectural decision records
+- `docs/specs/PHASE_*_SPEC.md` — milestone specifications referenced by review checklists
+- `.omc/`, `.spec-workflow/` — workflow state directories used by OMC autopilot
+- `.env.template`, `.gitignore`, `.codespell-ignore` — repository configuration
+
+If a cleanup task appears to require touching any of these, **stop and ask**.
 
 ## Output Directory Management
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -256,10 +256,10 @@ Reviewers must maintain **extreme engineering rigor** and keep the bar exception
       ```bash
       ./verify.sh
       ```
-   5. **Cleanup:** Safely remove the worktree:
+   5. **Cleanup:** Safely remove the worktree per the [Git/Repo Cleanup Workflow in CLAUDE.md](CLAUDE.md#gitrepo-cleanup-workflow). Worktree removal requires explicit user confirmation; review worktrees that have unpushed commits (e.g., from rebased branches) trigger the safety check and must be force-removed only after verifying contents are upstream:
       ```bash
       cd ..
-      git worktree remove pr-review-ID
+      git wt-remove pr-review-ID  # safe alias; blocks if work is at risk
       ```
 
    **Environment Integrity Checks:**
@@ -282,7 +282,13 @@ Reviewers must maintain **extreme engineering rigor** and keep the bar exception
    - **Security First:** Verify all security checklist items are met. No compromises.
    - **Secrets Management:** Ensure no real keys are committed.
    - **Path Security:** Audit `.gitignore` and path sanitization logic.
-7. **Final Assessment:** A clear "Status" (APPROVED or CHANGES REQUESTED) with a recommendation for action.
+7. **Verification Before Action (Non-Negotiable)** *(implementor-side guidance lives in [CLAUDE.md "Debugging Principles"](CLAUDE.md#debugging-principles))*:
+   - **Verify the root cause before "fixing":** When a CI gate fails, do not reformat / edit / loosen-validator reflexively. Confirm the failure is real and trace the code path before recommending a fix.
+   - **Reviewer-specific failure modes to watch for:**
+     - **Local checks silently skipped:** if a reviewer's local `verify.sh` is greener than CI, suspect missing tooling (e.g., `codespell` not installed) — confirm by inspecting which gates ran, not just the final exit code.
+     - **Reviewing a stale OID:** always pin to the PR's `headRefOid` (per step 2 above). A "fix" that addresses code on an old SHA wastes the PR author's time when the branch has moved.
+     - **Symptom ≠ cause:** a fixture failure may indicate the production validator was correctly tightened; the right outcome is updating the test, not loosening the validator.
+8. **Final Assessment:** A clear "Status" (APPROVED or CHANGES REQUESTED) with a recommendation for action.
 
 ---
 
@@ -421,6 +427,8 @@ Refer to `CLAUDE.md` and `README.md` for project details, tech stack, and develo
 ## Coding Standards
 
 Adhere strictly to the coding standards, security standards, and testing standards defined in `CLAUDE.md`.
+
+When reviewing test changes specifically, verify the test author followed the [Test Authoring Conventions in CLAUDE.md](CLAUDE.md#test-authoring-conventions): tests must be built on attribute names, API signatures, and validator constraints actually present in the target module — not assumed. Tests built on wrong names are the silent failure mode (they pass but exercise nothing). Confirm the production code path the test claims to cover is actually invoked.
 
 ## Key Implementation Details
 


### PR DESCRIPTION
## Summary

Three additions to **CLAUDE.md** with reviewer-focused mirrors in **GEMINI.md**, codifying lessons from recent PRs (especially #126 and #132). Doc-only PR — zero code changes.

### Changes

1. **`## Git/Repo Cleanup Workflow`** (new top-level section in CLAUDE.md, before Output Directory Management)
   - Post-merge sequence: sync → prune → branch delete → worktree (with explicit ordering)
   - Cross-references the existing Git Worktree Protection Protocol so the "automatic cleanup" guidance does not contradict the "explicit user confirmation required" rule
   - "Files That MUST NOT Be Deleted Without Explicit User Confirmation" allow-list covers governance docs (CLAUDE.md, GEMINI.md, CODE_REVIEW_AGENT.md, DESIGN_DOC_*.md, docs/specs/*, .omc/, .spec-workflow/, etc.)

2. **`## Debugging Principles` → `### Verification Before Action`** (new top-level section in CLAUDE.md, between Development Workflow and Coding Standards; GEMINI.md gets a parallel reviewer-side bullet at PR Review Protocol step #7)
   - Codifies the lesson from PR #132: codespell silently skipped locally when the tool was not installed; local "all green" was misleading and CI rightly flagged a real spelling defect
   - Calls out four common false leads: tool-version mismatch, config drift, silently-skipped local checks, side-effect interactions (e.g., structlog `cache_logger_on_first_use`)
   - Reviewer-side variant adds: stale-OID review, symptom-vs-cause trap, and the "did all gates actually run" question

3. **`### Test Authoring Conventions`** (new subsection in CLAUDE.md under existing Testing Standards; GEMINI.md gets a one-line reviewer cross-reference)
   - Lists the five things to read on the target module before drafting a test (attribute names, API signatures, validator constraints, fixture patterns, structlog capture pattern)
   - References `tests/unit/test_scheduling/test_monitoring_check_job.py` as the canonical pattern for the `cache_logger_on_first_use` rebind monkeypatch (originated in PR #126 fix work)

### Spelling note

Used "implementer" not "implementor" in the new CLAUDE.md content because the project's codespell config flags "implementor" as a typo. Existing GEMINI.md usages of "implementor-side" pass codespell only because hyphenation changes tokenization — left those untouched to avoid scope creep.

### Verification

- Pre-push verify ✅ (176s — Black/Flake8/Mypy/codespell/full pytest all green)
- All five CI gates expected to pass (no code changes; spelling pre-checked locally with codespell installed)

## Test plan

- [ ] All 5 CI gates pass (`test (3.14)`, `Lint Markdown`, `Check Spelling`, `Documentation Drift Check`, `Validate Phase Specs`)
- [ ] Spot-check the rendered headings in CLAUDE.md and GEMINI.md on GitHub
- [ ] Verify the cross-reference anchors resolve (e.g., `CLAUDE.md#debugging-principles` from GEMINI.md)