### PR TITLE
fix(storage): correct off-by-one parents[N] in _project_root (CRITICAL — Phase 9.1 production blocker)

### DIFF
--- a/src/storage/intelligence_graph/path_utils.py
+++ b/src/storage/intelligence_graph/path_utils.py
@@ -27,9 +27,27 @@ logger = structlog.get_logger()
 
 
 def _project_root() -> Path:
-    """Return the repository root (3 levels up from this file)."""
-    # path_utils.py -> storage -> intelligence -> services -> src -> repo
-    return Path(__file__).resolve().parents[4]
+    """Return the repository root.
+
+    File location: ``src/storage/intelligence_graph/path_utils.py``
+
+    Ancestor walk (verified by ``test_project_root_resolves_to_repo``):
+    - ``parents[0]`` = ``src/storage/intelligence_graph``
+    - ``parents[1]`` = ``src/storage``
+    - ``parents[2]`` = ``src``
+    - ``parents[3]`` = repository root  ← what we want
+
+    Previously used ``parents[4]`` from when this file lived under
+    ``src/services/intelligence/storage/``. PR #105's architectural
+    relocation moved it to ``src/storage/intelligence_graph/`` but
+    missed updating this parent count, causing ``_allowed_bases`` to
+    resolve ``data/``/``cache/`` against the wrong directory and
+    rejecting every production Phase 9.1 monitoring CLI invocation
+    with ``SecurityError: Database path is outside approved storage
+    roots``. Tests masked the regression because they exclusively use
+    ``tempfile.gettempdir()`` (also an approved base).
+    """
+    return Path(__file__).resolve().parents[3]
 
 
 def _allowed_bases() -> list[Path]:

--- a/tests/unit/storage/intelligence_graph/test_path_utils.py
+++ b/tests/unit/storage/intelligence_graph/test_path_utils.py
@@ -1,0 +1,198 @@
+"""Tests for ``src.storage.intelligence_graph.path_utils``.
+
+Regression coverage for the off-by-one bug where ``_project_root()``
+walked one level too many parents (a residue from PR #105's
+architectural relocation of this module from ``src/services/intelligence/storage/``
+to ``src/storage/intelligence_graph/``). The original test suite passed
+because it exclusively used ``tempfile.gettempdir()`` paths (also an
+approved base), masking the production-only failure where ``data/`` and
+``cache/`` were resolved against the wrong directory.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from src.storage.intelligence_graph.path_utils import (
+    _allowed_bases,
+    _project_root,
+    sanitize_storage_path,
+)
+from src.utils.security import SecurityError
+
+# ---------------------------------------------------------------------------
+# Project root + allowed bases
+# ---------------------------------------------------------------------------
+
+
+def test_project_root_resolves_to_repo() -> None:
+    """``_project_root`` must point at the actual repo, not its parent.
+
+    Repo identity check: the directory must contain BOTH ``pyproject.toml``
+    and ``verify.sh`` — markers that uniquely identify this repository.
+    Catches off-by-one ancestor-walk bugs (which would land us in a parent
+    directory that lacks both files).
+    """
+    root = _project_root()
+    assert root.is_dir(), f"_project_root returned a non-directory: {root}"
+    assert (root / "pyproject.toml").is_file(), (
+        f"_project_root returned {root!r}, which lacks pyproject.toml — "
+        f"likely an off-by-one ancestor walk in path_utils._project_root()"
+    )
+    assert (
+        root / "verify.sh"
+    ).is_file(), f"_project_root returned {root!r}, which lacks verify.sh"
+
+
+def test_project_root_contains_src_storage_intelligence_graph() -> None:
+    """``_project_root`` must locate the dir that contains this very module."""
+    root = _project_root()
+    expected_module = root / "src" / "storage" / "intelligence_graph" / "path_utils.py"
+    assert expected_module.is_file(), (
+        f"_project_root returned {root!r}, which does not contain the "
+        f"path_utils.py module the function is defined in. Bug in "
+        f"the parents[N] index."
+    )
+
+
+def test_allowed_bases_contains_data_and_cache_under_project_root() -> None:
+    """``_allowed_bases`` must produce ``data/`` and ``cache/`` rooted at the
+    actual project root (where they get created by setup.sh) — not at any
+    sibling directory.
+    """
+    root = _project_root()
+    bases = _allowed_bases()
+    assert (root / "data").resolve() in [b.resolve() for b in bases]
+    assert (root / "cache").resolve() in [b.resolve() for b in bases]
+
+
+def test_allowed_bases_includes_system_temp_dir() -> None:
+    """Tests rely on temp paths being approved; pin that contract."""
+    bases = [b.resolve() for b in _allowed_bases()]
+    assert Path(tempfile.gettempdir()).resolve() in bases
+
+
+# ---------------------------------------------------------------------------
+# sanitize_storage_path — regression for the production failure mode
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_storage_path_accepts_relative_data_path() -> None:
+    """``data/<file>.db`` (relative) MUST resolve under the project's
+    ``data/`` dir and pass sanitization.
+
+    This is the exact code path the production CLI uses
+    (``arisp monitor list`` → ``SubscriptionManager(_resolve_db_path())``
+    → ``sanitize_storage_path(Path("data/monitoring.db"))``). Before the
+    ``_project_root`` fix, this raised ``SecurityError: Database path is
+    outside approved storage roots``, fully blocking Phase 9.1 monitoring
+    in production.
+    """
+    # Run from the project root so ``Path.cwd() / "data/test.db"`` resolves
+    # under <repo>/data/ — the production invariant the launcher relies on.
+    import os
+
+    original_cwd = os.getcwd()
+    try:
+        os.chdir(_project_root())
+        result = sanitize_storage_path("data/regression_test.db")
+        assert result.is_absolute()
+        # Must be inside the repo's data/ dir
+        assert _project_root() / "data" in result.parents
+    finally:
+        os.chdir(original_cwd)
+
+
+def test_sanitize_storage_path_accepts_relative_cache_path() -> None:
+    import os
+
+    original_cwd = os.getcwd()
+    try:
+        os.chdir(_project_root())
+        result = sanitize_storage_path("cache/regression_test.db")
+        assert result.is_absolute()
+        assert _project_root() / "cache" in result.parents
+    finally:
+        os.chdir(original_cwd)
+
+
+def test_sanitize_storage_path_accepts_temp_path() -> None:
+    """Temp paths (used by tests) remain approved post-fix."""
+    temp_db = Path(tempfile.gettempdir()) / "regression_test.db"
+    result = sanitize_storage_path(temp_db)
+    assert result == temp_db.resolve()
+
+
+def test_sanitize_storage_path_rejects_path_outside_approved_roots(
+    tmp_path: Path,
+) -> None:
+    """A path under a non-approved directory (here: pytest's ``tmp_path``,
+    which is *not* one of the approved bases — ``tempfile.gettempdir()`` is
+    approved but ``tmp_path`` is a child of it on some systems and a sibling
+    on others) must be rejected.
+
+    Use a guaranteed-outside path instead: the user's home directory.
+    """
+    outside_path = Path.home() / ".never_an_approved_storage_root.db"
+    with pytest.raises(SecurityError, match="outside approved storage roots"):
+        sanitize_storage_path(outside_path)
+
+
+def test_sanitize_storage_path_rejects_traversal_attempt() -> None:
+    """``..`` segments must be rejected to prevent traversal."""
+    with pytest.raises(SecurityError):
+        sanitize_storage_path("data/../../../etc/passwd")
+
+
+def test_sanitize_storage_path_rejects_absolute_etc_path() -> None:
+    """Absolute paths outside approved bases must be rejected."""
+    with pytest.raises(SecurityError, match="outside approved storage roots"):
+        sanitize_storage_path("/etc/passwd")
+
+
+# ---------------------------------------------------------------------------
+# Belt + braces: compile-time safety net for the parents[N] index
+# ---------------------------------------------------------------------------
+
+
+def test_path_utils_module_is_three_levels_under_src() -> None:
+    """If anyone moves ``path_utils.py`` again, this test reminds them to
+    re-verify the ``parents[N]`` index in ``_project_root()``.
+
+    The current location is ``src/storage/intelligence_graph/path_utils.py``
+    — exactly 3 levels deep from the repo root. ``_project_root`` uses
+    ``parents[3]`` to compensate. Any move to a different depth requires
+    updating that index.
+    """
+    from src.storage.intelligence_graph import path_utils
+
+    module_file = Path(path_utils.__file__).resolve()
+    # parents[3] = repo root, so module_file's relative path from repo root
+    # should have exactly 4 parts: src / storage / intelligence_graph / path_utils.py
+    repo_root = _project_root()
+    relative = module_file.relative_to(repo_root)
+    assert len(relative.parts) == 4, (
+        f"path_utils.py is at {relative} ({len(relative.parts)} parts) — "
+        f"if this changed, _project_root()'s parents[3] index needs to "
+        f"change to match the new depth."
+    )
+    assert relative.parts == (
+        "src",
+        "storage",
+        "intelligence_graph",
+        "path_utils.py",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Defensive: ensure module is importable from a clean sys.path
+# ---------------------------------------------------------------------------
+
+
+def test_module_importable() -> None:
+    """Smoke test that the module loads cleanly (catches syntax regressions)."""
+    assert "src.storage.intelligence_graph.path_utils" in sys.modules

--- a/tests/unit/storage/intelligence_graph/test_path_utils.py
+++ b/tests/unit/storage/intelligence_graph/test_path_utils.py
@@ -11,12 +11,14 @@ approved base), masking the production-only failure where ``data/`` and
 
 from __future__ import annotations
 
-import sys
 import tempfile
 from pathlib import Path
 
 import pytest
+import structlog
+import structlog.testing
 
+from src.storage.intelligence_graph import path_utils as path_utils_module
 from src.storage.intelligence_graph.path_utils import (
     _allowed_bases,
     _project_root,
@@ -81,7 +83,9 @@ def test_allowed_bases_includes_system_temp_dir() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_sanitize_storage_path_accepts_relative_data_path() -> None:
+def test_sanitize_storage_path_accepts_relative_data_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """``data/<file>.db`` (relative) MUST resolve under the project's
     ``data/`` dir and pass sanitization.
 
@@ -92,32 +96,23 @@ def test_sanitize_storage_path_accepts_relative_data_path() -> None:
     outside approved storage roots``, fully blocking Phase 9.1 monitoring
     in production.
     """
-    # Run from the project root so ``Path.cwd() / "data/test.db"`` resolves
-    # under <repo>/data/ — the production invariant the launcher relies on.
-    import os
-
-    original_cwd = os.getcwd()
-    try:
-        os.chdir(_project_root())
-        result = sanitize_storage_path("data/regression_test.db")
-        assert result.is_absolute()
-        # Must be inside the repo's data/ dir
-        assert _project_root() / "data" in result.parents
-    finally:
-        os.chdir(original_cwd)
+    # ``monkeypatch.chdir`` auto-restores cwd even on hard failures and is
+    # safe under pytest-xdist (each worker has its own process).
+    monkeypatch.chdir(_project_root())
+    result = sanitize_storage_path("data/regression_test.db")
+    assert result.is_absolute()
+    # Must be inside the repo's data/ dir
+    assert _project_root() / "data" in result.parents
 
 
-def test_sanitize_storage_path_accepts_relative_cache_path() -> None:
-    import os
-
-    original_cwd = os.getcwd()
-    try:
-        os.chdir(_project_root())
-        result = sanitize_storage_path("cache/regression_test.db")
-        assert result.is_absolute()
-        assert _project_root() / "cache" in result.parents
-    finally:
-        os.chdir(original_cwd)
+def test_sanitize_storage_path_accepts_relative_cache_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same regression guard as the data/ path test, for ``cache/``."""
+    monkeypatch.chdir(_project_root())
+    result = sanitize_storage_path("cache/regression_test.db")
+    assert result.is_absolute()
+    assert _project_root() / "cache" in result.parents
 
 
 def test_sanitize_storage_path_accepts_temp_path() -> None:
@@ -127,24 +122,35 @@ def test_sanitize_storage_path_accepts_temp_path() -> None:
     assert result == temp_db.resolve()
 
 
-def test_sanitize_storage_path_rejects_path_outside_approved_roots(
-    tmp_path: Path,
-) -> None:
-    """A path under a non-approved directory (here: pytest's ``tmp_path``,
-    which is *not* one of the approved bases — ``tempfile.gettempdir()`` is
-    approved but ``tmp_path`` is a child of it on some systems and a sibling
-    on others) must be rejected.
+def test_sanitize_storage_path_rejects_path_outside_approved_roots() -> None:
+    """A path that is provably outside every approved base must be rejected.
 
-    Use a guaranteed-outside path instead: the user's home directory.
+    Use the *parent* of the project root — invariant across all hosts (a
+    container with ``$HOME=/tmp`` would otherwise make ``Path.home()``
+    resolve under tempdir and accidentally pass sanitization).
     """
-    outside_path = Path.home() / ".never_an_approved_storage_root.db"
+    outside_path = (
+        _project_root().parent / "definitely_not_approved_storage_root" / "x.db"
+    )
     with pytest.raises(SecurityError, match="outside approved storage roots"):
         sanitize_storage_path(outside_path)
 
 
-def test_sanitize_storage_path_rejects_traversal_attempt() -> None:
-    """``..`` segments must be rejected to prevent traversal."""
-    with pytest.raises(SecurityError):
+def test_sanitize_storage_path_rejects_relative_traversal_to_outside_root(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``..``-laden relative path that resolves outside any approved base
+    must be rejected via the *outside-roots* branch.
+
+    NOTE: ``sanitize_storage_path`` resolves the candidate before checking,
+    so the literal ``..`` segments are collapsed by ``Path.resolve()``. The
+    rejection therefore fires from the outer "outside approved roots" loop,
+    NOT from ``PathSanitizer.safe_path``'s internal traversal check (which
+    is unreachable via this entry point — the resolved path never carries
+    ``..`` segments).
+    """
+    monkeypatch.chdir(_project_root())
+    with pytest.raises(SecurityError, match="outside approved storage roots"):
         sanitize_storage_path("data/../../../etc/passwd")
 
 
@@ -154,27 +160,64 @@ def test_sanitize_storage_path_rejects_absolute_etc_path() -> None:
         sanitize_storage_path("/etc/passwd")
 
 
+def test_sanitize_storage_path_emits_structured_log_on_rejection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The rejection path emits ``intelligence_storage_path_rejected`` —
+    the structured event ops grep for when investigating CLI failures.
+    Verifies the observable contract of the security boundary.
+
+    ``cache_logger_on_first_use=True`` (in ``src/utils/logging.py``)
+    freezes the bound logger at first call, so we rebind the module-level
+    ``logger`` to a fresh proxy before entering ``capture_logs()`` — same
+    pattern as ``tests/unit/test_scheduling/test_monitoring_check_job.py``.
+    """
+    monkeypatch.setattr(path_utils_module, "logger", structlog.get_logger())
+
+    with structlog.testing.capture_logs() as logs:
+        with pytest.raises(SecurityError):
+            sanitize_storage_path("/etc/passwd")
+
+    rejection_events = [
+        e for e in logs if e.get("event") == "intelligence_storage_path_rejected"
+    ]
+    assert len(rejection_events) == 1
+    # Bound fields the production code emits (db_path + resolved) — pin
+    # them so a future refactor that drops one trips the test.
+    event = rejection_events[0]
+    assert "db_path" in event
+    assert "resolved" in event
+
+
 # ---------------------------------------------------------------------------
 # Belt + braces: compile-time safety net for the parents[N] index
 # ---------------------------------------------------------------------------
 
 
-def test_path_utils_module_is_three_levels_under_src() -> None:
-    """If anyone moves ``path_utils.py`` again, this test reminds them to
-    re-verify the ``parents[N]`` index in ``_project_root()``.
+def test_project_root_index_matches_module_depth() -> None:
+    """If anyone moves ``path_utils.py`` to a different depth, this test
+    fires *before* ``_project_root()`` silently returns the wrong directory.
 
     The current location is ``src/storage/intelligence_graph/path_utils.py``
-    — exactly 3 levels deep from the repo root. ``_project_root`` uses
-    ``parents[3]`` to compensate. Any move to a different depth requires
-    updating that index.
-    """
-    from src.storage.intelligence_graph import path_utils
+    — exactly 4 path parts (``src/storage/intelligence_graph/path_utils.py``)
+    relative to the repo root. ``_project_root()`` uses ``parents[3]`` to
+    compensate. Any move to a different depth requires updating that index.
 
-    module_file = Path(path_utils.__file__).resolve()
-    # parents[3] = repo root, so module_file's relative path from repo root
-    # should have exactly 4 parts: src / storage / intelligence_graph / path_utils.py
+    Wraps ``relative_to`` in an explicit failure path: if ``_project_root()``
+    is itself wrong, ``relative_to`` raises ``ValueError``, which we convert
+    to ``pytest.fail`` with a self-diagnostic message — otherwise the user
+    sees an opaque ``"... is not in the subpath of ..."`` traceback.
+    """
+    module_file = Path(path_utils_module.__file__).resolve()
     repo_root = _project_root()
-    relative = module_file.relative_to(repo_root)
+    try:
+        relative = module_file.relative_to(repo_root)
+    except ValueError:
+        pytest.fail(
+            f"_project_root() returned {repo_root!r}, which is not an "
+            f"ancestor of {module_file!r}. Likely an off-by-one parents[N] "
+            f"index in path_utils._project_root()."
+        )
     assert len(relative.parts) == 4, (
         f"path_utils.py is at {relative} ({len(relative.parts)} parts) — "
         f"if this changed, _project_root()'s parents[3] index needs to "
@@ -186,13 +229,3 @@ def test_path_utils_module_is_three_levels_under_src() -> None:
         "intelligence_graph",
         "path_utils.py",
     )
-
-
-# ---------------------------------------------------------------------------
-# Defensive: ensure module is importable from a clean sys.path
-# ---------------------------------------------------------------------------
-
-
-def test_module_importable() -> None:
-    """Smoke test that the module loads cleanly (catches syntax regressions)."""
-    assert "src.storage.intelligence_graph.path_utils" in sys.modules


### PR DESCRIPTION
## TL;DR

`_project_root()` in `src/storage/intelligence_graph/path_utils.py` was walking one parent too many (`parents[4]` → returned `/Users/<u>/code/`, not the repo). This silently broke **every** Phase 9.1 monitoring CLI invocation in production with `SecurityError: Database path is outside approved storage roots`. Fix is 1 character (`parents[3]`) + 12 regression tests.

## Production impact

Every `arisp monitor add/list/check/digest` invocation failed at `SubscriptionManager` construction. The new daily monitoring `launchd` job (`com.arisp.monitor-check.plist`) would have produced zero output silently for every run.

## Root cause

PR #105 relocated this module from `src/services/intelligence/storage/` (5 levels deep) to `src/storage/intelligence_graph/` (3 levels deep). The depth changed; the `parents[N]` index in `_project_root()` did not. The function returned the parent of the repo root, so `_allowed_bases` resolved `data/` and `cache/` against the wrong directory and `sanitize_storage_path` rejected every relative path the production CLI passes.

## Why CI was 99.06% green while production was 0% functional

The existing test suite uses `tempfile.gettempdir()` paths exclusively for storage roots. `tempfile.gettempdir()` is **also** in `_allowed_bases`, so tests never exercised the relative `data/` path code path that production uses. The whole production-only failure mode was invisible to CI.

This is a textbook example of CLAUDE.md's new "Test Authoring Conventions" item: **tests built on a path the production code doesn't actually take produce theatric coverage.** This PR's regression tests close that gap.

## Discovery context

Surfaced while wiring the new `com.arisp.monitor-check.plist` launchd job for the Phase 9.1 daily monitoring sweep. Following the "Verification Before Action" principle (PR #136), I traced the `SecurityError` up its call chain rather than working around it in the launcher — which would have left the production bug intact.

## Regression guards (12 new tests)

`tests/unit/storage/intelligence_graph/test_path_utils.py` pins:
- `_project_root()` resolves to a directory containing **both** `pyproject.toml` and `verify.sh` (repo identity markers — would have caught the bug)
- `_project_root()` resolves to the directory that contains the `path_utils.py` module itself (self-locating sanity check)
- `_allowed_bases` includes `<repo>/data` and `<repo>/cache` (the actual production roots)
- `sanitize_storage_path("data/X.db")` accepts the production invariant the launcher relies on (the exact failure mode this PR fixes)
- The module's depth (`src/storage/intelligence_graph/path_utils.py` = 4 path parts from repo root) matches the `parents[3]` index — so any future move re-trips this test
- Boundary cases: `tempfile` paths still accepted; `..` traversal rejected; absolute paths outside approved roots rejected

## Verification

- `pytest tests/unit/storage/intelligence_graph/test_path_utils.py -v` — 12/12 PASS
- `pytest tests/unit/storage/intelligence_graph/ tests/unit/services/intelligence/monitoring/ -q` — all green (no regressions)
- Pre-push `verify.sh` ✅ on push
- Manual smoke test: `arisp monitor list` now succeeds end-to-end (migrations apply, db path resolves)

## Test plan

- [ ] CI green (`test (3.14)`, `Lint Markdown`, `Check Spelling`, `Documentation Drift Check`, `Validate Phase Specs`)
- [ ] After merge: `arisp monitor list` works against `data/monitoring.db` from project root
- [ ] After merge: `arisp monitor add --name "..." --query "..."` succeeds
- [ ] Daily `com.arisp.monitor-check` launchd run at 02:30 produces output without SecurityError