### PR TITLE
feat(phase-9.1): Tier 1 — multi-provider monitor + LLM query expansion (closes #139)

### DIFF
--- a/src/cli/monitor.py
+++ b/src/cli/monitor.py
@@ -149,7 +149,9 @@ def _build_runner(
             llm_cost_limits = CostLimits()
             llm_svc = LLMService(config=llm_config, cost_limits=llm_cost_limits)
         except Exception as exc:
-            logger.warning(
+            # H-M7: env var was set but init failed — this is an operator
+            # misconfiguration, not a soft degradation; raise to error level.
+            logger.error(
                 "monitor_cli_llm_init_failed",
                 error_type=type(exc).__name__,
                 reason="scoring_and_expansion_will_be_skipped",
@@ -383,11 +385,9 @@ def digest_command(
             raise typer.Exit(code=1)
         audit_run = latest_runs[0]
     else:
-        # ``run_id`` is non-None at this point (mutually-exclusive guard
-        # above). Use a proper guard rather than assert (H-C4).
-        if run_id is None:
-            raise typer.BadParameter("internal: run_id missing despite guard")
-        audit_run = repo.get_run(run_id)
+        # ``run_id`` is non-None at this point — guaranteed by the
+        # mutually-exclusive guard above (H-M8: removed unreachable inner guard).
+        audit_run = repo.get_run(run_id)  # type: ignore[arg-type]
         if audit_run is None:
             display_error(f"Run not found: {run_id}")
             raise typer.Exit(code=1)

--- a/src/cli/monitor.py
+++ b/src/cli/monitor.py
@@ -130,7 +130,7 @@ def _build_runner(
             When ``None``, a default ``ArxivProvider()`` is built.
     """
     from src.models.llm import CostLimits, LLMConfig
-    from src.services.intelligence.monitoring.models import PaperSource
+    from src.services.intelligence.monitoring._tier1_factory import build_tier1_extras
     from src.services.llm.service import LLMService
     from src.services.providers.arxiv import ArxivProvider
     from src.services.registry.service import RegistryService
@@ -142,7 +142,7 @@ def _build_runner(
     # (never hardcoded). If the key is absent, run without scoring or
     # expansion (graceful degradation -- legacy single-arxiv behavior).
     llm_svc = None
-    llm_api_key = os.environ.get("LLM_API_KEY") or os.environ.get("GEMINI_API_KEY")
+    llm_api_key = os.environ.get("LLM_API_KEY")
     if llm_api_key and llm_api_key.strip():
         try:
             llm_config = LLMConfig(api_key=llm_api_key)
@@ -157,39 +157,8 @@ def _build_runner(
 
     # Tier 1: build extra providers + query expander when LLM is wired.
     # Constructed lazily so the legacy-fallback path doesn't pay the
-    # provider-construction cost.
-    extra_providers = None
-    query_expander = None
-    if llm_svc is not None:
-        try:
-            from src.services.providers.huggingface import HuggingFaceProvider
-            from src.services.providers.openalex import OpenAlexProvider
-            from src.services.providers.semantic_scholar import (
-                SemanticScholarProvider,
-            )
-            from src.utils.query_expander import QueryExpander
-
-            # Semantic Scholar requires an API key; OpenAlex + HuggingFace
-            # are anonymous-public. If S2 key is missing, skip S2 only --
-            # the other providers still broaden discovery.
-            extra_providers = {
-                PaperSource.OPENALEX: OpenAlexProvider(),
-                PaperSource.HUGGINGFACE: HuggingFaceProvider(),
-            }
-            s2_key = os.environ.get("SEMANTIC_SCHOLAR_API_KEY")
-            if s2_key and s2_key.strip():
-                extra_providers[PaperSource.SEMANTIC_SCHOLAR] = SemanticScholarProvider(
-                    api_key=s2_key
-                )
-            query_expander = QueryExpander(llm_service=llm_svc)
-        except Exception as exc:
-            logger.warning(
-                "monitor_cli_tier1_init_failed",
-                error=str(exc),
-                reason="falling_back_to_legacy_single_arxiv",
-            )
-            extra_providers = None
-            query_expander = None
+    # provider-construction cost. H-C4: delegated to build_tier1_extras.
+    extra_providers, query_expander = build_tier1_extras(llm_svc)
 
     return MonitoringRunner.from_paths(
         db_path=_resolve_db_path(),

--- a/src/cli/monitor.py
+++ b/src/cli/monitor.py
@@ -129,8 +129,6 @@ def _build_runner(
         arxiv: Optional ``ArxivProvider`` seam for testing.
             When ``None``, a default ``ArxivProvider()`` is built.
     """
-    import os
-
     from src.models.llm import CostLimits, LLMConfig
     from src.services.intelligence.monitoring.models import PaperSource
     from src.services.llm.service import LLMService
@@ -145,7 +143,7 @@ def _build_runner(
     # expansion (graceful degradation -- legacy single-arxiv behavior).
     llm_svc = None
     llm_api_key = os.environ.get("LLM_API_KEY") or os.environ.get("GEMINI_API_KEY")
-    if llm_api_key:
+    if llm_api_key and llm_api_key.strip():
         try:
             llm_config = LLMConfig(api_key=llm_api_key)
             llm_cost_limits = CostLimits()
@@ -153,7 +151,7 @@ def _build_runner(
         except Exception as exc:
             logger.warning(
                 "monitor_cli_llm_init_failed",
-                error=str(exc),
+                error_type=type(exc).__name__,
                 reason="scoring_and_expansion_will_be_skipped",
             )
 
@@ -179,7 +177,7 @@ def _build_runner(
                 PaperSource.HUGGINGFACE: HuggingFaceProvider(),
             }
             s2_key = os.environ.get("SEMANTIC_SCHOLAR_API_KEY")
-            if s2_key:
+            if s2_key and s2_key.strip():
                 extra_providers[PaperSource.SEMANTIC_SCHOLAR] = SemanticScholarProvider(
                     api_key=s2_key
                 )

--- a/src/cli/monitor.py
+++ b/src/cli/monitor.py
@@ -114,6 +114,15 @@ def _build_runner(
     cost (or the side-effect risk) of constructing the registry +
     arxiv provider when they don't need them.
 
+    Tier 1 (Issue #139): when an LLM key is available we wire the
+    multi-provider monitor with arXiv + Semantic Scholar + OpenAlex +
+    HuggingFace, plus a :class:`QueryExpander` that turns each
+    subscription's literal query into N variants via Gemini Flash. This
+    dramatically broadens discovery without requiring spec changes —
+    the monitor still returns ``ArxivMonitorResult`` so the runner is
+    duck-type compatible. When the LLM key is missing, falls back to
+    legacy single-arXiv behavior (no expansion, single provider).
+
     Args:
         registry: Optional ``RegistryService`` seam for testing.
             When ``None``, a default ``RegistryService()`` is built.
@@ -123,6 +132,7 @@ def _build_runner(
     import os
 
     from src.models.llm import CostLimits, LLMConfig
+    from src.services.intelligence.monitoring.models import PaperSource
     from src.services.llm.service import LLMService
     from src.services.providers.arxiv import ArxivProvider
     from src.services.registry.service import RegistryService
@@ -130,8 +140,9 @@ def _build_runner(
     resolved_registry = registry if registry is not None else RegistryService()
     resolved_arxiv = arxiv if arxiv is not None else ArxivProvider()
 
-    # Build LLMService for relevance scoring from env (never hardcoded).
-    # If the key is absent, run without scoring (graceful degradation).
+    # Build LLMService for relevance scoring + query expansion from env
+    # (never hardcoded). If the key is absent, run without scoring or
+    # expansion (graceful degradation -- legacy single-arxiv behavior).
     llm_svc = None
     llm_api_key = os.environ.get("LLM_API_KEY") or os.environ.get("GEMINI_API_KEY")
     if llm_api_key:
@@ -143,13 +154,52 @@ def _build_runner(
             logger.warning(
                 "monitor_cli_llm_init_failed",
                 error=str(exc),
-                reason="scoring_will_be_skipped",
+                reason="scoring_and_expansion_will_be_skipped",
             )
+
+    # Tier 1: build extra providers + query expander when LLM is wired.
+    # Constructed lazily so the legacy-fallback path doesn't pay the
+    # provider-construction cost.
+    extra_providers = None
+    query_expander = None
+    if llm_svc is not None:
+        try:
+            from src.services.providers.huggingface import HuggingFaceProvider
+            from src.services.providers.openalex import OpenAlexProvider
+            from src.services.providers.semantic_scholar import (
+                SemanticScholarProvider,
+            )
+            from src.utils.query_expander import QueryExpander
+
+            # Semantic Scholar requires an API key; OpenAlex + HuggingFace
+            # are anonymous-public. If S2 key is missing, skip S2 only --
+            # the other providers still broaden discovery.
+            extra_providers = {
+                PaperSource.OPENALEX: OpenAlexProvider(),
+                PaperSource.HUGGINGFACE: HuggingFaceProvider(),
+            }
+            s2_key = os.environ.get("SEMANTIC_SCHOLAR_API_KEY")
+            if s2_key:
+                extra_providers[PaperSource.SEMANTIC_SCHOLAR] = SemanticScholarProvider(
+                    api_key=s2_key
+                )
+            query_expander = QueryExpander(llm_service=llm_svc)
+        except Exception as exc:
+            logger.warning(
+                "monitor_cli_tier1_init_failed",
+                error=str(exc),
+                reason="falling_back_to_legacy_single_arxiv",
+            )
+            extra_providers = None
+            query_expander = None
+
     return MonitoringRunner.from_paths(
         db_path=_resolve_db_path(),
         registry=resolved_registry,  # type: ignore[arg-type]
         arxiv_provider=resolved_arxiv,  # type: ignore[arg-type]
         llm_service=llm_svc,
+        extra_providers=extra_providers,  # type: ignore[arg-type]
+        query_expander=query_expander,
     )
 
 

--- a/src/scheduling/jobs.py
+++ b/src/scheduling/jobs.py
@@ -782,7 +782,7 @@ class MonitoringCheckJob(BaseJob):
             llm_api_key = os.environ.get("LLM_API_KEY") or os.environ.get(
                 "GEMINI_API_KEY"
             )
-            if llm_api_key:
+            if llm_api_key and llm_api_key.strip():
                 try:
                     llm_config = LLMConfig(api_key=llm_api_key)
                     llm_cost_limits = CostLimits()
@@ -790,7 +790,7 @@ class MonitoringCheckJob(BaseJob):
                 except Exception as exc:
                     logger.warning(
                         "monitoring_check_job_llm_init_failed",
-                        error=str(exc),
+                        error_type=type(exc).__name__,
                         reason="scoring_will_be_skipped",
                     )
             else:
@@ -825,7 +825,7 @@ class MonitoringCheckJob(BaseJob):
                         PaperSource.HUGGINGFACE: HuggingFaceProvider(),
                     }
                     s2_key = os.environ.get("SEMANTIC_SCHOLAR_API_KEY")
-                    if s2_key:
+                    if s2_key and s2_key.strip():
                         extra_providers[PaperSource.SEMANTIC_SCHOLAR] = (
                             SemanticScholarProvider(api_key=s2_key)
                         )

--- a/src/scheduling/jobs.py
+++ b/src/scheduling/jobs.py
@@ -798,11 +798,54 @@ class MonitoringCheckJob(BaseJob):
                     "monitoring_check_job_no_llm_api_key",
                     reason="scoring_will_be_skipped",
                 )
+            # Tier 1 (Issue #139): wire multi-provider monitor + query
+            # expander when LLM is available. Falls back to legacy
+            # single-arxiv when LLM key is missing (graceful).
+            extra_providers = None
+            query_expander = None
+            if llm_svc is not None:
+                try:
+                    from src.services.intelligence.monitoring.models import (
+                        PaperSource,
+                    )
+                    from src.services.providers.huggingface import (
+                        HuggingFaceProvider,
+                    )
+                    from src.services.providers.openalex import OpenAlexProvider
+                    from src.services.providers.semantic_scholar import (
+                        SemanticScholarProvider,
+                    )
+                    from src.utils.query_expander import QueryExpander
+
+                    # Semantic Scholar requires an API key; OpenAlex +
+                    # HuggingFace are anonymous-public. Skip S2 if its
+                    # key is missing -- the others still broaden search.
+                    extra_providers = {
+                        PaperSource.OPENALEX: OpenAlexProvider(),
+                        PaperSource.HUGGINGFACE: HuggingFaceProvider(),
+                    }
+                    s2_key = os.environ.get("SEMANTIC_SCHOLAR_API_KEY")
+                    if s2_key:
+                        extra_providers[PaperSource.SEMANTIC_SCHOLAR] = (
+                            SemanticScholarProvider(api_key=s2_key)
+                        )
+                    query_expander = QueryExpander(llm_service=llm_svc)
+                except Exception as exc:
+                    logger.warning(
+                        "monitoring_check_job_tier1_init_failed",
+                        error=str(exc),
+                        reason="falling_back_to_legacy_single_arxiv",
+                    )
+                    extra_providers = None
+                    query_expander = None
+
             self._runner = MonitoringRunner.from_paths(
                 db_path=self._db_path,
                 registry=registry or RegistryService(),
                 arxiv_provider=arxiv_provider or ArxivProvider(),
                 llm_service=llm_svc,
+                extra_providers=extra_providers,
+                query_expander=query_expander,
             )
         self._digest_generator = digest_generator or DigestGenerator(
             output_root=digest_output_root,

--- a/src/scheduling/jobs.py
+++ b/src/scheduling/jobs.py
@@ -789,7 +789,9 @@ class MonitoringCheckJob(BaseJob):
                     llm_cost_limits = CostLimits()
                     llm_svc = LLMService(config=llm_config, cost_limits=llm_cost_limits)
                 except Exception as exc:
-                    logger.warning(
+                    # H-M7: env var was set but init failed — operator
+                    # misconfiguration, raise to error severity.
+                    logger.error(
                         "monitoring_check_job_llm_init_failed",
                         error_type=type(exc).__name__,
                         reason="scoring_will_be_skipped",

--- a/src/scheduling/jobs.py
+++ b/src/scheduling/jobs.py
@@ -777,11 +777,12 @@ class MonitoringCheckJob(BaseJob):
             import os
 
             from src.models.llm import CostLimits, LLMConfig
+            from src.services.intelligence.monitoring._tier1_factory import (
+                build_tier1_extras,
+            )
 
             llm_svc = None
-            llm_api_key = os.environ.get("LLM_API_KEY") or os.environ.get(
-                "GEMINI_API_KEY"
-            )
+            llm_api_key = os.environ.get("LLM_API_KEY")
             if llm_api_key and llm_api_key.strip():
                 try:
                     llm_config = LLMConfig(api_key=llm_api_key)
@@ -799,45 +800,9 @@ class MonitoringCheckJob(BaseJob):
                     reason="scoring_will_be_skipped",
                 )
             # Tier 1 (Issue #139): wire multi-provider monitor + query
-            # expander when LLM is available. Falls back to legacy
-            # single-arxiv when LLM key is missing (graceful).
-            extra_providers = None
-            query_expander = None
-            if llm_svc is not None:
-                try:
-                    from src.services.intelligence.monitoring.models import (
-                        PaperSource,
-                    )
-                    from src.services.providers.huggingface import (
-                        HuggingFaceProvider,
-                    )
-                    from src.services.providers.openalex import OpenAlexProvider
-                    from src.services.providers.semantic_scholar import (
-                        SemanticScholarProvider,
-                    )
-                    from src.utils.query_expander import QueryExpander
-
-                    # Semantic Scholar requires an API key; OpenAlex +
-                    # HuggingFace are anonymous-public. Skip S2 if its
-                    # key is missing -- the others still broaden search.
-                    extra_providers = {
-                        PaperSource.OPENALEX: OpenAlexProvider(),
-                        PaperSource.HUGGINGFACE: HuggingFaceProvider(),
-                    }
-                    s2_key = os.environ.get("SEMANTIC_SCHOLAR_API_KEY")
-                    if s2_key and s2_key.strip():
-                        extra_providers[PaperSource.SEMANTIC_SCHOLAR] = (
-                            SemanticScholarProvider(api_key=s2_key)
-                        )
-                    query_expander = QueryExpander(llm_service=llm_svc)
-                except Exception as exc:
-                    logger.warning(
-                        "monitoring_check_job_tier1_init_failed",
-                        error=str(exc),
-                        reason="falling_back_to_legacy_single_arxiv",
-                    )
-                    extra_providers = None
-                    query_expander = None
+            # expander when LLM is available. H-C4: delegated to
+            # build_tier1_extras so the wiring logic is not duplicated.
+            extra_providers, query_expander = build_tier1_extras(llm_svc)
 
             self._runner = MonitoringRunner.from_paths(
                 db_path=self._db_path,

--- a/src/services/intelligence/monitoring/__init__.py
+++ b/src/services/intelligence/monitoring/__init__.py
@@ -31,6 +31,10 @@ from src.services.intelligence.monitoring.arxiv_monitor import (
     ArxivMonitor,
     ArxivMonitorResult,
 )
+from src.services.intelligence.monitoring.multi_provider_monitor import (
+    MultiProviderMonitor,
+    MultiProviderMonitorConfig,
+)
 from src.services.intelligence.monitoring.models import (
     MonitoringPaperAudit,
     MonitoringPaperRecord,
@@ -70,6 +74,8 @@ __all__ = [
     "MonitoringRunRepository",
     "MonitoringRunStatus",
     "MonitoringRunner",
+    "MultiProviderMonitor",
+    "MultiProviderMonitorConfig",
     "RelevanceScorer",
     "RelevanceScoreResult",
     "ResearchSubscription",

--- a/src/services/intelligence/monitoring/_paper_records.py
+++ b/src/services/intelligence/monitoring/_paper_records.py
@@ -1,0 +1,78 @@
+"""Shared helpers for constructing monitoring paper records and topics.
+
+Extracted from :class:`ArxivMonitor` and :class:`MultiProviderMonitor` so
+neither monitor duplicates the same DTO-building and topic-building logic.
+
+H-C1: ``to_paper_record`` consolidates ``ArxivMonitor._to_record`` and the
+inline import of that static method in ``MultiProviderMonitor._resolve_and_register``.
+
+H-C3: ``build_topic`` consolidates ``ArxivMonitor._build_topic`` and
+``MultiProviderMonitor._build_topic_for_query`` into one canonical impl.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from src.models.config.core import ResearchTopic, TimeframeRecent, TimeframeType
+from src.models.paper import PaperMetadata
+from src.services.intelligence.monitoring.models import (
+    MAX_POLL_HOURS,
+    MonitoringPaperRecord,
+)
+
+
+def to_paper_record(paper: PaperMetadata, is_new: bool) -> MonitoringPaperRecord:
+    """Convert a :class:`PaperMetadata` into a :class:`MonitoringPaperRecord`.
+
+    ``PaperMetadata.url`` and ``open_access_pdf`` are Pydantic ``HttpUrl``
+    objects; ``MonitoringPaperRecord`` stores plain strings. ``str()``
+    serialisation is correct here — Pydantic's ``HttpUrl`` coerces cleanly
+    to the canonical URL string.
+
+    Args:
+        paper: Source paper metadata from a discovery provider.
+        is_new: ``True`` if the paper was not yet known to the registry
+            before this cycle.
+
+    Returns:
+        A ``MonitoringPaperRecord`` ready to be appended to
+        ``MonitoringRun.papers``.
+    """
+    published: Optional[datetime] = paper.publication_date
+    return MonitoringPaperRecord(
+        paper_id=paper.paper_id,
+        title=paper.title,
+        url=str(paper.url) if paper.url else None,
+        pdf_url=str(paper.open_access_pdf) if paper.open_access_pdf else None,
+        published_at=published,
+        is_new=is_new,
+    )
+
+
+def build_topic(query: str, poll_interval_hours: int) -> ResearchTopic:
+    """Construct a :class:`ResearchTopic` for a given query and interval.
+
+    The ``TimeframeRecent`` value pattern is ``\\d+[hd]``, with a
+    ``MAX_POLL_HOURS`` cap (~30 days) enforced by the model's
+    ``validate_recent_format``. We clamp ``poll_interval_hours`` to that
+    ceiling here to avoid a validation error mid-cycle.
+
+    Args:
+        query: The search query string (already expanded / validated by
+            the caller).
+        poll_interval_hours: The subscription's polling interval; used as
+            the look-back window. Values above ``MAX_POLL_HOURS`` are
+            silently clamped.
+
+    Returns:
+        A ``ResearchTopic`` ready to be passed to a
+        ``DiscoveryProvider.search`` call.
+    """
+    hours = min(poll_interval_hours, MAX_POLL_HOURS)
+    timeframe = TimeframeRecent(
+        type=TimeframeType.RECENT,
+        value=f"{hours}h",
+    )
+    return ResearchTopic(query=query, timeframe=timeframe)

--- a/src/services/intelligence/monitoring/_tier1_factory.py
+++ b/src/services/intelligence/monitoring/_tier1_factory.py
@@ -1,0 +1,87 @@
+"""Shared factory for wiring Tier-1 multi-provider extras.
+
+H-C4: Both ``cli/monitor.py:_build_runner`` and
+``src/scheduling/jobs.py:MonitoringCheckJob.__init__`` need the same
+~30-line block that constructs the extra providers dict and the
+``QueryExpander``. Extracting it here gives both call sites a one-liner
+and makes the logic easy to unit-test in isolation.
+
+Usage::
+
+    extra_providers, query_expander = build_tier1_extras(llm_service)
+    runner = MonitoringRunner.from_paths(
+        ...,
+        extra_providers=extra_providers,
+        query_expander=query_expander,
+    )
+
+Returns ``(None, None)`` when ``llm_service`` is ``None`` (graceful
+degradation — caller falls back to legacy single-ArXiv behavior).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Optional
+
+import structlog
+
+if TYPE_CHECKING:
+    from src.services.providers.base import DiscoveryProvider
+    from src.services.intelligence.monitoring.models import PaperSource
+    from src.services.llm.service import LLMService
+    from src.utils.query_expander import QueryExpander
+
+logger = structlog.get_logger(__name__)
+
+
+def build_tier1_extras(
+    llm_service: Optional["LLMService"],
+) -> "tuple[dict[PaperSource, DiscoveryProvider] | None, QueryExpander | None]":
+    """Build the extra-providers dict and query expander for Tier-1 discovery.
+
+    Constructs OpenAlex, HuggingFace (always) and optionally Semantic Scholar
+    (when ``SEMANTIC_SCHOLAR_API_KEY`` is set) providers. Also constructs a
+    :class:`QueryExpander` backed by ``llm_service``.
+
+    Args:
+        llm_service: A configured :class:`~src.services.llm.service.LLMService`
+            instance. When ``None``, both outputs are ``None`` (no Tier-1
+            expansion, caller uses legacy ArXiv-only behavior).
+
+    Returns:
+        A ``(extra_providers, query_expander)`` tuple.
+        Both elements are ``None`` when ``llm_service`` is ``None`` **or** when
+        provider construction fails (logged as a warning; caller falls back).
+    """
+    if llm_service is None:
+        return None, None
+
+    try:
+        from src.services.intelligence.monitoring.models import PaperSource
+        from src.services.providers.huggingface import HuggingFaceProvider
+        from src.services.providers.openalex import OpenAlexProvider
+        from src.services.providers.semantic_scholar import SemanticScholarProvider
+        from src.utils.query_expander import QueryExpander
+
+        extra_providers: dict = {
+            PaperSource.OPENALEX: OpenAlexProvider(),
+            PaperSource.HUGGINGFACE: HuggingFaceProvider(),
+        }
+        s2_key = os.environ.get("SEMANTIC_SCHOLAR_API_KEY")
+        if s2_key and s2_key.strip():
+            extra_providers[PaperSource.SEMANTIC_SCHOLAR] = SemanticScholarProvider(
+                api_key=s2_key
+            )
+        query_expander: QueryExpander = QueryExpander(  # type: ignore[arg-type]
+            llm_service=llm_service
+        )
+        return extra_providers, query_expander
+
+    except Exception as exc:
+        logger.warning(
+            "monitor_tier1_init_failed",
+            error=str(exc),
+            reason="falling_back_to_legacy_single_arxiv",
+        )
+        return None, None

--- a/src/services/intelligence/monitoring/arxiv_monitor.py
+++ b/src/services/intelligence/monitoring/arxiv_monitor.py
@@ -46,6 +46,7 @@ from src.services.intelligence.monitoring.models import (
     MonitoringRun,
     MonitoringRunStatus,
     ResearchSubscription,
+    SubscriptionStatus,
 )
 from src.services.providers.arxiv import ArxivProvider
 from src.services.registry import RegistryService
@@ -242,7 +243,8 @@ class ArxivMonitor:
     @staticmethod
     def _monitor_eligible(subscription: ResearchSubscription) -> bool:
         """Return True if the monitor should poll for this subscription."""
-        if subscription.status.value != "active":
+        # H-M2: use enum identity instead of raw-string comparison.
+        if subscription.status is not SubscriptionStatus.ACTIVE:
             return False
         if PaperSource.ARXIV not in subscription.sources:
             return False

--- a/src/services/intelligence/monitoring/arxiv_monitor.py
+++ b/src/services/intelligence/monitoring/arxiv_monitor.py
@@ -27,21 +27,21 @@ Design notes:
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Optional
 
 import structlog
 from pydantic import BaseModel, ConfigDict
 
-from src.models.config.core import (
-    ResearchTopic,
-    TimeframeRecent,
-    TimeframeType,
-)
+from src.models.config.core import ResearchTopic
 from src.models.paper import PaperMetadata
 from src.models.registry import RegistryEntry
 from src.services.intelligence.models.monitoring import PaperSource
+from src.services.intelligence.monitoring._paper_records import (
+    build_topic,
+    to_paper_record,
+)
 from src.services.intelligence.monitoring.models import (
     MAX_PAPERS_PER_CYCLE,
+    MAX_POLL_HOURS,
     MonitoringPaperRecord,
     MonitoringRun,
     MonitoringRunStatus,
@@ -53,10 +53,10 @@ from src.services.registry import RegistryService
 logger = structlog.get_logger()
 
 
-# Default lookback window when a poll interval is too long to express
-# as a TimeframeRecent (>720h cap). ``ArxivProvider`` validates the
-# string at construction time so we cap to the provider's known max.
-_MAX_POLL_HOURS = 720
+# H-C2: _MAX_POLL_HOURS is now imported from models.py as MAX_POLL_HOURS.
+# Keep a local alias for backward compat with imports from other modules
+# that depended on the old private name.
+_MAX_POLL_HOURS = MAX_POLL_HOURS
 # How many papers to ask ArXiv for per call. We pull the per-cycle cap
 # so a single subscription can saturate the cycle if necessary.
 _DEFAULT_MAX_PAPERS = MAX_PAPERS_PER_CYCLE
@@ -252,20 +252,10 @@ class ArxivMonitor:
     def _build_topic(subscription: ResearchSubscription) -> ResearchTopic:
         """Map a subscription to a ``ResearchTopic`` for the provider.
 
-        ArxivProvider's ``TimeframeRecent`` value pattern is ``\\d+[hd]``,
-        with a 720h cap (~30 days) enforced by the model's
-        ``validate_recent_format``. We clamp ``poll_interval_hours`` to
-        that ceiling to avoid a validation error mid-cycle.
+        Delegates to the shared :func:`build_topic` helper in
+        ``_paper_records`` (H-C3) so the clamping logic lives in one place.
         """
-        hours = min(subscription.poll_interval_hours, _MAX_POLL_HOURS)
-        timeframe = TimeframeRecent(
-            type=TimeframeType.RECENT,
-            value=f"{hours}h",
-        )
-        return ResearchTopic(
-            query=subscription.query,
-            timeframe=timeframe,
-        )
+        return build_topic(subscription.query, subscription.poll_interval_hours)
 
     def _topic_slug(self, subscription: ResearchSubscription) -> str:
         """Derive a topic slug for registry affiliation."""
@@ -291,14 +281,5 @@ class ArxivMonitor:
 
     @staticmethod
     def _to_record(paper: PaperMetadata, is_new: bool) -> MonitoringPaperRecord:
-        published: Optional[datetime] = paper.publication_date
-        # PaperMetadata uses HttpUrl; MonitoringPaperRecord stores plain
-        # strings (it's a serialization-friendly DTO). Cast via str().
-        return MonitoringPaperRecord(
-            paper_id=paper.paper_id,
-            title=paper.title,
-            url=str(paper.url) if paper.url else None,
-            pdf_url=str(paper.open_access_pdf) if paper.open_access_pdf else None,
-            published_at=published,
-            is_new=is_new,
-        )
+        """Delegate to the shared :func:`to_paper_record` helper (H-C1)."""
+        return to_paper_record(paper, is_new)

--- a/src/services/intelligence/monitoring/models.py
+++ b/src/services/intelligence/monitoring/models.py
@@ -47,6 +47,12 @@ MAX_KEYWORDS_PER_SUBSCRIPTION = 100
 MAX_EXCLUDE_KEYWORDS_PER_SUBSCRIPTION = 100
 MAX_PAPERS_PER_CYCLE = 1000
 
+# H-C2: Maximum lookback window (hours) for the TimeframeRecent model.
+# ArxivProvider validates the string at construction time so we cap here.
+# Both ArxivMonitor and MultiProviderMonitor import this instead of each
+# defining a local ``_MAX_POLL_HOURS = 720`` copy.
+MAX_POLL_HOURS = 720
+
 # Subscription name pattern: same character class as the rest of the
 # Phase 9 surface (matches ``ENTITY_NAME_PATTERN`` extended with
 # underscore so existing user_id slugs keep working).

--- a/src/services/intelligence/monitoring/multi_provider_monitor.py
+++ b/src/services/intelligence/monitoring/multi_provider_monitor.py
@@ -116,17 +116,6 @@ class MultiProviderMonitorConfig(BaseModel):
         description="Prefix used when affiliating monitored papers in the registry.",
     )
 
-    @classmethod
-    def with_defaults(cls) -> "MultiProviderMonitorConfig":
-        """Return a config with all defaults applied.
-
-        .. deprecated::
-            Calling ``MultiProviderMonitorConfig()`` directly is equivalent
-            and is preferred. This classmethod is retained for backward
-            compatibility only and will be removed in a future iteration.
-        """
-        return cls()
-
 
 class MultiProviderMonitor:
     """Polls multiple discovery providers, optionally with query expansion.
@@ -142,8 +131,9 @@ class MultiProviderMonitor:
             the subscription's query is expanded into N variants via
             an LLM call before the provider fan-out. When ``None``, only
             the literal subscription query is searched (no LLM cost).
-        config: Knobs (caps, prefix). Defaults via
-            :meth:`MultiProviderMonitorConfig.with_defaults`.
+        config: Knobs (caps, prefix). Defaults to
+            ``MultiProviderMonitorConfig()`` (all fields at their
+            default values).
 
     Raises:
         ValueError: If ``providers`` is empty or ``config`` rejects the
@@ -166,7 +156,7 @@ class MultiProviderMonitor:
         self._providers = dict(providers)  # defensive copy
         self._registry = registry
         self._query_expander = query_expander
-        self._config = config or MultiProviderMonitorConfig.with_defaults()
+        self._config = config or MultiProviderMonitorConfig()
 
     # ------------------------------------------------------------------
     # Public API — same shape as ArxivMonitor.check()
@@ -255,6 +245,13 @@ class MultiProviderMonitor:
         # Step 3: fan-out across (variant × provider). One provider+variant
         # failure does NOT abort the cycle — each is independent.
         # H-S3: Only search providers the subscription's allowlist permits.
+        #
+        # L-7: The nested loop is sequential by design. Fan-out is IO-bound
+        # (arXiv, S2, OpenAlex each have their own rate limits), and the
+        # provider SDKs are not guaranteed thread-safe. Async gather across
+        # providers would also complicate partial-failure accounting without
+        # meaningful latency gains at small provider counts (≤4). Change
+        # only after profiling confirms fan-out latency is the bottleneck.
         fetched: list[PaperMetadata] = []
         partial_failure = expansion_degraded  # H-C5: expander degradation → PARTIAL
         for variant in queries:
@@ -287,6 +284,12 @@ class MultiProviderMonitor:
 
         # Step 5: enforce per-cycle paper cap
         if len(deduped_fetch) > self._config.max_papers_per_cycle:
+            logger.info(
+                "monitor_per_cycle_cap_applied",
+                subscription_id=subscription.subscription_id,
+                papers_before_cap=len(deduped_fetch),
+                cap=self._config.max_papers_per_cycle,
+            )
             deduped_fetch = deduped_fetch[: self._config.max_papers_per_cycle]
 
         run.papers_seen = len(deduped_fetch)

--- a/src/services/intelligence/monitoring/multi_provider_monitor.py
+++ b/src/services/intelligence/monitoring/multi_provider_monitor.py
@@ -213,7 +213,7 @@ class MultiProviderMonitor:
                         subscription_id=subscription.subscription_id,
                         source=source.value,
                         query=variant[:120],
-                        error=str(exc),
+                        error=repr(str(exc)[:512]),
                     )
                     continue
                 fetched.extend(results)
@@ -288,7 +288,7 @@ class MultiProviderMonitor:
             logger.warning(
                 "monitor_query_expansion_failed",
                 subscription_id=subscription.subscription_id,
-                error=str(exc),
+                error=repr(str(exc)[:512]),
             )
             return [subscription.query]
 
@@ -351,7 +351,7 @@ class MultiProviderMonitor:
                     "monitor_identity_resolution_error",
                     subscription_id=subscription.subscription_id,
                     paper_id=paper.paper_id,
-                    error=str(exc),
+                    error=repr(str(exc)[:512]),
                 )
                 continue
 
@@ -372,7 +372,7 @@ class MultiProviderMonitor:
                     "monitor_registry_write_error",
                     subscription_id=subscription.subscription_id,
                     paper_id=paper.paper_id,
-                    error=str(exc),
+                    error=repr(str(exc)[:512]),
                 )
                 continue
 

--- a/src/services/intelligence/monitoring/multi_provider_monitor.py
+++ b/src/services/intelligence/monitoring/multi_provider_monitor.py
@@ -147,19 +147,16 @@ class MultiProviderMonitor:
 
         Behavior:
 
-        1. Skip immediately if the subscription is paused. (Per-source
-           filtering is NOT applied here — multi-provider monitors
-           consult every configured provider regardless of the
-           subscription's ``sources`` list, since the whole point of
-           Tier 1 is broader discovery. Sources filtering can be
-           reintroduced in a follow-up if users want per-subscription
-           provider opt-out.)
+        1. Skip immediately if the subscription is paused. Per-source
+           filtering IS applied (H-S3): providers not in the
+           subscription's ``sources`` allowlist are skipped so each
+           subscription can opt out of specific providers.
         2. Expand the query into N variants (or use only the literal
            query if no expander is configured).
-        3. For each variant, search every configured provider. Provider
-           failures on a single variant are logged and skipped — the
-           cycle continues with whatever other providers/variants
-           succeed.
+        3. For each variant, search every provider the subscription has
+           allowlisted. Provider failures on a single variant are logged
+           and skipped — the cycle continues with whatever other
+           providers/variants succeed.
         4. Union all returned papers, dedup by ``paper_id``.
         5. Apply the per-cycle paper cap.
         6. For each paper, resolve identity against the registry. New
@@ -175,6 +172,10 @@ class MultiProviderMonitor:
         run = MonitoringRun(
             subscription_id=subscription.subscription_id,
             # See Tier 1 schema-compat note in module docstring.
+            # TODO(issue #141): per-paper source tracking — add
+            # MonitoringPaperRecord.source field + schema migration so
+            # each paper records its actual discovery provider instead of
+            # hardcoding PaperSource.ARXIV for schema compatibility.
             source=PaperSource.ARXIV,
         )
 
@@ -199,11 +200,14 @@ class MultiProviderMonitor:
 
         # Step 3: fan-out across (variant × provider). One provider+variant
         # failure does NOT abort the cycle — each is independent.
+        # H-S3: Only search providers the subscription's allowlist permits.
         fetched: list[PaperMetadata] = []
         partial_failure = False
         for variant in queries:
             topic = self._build_topic_for_query(subscription, variant)
             for source, provider in self._providers.items():
+                if source not in subscription.sources:
+                    continue
                 try:
                     results = await provider.search(topic)
                 except Exception as exc:
@@ -275,6 +279,11 @@ class MultiProviderMonitor:
         Expander failures are caught and logged; the literal query is
         used as a fail-soft fallback (matching ``QueryExpander.expand``'s
         own contract — see ``src/utils/query_expander.py:88``).
+
+        ``max_query_variants`` is the final cap on the total result set
+        including the original query. The expander is asked for that many
+        variants; the result is clipped locally afterwards to enforce the
+        cap regardless of what the expander returns.
         """
         if self._query_expander is None:
             return [subscription.query]
@@ -282,7 +291,7 @@ class MultiProviderMonitor:
         try:
             variants = await self._query_expander.expand(
                 subscription.query,
-                max_variants=self._config.max_query_variants - 1,
+                max_variants=self._config.max_query_variants,
             )
         except Exception as exc:
             logger.warning(
@@ -296,7 +305,11 @@ class MultiProviderMonitor:
         # to the literal query so we never search with an empty list.
         if not variants:
             return [subscription.query]
-        return variants
+
+        # Clip to the configured cap so callers are never surprised by an
+        # oversized variant list even if the expander ignores max_variants.
+        result = variants[: self._config.max_query_variants]
+        return result
 
     def _build_topic_for_query(
         self, subscription: ResearchSubscription, query: str

--- a/src/services/intelligence/monitoring/multi_provider_monitor.py
+++ b/src/services/intelligence/monitoring/multi_provider_monitor.py
@@ -46,12 +46,13 @@ from typing import TYPE_CHECKING, Optional
 import structlog
 from pydantic import BaseModel, ConfigDict
 
-from src.models.config.core import ResearchTopic, TimeframeRecent, TimeframeType
+from src.models.config.core import ResearchTopic
 from src.models.paper import PaperMetadata
-from src.services.intelligence.monitoring.arxiv_monitor import (
-    _MAX_POLL_HOURS,
-    ArxivMonitorResult,
+from src.services.intelligence.monitoring._paper_records import (
+    build_topic,
+    to_paper_record,
 )
+from src.services.intelligence.monitoring.arxiv_monitor import ArxivMonitorResult
 from src.services.intelligence.monitoring.models import (
     MAX_PAPERS_PER_CYCLE,
     MonitoringRun,
@@ -314,13 +315,12 @@ class MultiProviderMonitor:
     def _build_topic_for_query(
         self, subscription: ResearchSubscription, query: str
     ) -> ResearchTopic:
-        """Construct a :class:`ResearchTopic` for one query variant."""
-        hours = min(subscription.poll_interval_hours, _MAX_POLL_HOURS)
-        timeframe = TimeframeRecent(
-            type=TimeframeType.RECENT,
-            value=f"{hours}h",
-        )
-        return ResearchTopic(query=query, timeframe=timeframe)
+        """Construct a :class:`ResearchTopic` for one query variant.
+
+        Delegates to the shared :func:`build_topic` helper (H-C3) so
+        the look-back-window clamping logic lives in one place.
+        """
+        return build_topic(query, subscription.poll_interval_hours)
 
     @staticmethod
     def _dedup_by_paper_id(papers: list[PaperMetadata]) -> list[PaperMetadata]:
@@ -348,8 +348,6 @@ class MultiProviderMonitor:
         — those are individually survivable but flag the overall cycle
         as PARTIAL.
         """
-        from src.services.intelligence.monitoring.arxiv_monitor import ArxivMonitor
-
         new_papers: list[PaperMetadata] = []
         deduped: list[PaperMetadata] = []
         partial_failure = False
@@ -370,7 +368,7 @@ class MultiProviderMonitor:
 
             if match.matched:
                 deduped.append(paper)
-                run.papers.append(ArxivMonitor._to_record(paper, is_new=False))
+                run.papers.append(to_paper_record(paper, is_new=False))
                 continue
 
             try:
@@ -390,6 +388,6 @@ class MultiProviderMonitor:
                 continue
 
             new_papers.append(paper)
-            run.papers.append(ArxivMonitor._to_record(paper, is_new=True))
+            run.papers.append(to_paper_record(paper, is_new=True))
 
         return new_papers, deduped, partial_failure

--- a/src/services/intelligence/monitoring/multi_provider_monitor.py
+++ b/src/services/intelligence/monitoring/multi_provider_monitor.py
@@ -44,7 +44,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Optional
 
 import structlog
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from src.models.config.core import ResearchTopic
 from src.models.paper import PaperMetadata
@@ -59,6 +59,7 @@ from src.services.intelligence.monitoring.models import (
     MonitoringRunStatus,
     PaperSource,
     ResearchSubscription,
+    SubscriptionStatus,
 )
 from src.services.providers.base import DiscoveryProvider
 from src.services.registry import RegistryService
@@ -87,16 +88,43 @@ class MultiProviderMonitorConfig(BaseModel):
     Wrapping the constructor params in a Pydantic model gives us strict
     validation at runtime (catching e.g. negative budget caps) and a
     single point to extend without breaking the constructor signature.
+
+    H-M1: all numeric fields carry Pydantic ``Field(ge=..., le=...)``
+    bounds so illegal values are caught at construction time rather than
+    producing silent misuse at runtime.
     """
 
     model_config = ConfigDict(extra="forbid", strict=True)
 
-    max_papers_per_cycle: int = MAX_PAPERS_PER_CYCLE
-    max_query_variants: int = _DEFAULT_MAX_QUERY_VARIANTS
-    topic_slug_prefix: str = "monitor"
+    max_papers_per_cycle: int = Field(
+        default=MAX_PAPERS_PER_CYCLE,
+        ge=1,
+        le=MAX_PAPERS_PER_CYCLE,
+        description="Hard cap on papers processed per cycle.",
+    )
+    max_query_variants: int = Field(
+        default=_DEFAULT_MAX_QUERY_VARIANTS,
+        ge=1,
+        le=10,
+        description="Maximum number of query variants including the original.",
+    )
+    topic_slug_prefix: str = Field(
+        default="monitor",
+        min_length=1,
+        max_length=64,
+        pattern=r"^[a-zA-Z0-9_-]+$",
+        description="Prefix used when affiliating monitored papers in the registry.",
+    )
 
     @classmethod
     def with_defaults(cls) -> "MultiProviderMonitorConfig":
+        """Return a config with all defaults applied.
+
+        .. deprecated::
+            Calling ``MultiProviderMonitorConfig()`` directly is equivalent
+            and is preferred. This classmethod is retained for backward
+            compatibility only and will be removed in a future iteration.
+        """
         return cls()
 
 
@@ -143,7 +171,13 @@ class MultiProviderMonitor:
     # ------------------------------------------------------------------
     # Public API — same shape as ArxivMonitor.check()
     # ------------------------------------------------------------------
-    async def check(self, subscription: ResearchSubscription) -> ArxivMonitorResult:
+    async def check(
+        self,
+        subscription: ResearchSubscription,
+        *,
+        llm_calls_used: Optional[list[int]] = None,
+        max_calls: Optional[int] = None,
+    ) -> ArxivMonitorResult:
         """Run one expanded multi-provider monitoring cycle.
 
         Behavior:
@@ -153,11 +187,17 @@ class MultiProviderMonitor:
            subscription's ``sources`` allowlist are skipped so each
            subscription can opt out of specific providers.
         2. Expand the query into N variants (or use only the literal
-           query if no expander is configured).
+           query if no expander is configured). H-S1: the expander call
+           is gated against the ``llm_calls_used`` / ``max_calls``
+           budget so the monitor cannot bypass ``MonitoringRunner``'s
+           ``MAX_LLM_CALLS_PER_CYCLE`` cap.
         3. For each variant, search every provider the subscription has
            allowlisted. Provider failures on a single variant are logged
            and skipped — the cycle continues with whatever other
            providers/variants succeed.
+           H-S5: ``_build_topic_for_query`` is called inside the
+           per-provider try/except so a Pydantic validation failure on
+           a bad variant does not abort the whole subscription cycle.
         4. Union all returned papers, dedup by ``paper_id``.
         5. Apply the per-cycle paper cap.
         6. For each paper, resolve identity against the registry. New
@@ -166,6 +206,16 @@ class MultiProviderMonitor:
         7. Return :class:`ArxivMonitorResult`. Status is ``PARTIAL`` if
            any provider/registry call surfaced an error during the
            cycle, ``SUCCESS`` otherwise.
+
+        Args:
+            subscription: The subscription to check.
+            llm_calls_used: Optional mutable single-element list acting
+                as a shared counter for LLM calls consumed this cycle.
+                When ``None``, budget enforcement is skipped (direct
+                callers and tests that don't need the cap).
+            max_calls: Maximum allowed LLM calls. Checked against
+                ``llm_calls_used[0]`` before the expander is invoked.
+                Ignored when ``llm_calls_used`` is ``None``.
 
         This method never raises — it always returns a result with a
         meaningful :class:`MonitoringRun` status.
@@ -180,7 +230,7 @@ class MultiProviderMonitor:
             source=PaperSource.ARXIV,
         )
 
-        if subscription.status.value != "active":
+        if subscription.status is not SubscriptionStatus.ACTIVE:
             run.status = MonitoringRunStatus.SUCCESS
             run.finished_at = datetime.now(timezone.utc)
             logger.info(
@@ -190,8 +240,11 @@ class MultiProviderMonitor:
             )
             return ArxivMonitorResult(run=run, new_papers=[], deduplicated_papers=[])
 
-        # Step 2: query expansion (or single-query fallback)
-        queries = await self._build_query_variants(subscription)
+        # Step 2: query expansion (or single-query fallback).
+        # H-S1: pass budget counters so the expander call is gated.
+        queries, expansion_degraded = await self._build_query_variants(
+            subscription, llm_calls_used=llm_calls_used, max_calls=max_calls
+        )
         logger.info(
             "monitor_query_expansion_complete",
             subscription_id=subscription.subscription_id,
@@ -203,13 +256,17 @@ class MultiProviderMonitor:
         # failure does NOT abort the cycle — each is independent.
         # H-S3: Only search providers the subscription's allowlist permits.
         fetched: list[PaperMetadata] = []
-        partial_failure = False
+        partial_failure = expansion_degraded  # H-C5: expander degradation → PARTIAL
         for variant in queries:
-            topic = self._build_topic_for_query(subscription, variant)
             for source, provider in self._providers.items():
                 if source not in subscription.sources:
                     continue
                 try:
+                    # H-S5: build topic INSIDE try/except so a Pydantic
+                    # validation error on a bad variant (e.g., containing
+                    # characters rejected by ResearchTopic) does not abort
+                    # the whole cycle — it's treated as a provider failure.
+                    topic = self._build_topic_for_query(subscription, variant)
                     results = await provider.search(topic)
                 except Exception as exc:
                     partial_failure = True
@@ -272,14 +329,33 @@ class MultiProviderMonitor:
     # Internal helpers
     # ------------------------------------------------------------------
     async def _build_query_variants(
-        self, subscription: ResearchSubscription
-    ) -> list[str]:
+        self,
+        subscription: ResearchSubscription,
+        *,
+        llm_calls_used: Optional[list[int]] = None,
+        max_calls: Optional[int] = None,
+    ) -> tuple[list[str], bool]:
         """Expand the subscription's query if an expander is configured.
 
-        Always returns a non-empty list — at minimum, the literal query.
-        Expander failures are caught and logged; the literal query is
-        used as a fail-soft fallback (matching ``QueryExpander.expand``'s
-        own contract — see ``src/utils/query_expander.py:88``).
+        Always returns ``(variants, degraded)`` where ``variants`` is a
+        non-empty list (at minimum, the literal query) and ``degraded``
+        is ``True`` when the expander was skipped, failed, or produced
+        only invalid variants — so the caller can mark the run PARTIAL.
+
+        H-S1 — Budget gate:
+            If ``llm_calls_used`` and ``max_calls`` are both provided and
+            ``llm_calls_used[0] >= max_calls``, the expander call is
+            skipped entirely and ``monitor_expansion_budget_exhausted``
+            is logged. ``degraded=True`` is returned so the run is PARTIAL.
+            On successful expansion, ``llm_calls_used[0]`` is incremented
+            by 1 to account for the expander's LLM call.
+
+        H-S2 — Variant validation:
+            Each variant is passed through
+            ``InputValidation.validate_query``. Invalid variants are
+            dropped with a ``monitor_expansion_variant_rejected`` log
+            event. If all variants are rejected, the literal query is
+            used as a fallback.
 
         ``max_query_variants`` is the final cap on the total result set
         including the original query. The expander is asked for that many
@@ -287,7 +363,23 @@ class MultiProviderMonitor:
         cap regardless of what the expander returns.
         """
         if self._query_expander is None:
-            return [subscription.query]
+            return [subscription.query], False
+
+        # H-S1: Budget guard — skip expander when the cycle's LLM budget
+        # is already exhausted. Use ``degraded=True`` so the caller marks
+        # the run PARTIAL and ops can grep for the audit event.
+        if (
+            llm_calls_used is not None
+            and max_calls is not None
+            and llm_calls_used[0] >= max_calls
+        ):
+            logger.warning(
+                "monitor_expansion_budget_exhausted",
+                subscription_id=subscription.subscription_id,
+                max_calls=max_calls,
+                calls_used=llm_calls_used[0],
+            )
+            return [subscription.query], True
 
         try:
             variants = await self._query_expander.expand(
@@ -300,17 +392,42 @@ class MultiProviderMonitor:
                 subscription_id=subscription.subscription_id,
                 error=repr(str(exc)[:512]),
             )
-            return [subscription.query]
+            return [subscription.query], True
+
+        # H-S1: Increment budget counter on successful expander call.
+        if llm_calls_used is not None:
+            llm_calls_used[0] += 1
 
         # Defensive: if the expander returned nothing usable, fall back
         # to the literal query so we never search with an empty list.
         if not variants:
-            return [subscription.query]
+            return [subscription.query], True
 
         # Clip to the configured cap so callers are never surprised by an
         # oversized variant list even if the expander ignores max_variants.
-        result = variants[: self._config.max_query_variants]
-        return result
+        clipped = variants[: self._config.max_query_variants]
+
+        # H-S2: Validate each variant through InputValidation to drop any
+        # LLM-produced strings that contain injection-risk characters.
+        from src.utils.security import InputValidation
+
+        validated: list[str] = []
+        for variant in clipped:
+            try:
+                InputValidation.validate_query(variant)
+                validated.append(variant)
+            except Exception:
+                logger.warning(
+                    "monitor_expansion_variant_rejected",
+                    subscription_id=subscription.subscription_id,
+                    variant=variant[:120],
+                )
+
+        if not validated:
+            # All variants were rejected — fall back to the literal query.
+            return [subscription.query], True
+
+        return validated, False
 
     def _build_topic_for_query(
         self, subscription: ResearchSubscription, query: str

--- a/src/services/intelligence/monitoring/multi_provider_monitor.py
+++ b/src/services/intelligence/monitoring/multi_provider_monitor.py
@@ -1,0 +1,382 @@
+"""Multi-provider, query-expanded monitor for Phase 9.1 Tier 1.
+
+Drop-in replacement for :class:`ArxivMonitor` that adds two
+discovery-broadening capabilities the original monitor lacked:
+
+1. **Query expansion** — uses :class:`QueryExpander` (Phase 7.2) to
+   generate semantically-related variants of the subscription's query
+   via a cheap Gemini Flash call. The original query is always
+   included as the first variant.
+2. **Multi-provider fan-out** — searches every configured provider
+   (typically arXiv + Semantic Scholar + OpenAlex + HuggingFace), not
+   just arXiv. Results are unioned and deduplicated by ``paper_id``
+   before identity resolution against the registry.
+
+Failure semantics mirror :class:`ArxivMonitor`:
+
+- A provider raising for one query is logged and skipped (fail-soft
+  across independent peers — one S2 timeout doesn't kill the cycle).
+- A registry write failure on one paper is logged and the cycle
+  continues with the remaining papers, ending in ``PARTIAL`` status.
+- Identity resolution failure on one paper is similarly survivable.
+- The whole cycle returns a :class:`MonitoringRun` with appropriate
+  status — never raises to the caller.
+
+Backward compatibility:
+
+- Returns an :class:`ArxivMonitorResult` (same DTO as the legacy
+  monitor) so :class:`MonitoringRunner._run_one` can consume either
+  monitor implementation without branching.
+- The ``source`` field on the produced :class:`MonitoringRun` remains
+  ``PaperSource.ARXIV`` for now — Tier 1 keeps schema compat; a
+  future iteration will add per-source provenance tracking.
+
+Note on threshold-based ingestion: this monitor does the *discovery*
+half (find candidate papers, register them with ``discovery_only=True``).
+The relevance-scoring + threshold-gated full ingestion happens
+downstream in :class:`MonitoringRunner._run_one` after this monitor
+returns its result.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Optional
+
+import structlog
+from pydantic import BaseModel, ConfigDict
+
+from src.models.config.core import ResearchTopic, TimeframeRecent, TimeframeType
+from src.models.paper import PaperMetadata
+from src.services.intelligence.monitoring.arxiv_monitor import (
+    _MAX_POLL_HOURS,
+    ArxivMonitorResult,
+)
+from src.services.intelligence.monitoring.models import (
+    MAX_PAPERS_PER_CYCLE,
+    MonitoringRun,
+    MonitoringRunStatus,
+    PaperSource,
+    ResearchSubscription,
+)
+from src.services.providers.base import DiscoveryProvider
+from src.services.registry import RegistryService
+
+if TYPE_CHECKING:
+    from src.utils.query_expander import QueryExpander
+
+
+__all__ = ["MultiProviderMonitor", "MultiProviderMonitorConfig"]
+
+
+logger = structlog.get_logger(__name__)
+
+
+# Default cap on how many query variants the expander returns. The
+# original query always counts as the first variant; this is the cap on
+# the total result set including the original. Lower than the default
+# in QueryExpander (5) because each variant fans out across N providers,
+# multiplying the API call count.
+_DEFAULT_MAX_QUERY_VARIANTS = 3
+
+
+class MultiProviderMonitorConfig(BaseModel):
+    """Validated knobs for a :class:`MultiProviderMonitor` instance.
+
+    Wrapping the constructor params in a Pydantic model gives us strict
+    validation at runtime (catching e.g. negative budget caps) and a
+    single point to extend without breaking the constructor signature.
+    """
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    max_papers_per_cycle: int = MAX_PAPERS_PER_CYCLE
+    max_query_variants: int = _DEFAULT_MAX_QUERY_VARIANTS
+    topic_slug_prefix: str = "monitor"
+
+    @classmethod
+    def with_defaults(cls) -> "MultiProviderMonitorConfig":
+        return cls()
+
+
+class MultiProviderMonitor:
+    """Polls multiple discovery providers, optionally with query expansion.
+
+    Args:
+        providers: Mapping of :class:`PaperSource` to a configured
+            :class:`DiscoveryProvider`. Must contain at least one entry.
+            All providers are searched in parallel for every query
+            variant; results are unioned and deduplicated by paper_id.
+        registry: Shared :class:`RegistryService` used for paper
+            identity resolution and discovery-time registration.
+        query_expander: Optional :class:`QueryExpander`. When provided,
+            the subscription's query is expanded into N variants via
+            an LLM call before the provider fan-out. When ``None``, only
+            the literal subscription query is searched (no LLM cost).
+        config: Knobs (caps, prefix). Defaults via
+            :meth:`MultiProviderMonitorConfig.with_defaults`.
+
+    Raises:
+        ValueError: If ``providers`` is empty or ``config`` rejects the
+            input (e.g., negative cap).
+    """
+
+    def __init__(
+        self,
+        providers: dict[PaperSource, DiscoveryProvider],
+        registry: RegistryService,
+        *,
+        query_expander: Optional["QueryExpander"] = None,
+        config: Optional[MultiProviderMonitorConfig] = None,
+    ) -> None:
+        if not providers:
+            raise ValueError(
+                "MultiProviderMonitor requires at least one provider "
+                "(empty providers dict was passed)"
+            )
+        self._providers = dict(providers)  # defensive copy
+        self._registry = registry
+        self._query_expander = query_expander
+        self._config = config or MultiProviderMonitorConfig.with_defaults()
+
+    # ------------------------------------------------------------------
+    # Public API — same shape as ArxivMonitor.check()
+    # ------------------------------------------------------------------
+    async def check(self, subscription: ResearchSubscription) -> ArxivMonitorResult:
+        """Run one expanded multi-provider monitoring cycle.
+
+        Behavior:
+
+        1. Skip immediately if the subscription is paused. (Per-source
+           filtering is NOT applied here — multi-provider monitors
+           consult every configured provider regardless of the
+           subscription's ``sources`` list, since the whole point of
+           Tier 1 is broader discovery. Sources filtering can be
+           reintroduced in a follow-up if users want per-subscription
+           provider opt-out.)
+        2. Expand the query into N variants (or use only the literal
+           query if no expander is configured).
+        3. For each variant, search every configured provider. Provider
+           failures on a single variant are logged and skipped — the
+           cycle continues with whatever other providers/variants
+           succeed.
+        4. Union all returned papers, dedup by ``paper_id``.
+        5. Apply the per-cycle paper cap.
+        6. For each paper, resolve identity against the registry. New
+           papers are registered ``discovery_only=True``; known papers
+           are added to the deduped list.
+        7. Return :class:`ArxivMonitorResult`. Status is ``PARTIAL`` if
+           any provider/registry call surfaced an error during the
+           cycle, ``SUCCESS`` otherwise.
+
+        This method never raises — it always returns a result with a
+        meaningful :class:`MonitoringRun` status.
+        """
+        run = MonitoringRun(
+            subscription_id=subscription.subscription_id,
+            # See Tier 1 schema-compat note in module docstring.
+            source=PaperSource.ARXIV,
+        )
+
+        if subscription.status.value != "active":
+            run.status = MonitoringRunStatus.SUCCESS
+            run.finished_at = datetime.now(timezone.utc)
+            logger.info(
+                "monitor_skipped",
+                subscription_id=subscription.subscription_id,
+                reason="paused",
+            )
+            return ArxivMonitorResult(run=run, new_papers=[], deduplicated_papers=[])
+
+        # Step 2: query expansion (or single-query fallback)
+        queries = await self._build_query_variants(subscription)
+        logger.info(
+            "monitor_query_expansion_complete",
+            subscription_id=subscription.subscription_id,
+            variant_count=len(queries),
+            had_expander=self._query_expander is not None,
+        )
+
+        # Step 3: fan-out across (variant × provider). One provider+variant
+        # failure does NOT abort the cycle — each is independent.
+        fetched: list[PaperMetadata] = []
+        partial_failure = False
+        for variant in queries:
+            topic = self._build_topic_for_query(subscription, variant)
+            for source, provider in self._providers.items():
+                try:
+                    results = await provider.search(topic)
+                except Exception as exc:
+                    partial_failure = True
+                    logger.warning(
+                        "monitor_provider_search_failed",
+                        subscription_id=subscription.subscription_id,
+                        source=source.value,
+                        query=variant[:120],
+                        error=str(exc),
+                    )
+                    continue
+                fetched.extend(results)
+
+        # Step 4: dedup by paper_id (preserving first-seen order so the
+        # original-query results land first when relevance scoring caps
+        # the per-subscription LLM budget downstream).
+        deduped_fetch = self._dedup_by_paper_id(fetched)
+
+        # Step 5: enforce per-cycle paper cap
+        if len(deduped_fetch) > self._config.max_papers_per_cycle:
+            deduped_fetch = deduped_fetch[: self._config.max_papers_per_cycle]
+
+        run.papers_seen = len(deduped_fetch)
+
+        # Step 6: identity-resolve + register-or-dedup against registry
+        new_papers, deduplicated_papers, registry_partial = self._resolve_and_register(
+            deduped_fetch, subscription, run
+        )
+        if registry_partial:
+            partial_failure = True
+
+        run.papers_new = len(new_papers)
+        run.papers_deduplicated = len(deduplicated_papers)
+        run.finished_at = datetime.now(timezone.utc)
+        run.status = (
+            MonitoringRunStatus.PARTIAL
+            if partial_failure
+            else MonitoringRunStatus.SUCCESS
+        )
+        if partial_failure and run.error is None:
+            run.error = "one_or_more_providers_or_papers_failed"
+
+        logger.info(
+            "monitor_cycle_complete",
+            subscription_id=subscription.subscription_id,
+            seen=run.papers_seen,
+            new=run.papers_new,
+            deduplicated=run.papers_deduplicated,
+            status=run.status.value,
+            variants_searched=len(queries),
+            providers_searched=len(self._providers),
+        )
+        return ArxivMonitorResult(
+            run=run,
+            new_papers=new_papers,
+            deduplicated_papers=deduplicated_papers,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    async def _build_query_variants(
+        self, subscription: ResearchSubscription
+    ) -> list[str]:
+        """Expand the subscription's query if an expander is configured.
+
+        Always returns a non-empty list — at minimum, the literal query.
+        Expander failures are caught and logged; the literal query is
+        used as a fail-soft fallback (matching ``QueryExpander.expand``'s
+        own contract — see ``src/utils/query_expander.py:88``).
+        """
+        if self._query_expander is None:
+            return [subscription.query]
+
+        try:
+            variants = await self._query_expander.expand(
+                subscription.query,
+                max_variants=self._config.max_query_variants - 1,
+            )
+        except Exception as exc:
+            logger.warning(
+                "monitor_query_expansion_failed",
+                subscription_id=subscription.subscription_id,
+                error=str(exc),
+            )
+            return [subscription.query]
+
+        # Defensive: if the expander returned nothing usable, fall back
+        # to the literal query so we never search with an empty list.
+        if not variants:
+            return [subscription.query]
+        return variants
+
+    def _build_topic_for_query(
+        self, subscription: ResearchSubscription, query: str
+    ) -> ResearchTopic:
+        """Construct a :class:`ResearchTopic` for one query variant."""
+        hours = min(subscription.poll_interval_hours, _MAX_POLL_HOURS)
+        timeframe = TimeframeRecent(
+            type=TimeframeType.RECENT,
+            value=f"{hours}h",
+        )
+        return ResearchTopic(query=query, timeframe=timeframe)
+
+    @staticmethod
+    def _dedup_by_paper_id(papers: list[PaperMetadata]) -> list[PaperMetadata]:
+        """Dedup a list of papers by ``paper_id`` while preserving order."""
+        seen: set[str] = set()
+        result: list[PaperMetadata] = []
+        for paper in papers:
+            if paper.paper_id in seen:
+                continue
+            seen.add(paper.paper_id)
+            result.append(paper)
+        return result
+
+    def _resolve_and_register(
+        self,
+        papers: list[PaperMetadata],
+        subscription: ResearchSubscription,
+        run: MonitoringRun,
+    ) -> tuple[list[PaperMetadata], list[PaperMetadata], bool]:
+        """Resolve identity + register new papers; return (new, dup, partial).
+
+        Mirrors :class:`ArxivMonitor`'s post-fetch logic but pulled out
+        as a pure helper that mutates ``run.papers``. ``partial`` is
+        True if any single paper triggered a registry / identity error
+        — those are individually survivable but flag the overall cycle
+        as PARTIAL.
+        """
+        from src.services.intelligence.monitoring.arxiv_monitor import ArxivMonitor
+
+        new_papers: list[PaperMetadata] = []
+        deduped: list[PaperMetadata] = []
+        partial_failure = False
+        topic_slug = f"{self._config.topic_slug_prefix}-{subscription.subscription_id}"
+
+        for paper in papers:
+            try:
+                match = self._registry.resolve_identity(paper)
+            except Exception as exc:
+                partial_failure = True
+                logger.warning(
+                    "monitor_identity_resolution_error",
+                    subscription_id=subscription.subscription_id,
+                    paper_id=paper.paper_id,
+                    error=str(exc),
+                )
+                continue
+
+            if match.matched:
+                deduped.append(paper)
+                run.papers.append(ArxivMonitor._to_record(paper, is_new=False))
+                continue
+
+            try:
+                self._registry.register_paper(
+                    paper=paper,
+                    topic_slug=topic_slug,
+                    discovery_only=True,
+                )
+            except Exception as exc:
+                partial_failure = True
+                logger.warning(
+                    "monitor_registry_write_error",
+                    subscription_id=subscription.subscription_id,
+                    paper_id=paper.paper_id,
+                    error=str(exc),
+                )
+                continue
+
+            new_papers.append(paper)
+            run.papers.append(ArxivMonitor._to_record(paper, is_new=True))
+
+        return new_papers, deduped, partial_failure

--- a/src/services/intelligence/monitoring/runner.py
+++ b/src/services/intelligence/monitoring/runner.py
@@ -54,10 +54,14 @@ from typing import TYPE_CHECKING, Optional
 import structlog
 
 from src.services.intelligence.monitoring.arxiv_monitor import ArxivMonitor
+from src.services.intelligence.monitoring.multi_provider_monitor import (
+    MultiProviderMonitor,
+)
 from src.services.intelligence.monitoring.models import (
     MonitoringPaperRecord,
     MonitoringRun,
     MonitoringRunStatus,
+    PaperSource,
     ResearchSubscription,
 )
 from src.services.intelligence.monitoring.relevance_scorer import (
@@ -74,7 +78,9 @@ from src.services.intelligence.monitoring.subscription_manager import (
 if TYPE_CHECKING:
     from src.services.llm.service import LLMService
     from src.services.providers.arxiv import ArxivProvider
+    from src.services.providers.base import DiscoveryProvider
     from src.services.registry.service import RegistryService
+    from src.utils.query_expander import QueryExpander
 
 logger = structlog.get_logger()
 
@@ -108,7 +114,7 @@ class MonitoringRunner:
     def __init__(
         self,
         subscription_manager: SubscriptionManager,
-        monitor: ArxivMonitor,
+        monitor: ArxivMonitor | MultiProviderMonitor,
         run_repo: MonitoringRunRepository,
         scorer: Optional[RelevanceScorer] = None,
     ) -> None:
@@ -117,10 +123,12 @@ class MonitoringRunner:
         Args:
             subscription_manager: Source of active subscriptions and
                 target for ``mark_checked`` updates.
-            monitor: ArXiv monitor that performs the per-subscription
-                poll. The runner does not care whether a future
-                multi-source monitor wraps this -- the contract is
-                ``check(subscription) -> ArxivMonitorResult``.
+            monitor: A monitor implementing ``check(subscription) ->
+                ArxivMonitorResult``. Either :class:`ArxivMonitor`
+                (single-provider, literal-query) or
+                :class:`MultiProviderMonitor` (multi-provider,
+                LLM-expanded queries — Tier 1) is accepted; the runner
+                duck-types on the ``check`` interface.
             run_repo: Repository for the per-cycle audit record.
             scorer: Optional ``RelevanceScorer`` for LLM-based relevance
                 scoring. When ``None``, papers are returned unscored
@@ -170,6 +178,8 @@ class MonitoringRunner:
         registry: "RegistryService",
         arxiv_provider: "ArxivProvider",
         llm_service: Optional["LLMService"] = None,
+        extra_providers: Optional["dict[PaperSource, DiscoveryProvider]"] = None,
+        query_expander: Optional["QueryExpander"] = None,
     ) -> "MonitoringRunner":
         """Convenience factory wiring the standard collaborators.
 
@@ -200,6 +210,23 @@ class MonitoringRunner:
             llm_service: Optional ``LLMService`` used to build a
                 ``RelevanceScorer``. When ``None``, papers are returned
                 unscored (backward-compatible with Week-1 behavior).
+            extra_providers: Optional mapping of ``PaperSource`` to
+                ``DiscoveryProvider`` for multi-provider search beyond
+                arXiv (e.g., Semantic Scholar, OpenAlex, HuggingFace).
+                When supplied, a :class:`MultiProviderMonitor` is
+                constructed with arXiv + the extras; queries fan out
+                across all providers in parallel. When ``None``
+                (default), the legacy single-provider
+                :class:`ArxivMonitor` is used (backward compatible).
+                (Tier 1: monitoring expanded search, Issue #139.)
+            query_expander: Optional :class:`QueryExpander` for
+                LLM-based query expansion. When supplied alongside
+                ``extra_providers`` (or even alone), each subscription's
+                literal query is expanded into N variants via Gemini
+                Flash before the provider fan-out — broadens discovery
+                coverage at ~1 cheap LLM call per subscription per
+                cycle. When ``None``, only the literal subscription
+                query is searched. (Tier 1.)
 
         Returns:
             A fully-wired, initialized ``MonitoringRunner`` ready for
@@ -222,7 +249,36 @@ class MonitoringRunner:
         db_path = Path(db_path)  # accept str | Path; coerce for downstream typing
         sub_mgr = SubscriptionManager(db_path)
         sub_mgr.initialize()
-        monitor = ArxivMonitor(provider=arxiv_provider, registry=registry)
+
+        # Tier 1: choose monitor implementation based on what was supplied.
+        # If the caller provided extra providers OR a query expander, build
+        # the broader-discovery MultiProviderMonitor. Otherwise keep the
+        # legacy single-provider ArxivMonitor for backward compatibility.
+        monitor: ArxivMonitor | MultiProviderMonitor
+        if extra_providers or query_expander is not None:
+            providers: dict[PaperSource, DiscoveryProvider] = {
+                PaperSource.ARXIV: arxiv_provider,
+            }
+            if extra_providers:
+                # Defensive copy to isolate from caller mutations; reject
+                # an attempt to override the canonical ArXiv provider via
+                # the extras dict (caller should pass the override as
+                # ``arxiv_provider`` instead).
+                for src, provider in extra_providers.items():
+                    if src is PaperSource.ARXIV:
+                        raise ValueError(
+                            "extra_providers must not include "
+                            "PaperSource.ARXIV; pass arxiv_provider directly"
+                        )
+                    providers[src] = provider
+            monitor = MultiProviderMonitor(
+                providers=providers,
+                registry=registry,
+                query_expander=query_expander,
+            )
+        else:
+            monitor = ArxivMonitor(provider=arxiv_provider, registry=registry)
+
         repo = MonitoringRunRepository(db_path)
         repo.initialize()
         scorer = RelevanceScorer(llm_service) if llm_service is not None else None

--- a/src/services/intelligence/monitoring/runner.py
+++ b/src/services/intelligence/monitoring/runner.py
@@ -255,11 +255,14 @@ class MonitoringRunner:
         # the broader-discovery MultiProviderMonitor. Otherwise keep the
         # legacy single-provider ArxivMonitor for backward compatibility.
         monitor: ArxivMonitor | MultiProviderMonitor
-        if extra_providers or query_expander is not None:
+        # H-C6: use ``is not None`` instead of truthiness so that an
+        # explicit ``extra_providers={}`` (empty dict) still builds
+        # MultiProviderMonitor — the caller explicitly opted in.
+        if extra_providers is not None or query_expander is not None:
             providers: dict[PaperSource, DiscoveryProvider] = {
                 PaperSource.ARXIV: arxiv_provider,
             }
-            if extra_providers:
+            if extra_providers is not None:
                 # Defensive copy to isolate from caller mutations; reject
                 # an attempt to override the canonical ArXiv provider via
                 # the extras dict (caller should pass the override as
@@ -453,7 +456,18 @@ class MonitoringRunner:
         level (Fail-Soft Boundary across independent peers).
         """
         try:
-            result = await self._monitor.check(subscription)
+            # H-S1: pass budget counters to MultiProviderMonitor so the
+            # expander call is gated against the cycle's LLM budget.
+            # ArxivMonitor.check does not accept these kwargs; duck-type
+            # on the concrete type so we only pass them when meaningful.
+            if isinstance(self._monitor, MultiProviderMonitor):
+                result = await self._monitor.check(
+                    subscription,
+                    llm_calls_used=llm_calls_used,
+                    max_calls=MAX_LLM_CALLS_PER_CYCLE,
+                )
+            else:
+                result = await self._monitor.check(subscription)
             run = result.run
         except Exception as exc:
             # Defensive envelope: ArxivMonitor.check is documented to

--- a/src/services/intelligence/monitoring/runner.py
+++ b/src/services/intelligence/monitoring/runner.py
@@ -375,15 +375,22 @@ class MonitoringRunner:
         # We need a PaperMetadata-compatible object to pass to the scorer.
         # MonitoringPaperRecord carries title + url; reconstruct a minimal
         # PaperMetadata so the scorer can build its prompt. PaperMetadata
-        # requires a valid HttpUrl, so provide a fallback when the paper
-        # record has no URL (common for papers registered without one).
+        # requires a valid HttpUrl; skip scoring rather than fabricating a
+        # URL for non-arXiv papers that have no provenance (C-2).
         from src.models.paper import PaperMetadata
 
-        paper_url = paper.url or f"https://arxiv.org/abs/{paper.paper_id}"
+        if paper.url is None:
+            logger.info(
+                "monitoring_relevance_score_skipped_no_url",
+                subscription_id=subscription.subscription_id,
+                paper_id=paper.paper_id,
+            )
+            return
+
         paper_meta = PaperMetadata(
             paper_id=paper.paper_id,
             title=paper.title,
-            url=paper_url,  # type: ignore[arg-type]
+            url=paper.url,  # type: ignore[arg-type]
         )
 
         async with sem:

--- a/tests/unit/cli/test_monitor_cli.py
+++ b/tests/unit/cli/test_monitor_cli.py
@@ -495,6 +495,9 @@ class TestBuildHelpers:
         from src.services.intelligence.monitoring.runner import MonitoringRunner
 
         monkeypatch.setenv(_DB_ENV_VAR, str(tmp_path / "m.db"))
+        # Without LLM keys, the legacy single-arxiv path runs.
+        monkeypatch.delenv("LLM_API_KEY", raising=False)
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
         # Stub ArxivProvider + RegistryService so the runner builds without
         # touching real settings / disk lock files.
         with (
@@ -507,6 +510,105 @@ class TestBuildHelpers:
         # H-T4: Assert isinstance and that public delegation method works.
         assert isinstance(runner_obj, MonitoringRunner)
         assert runner_obj.list_subscriptions() == []
+
+    def test_build_runner_with_llm_key_wires_tier1(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Tier 1 (Issue #139): when LLM_API_KEY is in the env,
+        ``_build_runner`` constructs the MultiProviderMonitor with
+        OpenAlex + HuggingFace (S2 only when its own key is present)
+        plus a QueryExpander.
+        """
+        from src.cli.monitor import _build_runner
+        from src.services.intelligence.monitoring.multi_provider_monitor import (
+            MultiProviderMonitor,
+        )
+
+        monkeypatch.setenv(_DB_ENV_VAR, str(tmp_path / "m.db"))
+        monkeypatch.setenv("LLM_API_KEY", "test-llm-key")
+        monkeypatch.delenv("SEMANTIC_SCHOLAR_API_KEY", raising=False)
+        with (
+            patch("src.services.providers.arxiv.ArxivProvider"),
+            patch("src.services.registry.service.RegistryService"),
+        ):
+            runner_obj = _build_runner()
+        # Tier 1 monitor selected
+        assert isinstance(runner_obj._monitor, MultiProviderMonitor)
+        # Without S2 key: no S2 in extras
+        from src.services.intelligence.monitoring.models import PaperSource
+
+        assert PaperSource.OPENALEX in runner_obj._monitor._providers
+        assert PaperSource.HUGGINGFACE in runner_obj._monitor._providers
+        assert PaperSource.SEMANTIC_SCHOLAR not in runner_obj._monitor._providers
+        # Expander wired
+        assert runner_obj._monitor._query_expander is not None
+
+    def test_build_runner_with_llm_and_s2_keys_includes_s2(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Tier 1: SEMANTIC_SCHOLAR_API_KEY enables Semantic Scholar."""
+        from src.cli.monitor import _build_runner
+
+        monkeypatch.setenv(_DB_ENV_VAR, str(tmp_path / "m.db"))
+        monkeypatch.setenv("LLM_API_KEY", "test-llm-key")
+        monkeypatch.setenv("SEMANTIC_SCHOLAR_API_KEY", "test-s2-key")
+        with (
+            patch("src.services.providers.arxiv.ArxivProvider"),
+            patch("src.services.registry.service.RegistryService"),
+        ):
+            runner_obj = _build_runner()
+        from src.services.intelligence.monitoring.models import PaperSource
+
+        assert PaperSource.SEMANTIC_SCHOLAR in runner_obj._monitor._providers
+
+    def test_build_runner_llm_init_failure_falls_back_to_legacy(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Tier 1: LLMService construction failure -> legacy single-arxiv
+        wiring (graceful degradation, no crash).
+        """
+        from src.cli.monitor import _build_runner
+        from src.services.intelligence.monitoring.arxiv_monitor import ArxivMonitor
+
+        monkeypatch.setenv(_DB_ENV_VAR, str(tmp_path / "m.db"))
+        monkeypatch.setenv("LLM_API_KEY", "test-llm-key")
+        with (
+            patch("src.services.providers.arxiv.ArxivProvider"),
+            patch("src.services.registry.service.RegistryService"),
+            patch(
+                "src.services.llm.service.LLMService",
+                side_effect=RuntimeError("bad llm config"),
+            ),
+        ):
+            runner_obj = _build_runner()
+        # LLM init failed → no scorer + legacy ArxivMonitor (no tier 1)
+        assert isinstance(runner_obj._monitor, ArxivMonitor)
+        assert runner_obj._scorer is None
+
+    def test_build_runner_tier1_provider_init_failure_falls_back(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Tier 1: extra-provider construction failure -> legacy
+        ArxivMonitor (LLM scorer still wired).
+        """
+        from src.cli.monitor import _build_runner
+        from src.services.intelligence.monitoring.arxiv_monitor import ArxivMonitor
+
+        monkeypatch.setenv(_DB_ENV_VAR, str(tmp_path / "m.db"))
+        monkeypatch.setenv("LLM_API_KEY", "test-llm-key")
+        monkeypatch.delenv("SEMANTIC_SCHOLAR_API_KEY", raising=False)
+        with (
+            patch("src.services.providers.arxiv.ArxivProvider"),
+            patch("src.services.registry.service.RegistryService"),
+            patch(
+                "src.services.providers.openalex.OpenAlexProvider",
+                side_effect=RuntimeError("openalex init failed"),
+            ),
+        ):
+            runner_obj = _build_runner()
+        # Extras init failed → legacy ArxivMonitor (scorer still works)
+        assert isinstance(runner_obj._monitor, ArxivMonitor)
+        assert runner_obj._scorer is not None
 
     def test_add_command_db_raises_exits_nonzero(
         self,

--- a/tests/unit/cli/test_monitor_cli.py
+++ b/tests/unit/cli/test_monitor_cli.py
@@ -714,3 +714,178 @@ class TestDigestFailedRunGate:
         )
         assert result.exit_code == 0, result.output
         assert "Digest written" in result.output
+
+
+# ---------------------------------------------------------------------------
+# C-3 regression: API key must NOT leak via LLM-init exception log
+# ---------------------------------------------------------------------------
+
+
+class TestApiKeyLeakageRegression:
+    """C-3: Pydantic ValidationError on LLM init must NOT embed API key in logs."""
+
+    def test_init_llm_failure_does_not_leak_api_key_to_logs(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """When LLMService raises (e.g., bad config embedding the key),
+        the ``error_type`` field is logged instead of the exception message
+        so the raw API key never appears in the log stream.
+        """
+        import structlog
+        import structlog.testing
+
+        from src.cli import monitor as monitor_module
+
+        monkeypatch.setattr(monitor_module, "logger", structlog.get_logger())
+        monkeypatch.setenv(_DB_ENV_VAR, str(tmp_path / "m.db"))
+        monkeypatch.setenv("LLM_API_KEY", "test-api-key-12345")
+
+        # The exception message intentionally embeds the key to simulate
+        # Pydantic's ValidationError format.
+        with (
+            patch("src.services.providers.arxiv.ArxivProvider"),
+            patch("src.services.registry.service.RegistryService"),
+            patch(
+                "src.services.llm.service.LLMService",
+                side_effect=ValueError("validation error: test-api-key-12345"),
+            ),
+        ):
+            with structlog.testing.capture_logs() as logs:
+                from src.cli.monitor import _build_runner
+
+                _build_runner()
+
+        # The api key must not appear in any log field value.
+        for log_entry in logs:
+            for val in log_entry.values():
+                assert "test-api-key-12345" not in str(
+                    val
+                ), f"API key leaked in log field: {val}"
+
+        # Confirm error_type (not error) was logged.
+        init_failed_events = [
+            e for e in logs if e.get("event") == "monitor_cli_llm_init_failed"
+        ]
+        assert len(init_failed_events) == 1
+        assert "error_type" in init_failed_events[0]
+        assert "error" not in init_failed_events[0]
+
+
+# ---------------------------------------------------------------------------
+# H-S4 regression: whitespace-only env vars must not enable LLM/S2 providers
+# ---------------------------------------------------------------------------
+
+
+class TestWhitespaceEnvVarRegression:
+    """H-S4: whitespace-only API key env vars must fall back to legacy."""
+
+    def test_whitespace_only_llm_api_key_falls_back_to_legacy(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A whitespace-only LLM_API_KEY must behave identically to absent."""
+        from src.cli.monitor import _build_runner
+        from src.services.intelligence.monitoring.arxiv_monitor import ArxivMonitor
+
+        monkeypatch.setenv(_DB_ENV_VAR, str(tmp_path / "m.db"))
+        monkeypatch.setenv("LLM_API_KEY", "   ")  # whitespace only
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+
+        with (
+            patch("src.services.providers.arxiv.ArxivProvider"),
+            patch("src.services.registry.service.RegistryService"),
+        ):
+            runner_obj = _build_runner()
+
+        # No LLM service wired → legacy ArxivMonitor fallback
+        assert isinstance(runner_obj._monitor, ArxivMonitor)
+        assert runner_obj._scorer is None
+
+    def test_whitespace_only_s2_key_skips_s2_provider(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A whitespace-only SEMANTIC_SCHOLAR_API_KEY must not wire S2."""
+        from src.cli.monitor import _build_runner
+        from src.services.intelligence.monitoring.models import PaperSource
+        from src.services.intelligence.monitoring.multi_provider_monitor import (
+            MultiProviderMonitor,
+        )
+
+        monkeypatch.setenv(_DB_ENV_VAR, str(tmp_path / "m.db"))
+        monkeypatch.setenv("LLM_API_KEY", "test-llm-key")
+        monkeypatch.setenv("SEMANTIC_SCHOLAR_API_KEY", "   ")  # whitespace only
+
+        with (
+            patch("src.services.providers.arxiv.ArxivProvider"),
+            patch("src.services.registry.service.RegistryService"),
+        ):
+            runner_obj = _build_runner()
+
+        assert isinstance(runner_obj._monitor, MultiProviderMonitor)
+        assert PaperSource.SEMANTIC_SCHOLAR not in runner_obj._monitor._providers
+
+
+# ---------------------------------------------------------------------------
+# C-4 regression: provider error messages must be truncated in logs
+# ---------------------------------------------------------------------------
+
+
+class TestProviderErrorTruncationRegression:
+    """C-4: long error messages from providers must be truncated in logs."""
+
+    @pytest.mark.asyncio
+    async def test_check_provider_failure_truncates_long_error_in_log(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A 10KB exception message from a provider must be truncated to
+        ≤520 chars in the structured log (repr adds ~2 extra chars for quotes).
+        """
+        import structlog
+        import structlog.testing
+
+        from src.services.intelligence.monitoring import (
+            multi_provider_monitor as mpm_module,
+        )
+        from src.services.intelligence.monitoring.models import (
+            PaperSource,
+            ResearchSubscription,
+            SubscriptionStatus,
+        )
+        from src.services.intelligence.monitoring.multi_provider_monitor import (
+            MultiProviderMonitor,
+        )
+        from unittest.mock import AsyncMock, MagicMock
+
+        monkeypatch.setattr(mpm_module, "logger", structlog.get_logger())
+
+        long_error = "X" * 10_000  # 10KB error message
+        provider = MagicMock()
+        provider.search = AsyncMock(side_effect=RuntimeError(long_error))
+
+        registry = MagicMock()
+        resolve_result = MagicMock()
+        resolve_result.matched = False
+        registry.resolve_identity = MagicMock(return_value=resolve_result)
+        registry.register_paper = MagicMock()
+
+        sub = ResearchSubscription(
+            subscription_id="sub-trunc",
+            user_id="u1",
+            name="Sub",
+            query="test query",
+            status=SubscriptionStatus.ACTIVE,
+        )
+
+        monitor = MultiProviderMonitor(
+            providers={PaperSource.ARXIV: provider},
+            registry=registry,
+        )
+
+        with structlog.testing.capture_logs() as logs:
+            await monitor.check(sub)
+
+        failed_events = [
+            e for e in logs if e.get("event") == "monitor_provider_search_failed"
+        ]
+        assert len(failed_events) >= 1
+        error_val = failed_events[0]["error"]
+        assert len(error_val) <= 520, f"Error was not truncated: len={len(error_val)}"

--- a/tests/unit/services/intelligence/monitoring/test_multi_provider_monitor.py
+++ b/tests/unit/services/intelligence/monitoring/test_multi_provider_monitor.py
@@ -21,6 +21,16 @@ Covers:
   neither is provided (backward compatible).
 - ``MonitoringRunner.from_paths`` rejects an attempt to override the
   arXiv provider via ``extra_providers``.
+- H-S1: expansion budget gate.
+- H-S2: variant validation + rejection.
+- H-S5: topic-build inside try/except.
+- H-C5: expander failure → PARTIAL status.
+- H-C6: empty-dict extra_providers builds MultiProviderMonitor.
+- H-T1: capture_logs assertions on failure paths.
+- H-T3: strong paper_id assertion.
+- H-T5: register_paper.call_count assertion.
+- H-T6: Pydantic strict-mode tests.
+- L-2: exact default field values.
 
 Note: ``ArxivMonitorResult`` is intentionally reused as the return DTO
 so both monitors are duck-type compatible from the runner's POV.
@@ -28,13 +38,17 @@ so both monitors are duck-type compatible from the runner's POV.
 
 from __future__ import annotations
 
+import structlog
+import structlog.testing
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from src.models.paper import PaperMetadata
+from src.services.intelligence.monitoring import multi_provider_monitor as mpm_module
 from src.services.intelligence.monitoring.arxiv_monitor import ArxivMonitor
 from src.services.intelligence.monitoring.models import (
+    MAX_PAPERS_PER_CYCLE,
     MonitoringRunStatus,
     PaperSource,
     ResearchSubscription,
@@ -43,6 +57,7 @@ from src.services.intelligence.monitoring.models import (
 from src.services.intelligence.monitoring.multi_provider_monitor import (
     MultiProviderMonitor,
     MultiProviderMonitorConfig,
+    _DEFAULT_MAX_QUERY_VARIANTS,
 )
 from src.services.intelligence.monitoring.runner import MonitoringRunner
 
@@ -155,10 +170,12 @@ def test_init_defensive_copies_providers_dict() -> None:
 
 
 def test_config_with_defaults_all_fields_set() -> None:
-    """Smoke-test the config helper -- all knobs have sane defaults."""
+    """Smoke-test the config helper -- all knobs have sane defaults.
+    L-2: pin exact default values so accidental changes trip the test.
+    """
     cfg = MultiProviderMonitorConfig.with_defaults()
-    assert cfg.max_papers_per_cycle > 0
-    assert cfg.max_query_variants > 0
+    assert cfg.max_papers_per_cycle == MAX_PAPERS_PER_CYCLE
+    assert cfg.max_query_variants == _DEFAULT_MAX_QUERY_VARIANTS
     assert cfg.topic_slug_prefix == "monitor"
 
 
@@ -169,7 +186,9 @@ def test_config_with_defaults_all_fields_set() -> None:
 
 @pytest.mark.asyncio
 async def test_check_paused_subscription_short_circuits() -> None:
-    """Paused subscriptions return SUCCESS without touching providers."""
+    """Paused subscriptions return SUCCESS without touching providers.
+    H-M9: also assert new_papers == [] and deduplicated_papers == [].
+    """
     sub = _make_subscription(status=SubscriptionStatus.PAUSED)
     arxiv = _make_provider(return_papers=[_make_paper("p1")])
     monitor = MultiProviderMonitor(
@@ -180,6 +199,9 @@ async def test_check_paused_subscription_short_circuits() -> None:
     assert result.run.status is MonitoringRunStatus.SUCCESS
     assert result.run.papers_seen == 0
     arxiv.search.assert_not_called()
+    # H-M9: verify empty paper lists for paused subscriptions
+    assert result.new_papers == []
+    assert result.deduplicated_papers == []
 
 
 # ---------------------------------------------------------------------------
@@ -238,7 +260,9 @@ async def test_check_with_expander_searches_all_variants() -> None:
 
 @pytest.mark.asyncio
 async def test_check_expander_failure_falls_back_to_literal_query() -> None:
-    """If expander.expand() raises, fall back to the literal query (Fail-Soft)."""
+    """If expander.expand() raises, fall back to the literal query (Fail-Soft).
+    H-C5: expander failure sets run status to PARTIAL.
+    """
     sub = _make_subscription(query="LLM agents")
     expander = MagicMock()
     expander.expand = AsyncMock(side_effect=RuntimeError("LLM down"))
@@ -248,15 +272,19 @@ async def test_check_expander_failure_falls_back_to_literal_query() -> None:
         registry=_make_registry(),
         query_expander=expander,
     )
-    await monitor.check(sub)
+    result = await monitor.check(sub)
     # Despite the expander failure, the cycle still searches the literal query.
     assert arxiv.search.await_count == 1
     assert arxiv.search.await_args.args[0].query == "LLM agents"
+    # H-C5: expander degradation marks the run PARTIAL.
+    assert result.run.status is MonitoringRunStatus.PARTIAL
 
 
 @pytest.mark.asyncio
 async def test_check_expander_returns_empty_falls_back_to_literal() -> None:
-    """If expander returns an empty list, fall back to literal query."""
+    """If expander returns an empty list, fall back to literal query.
+    H-C5: empty expansion is treated as degraded → PARTIAL.
+    """
     sub = _make_subscription(query="LLM agents")
     expander = MagicMock()
     expander.expand = AsyncMock(return_value=[])  # pathological case
@@ -266,9 +294,11 @@ async def test_check_expander_returns_empty_falls_back_to_literal() -> None:
         registry=_make_registry(),
         query_expander=expander,
     )
-    await monitor.check(sub)
+    result = await monitor.check(sub)
     assert arxiv.search.await_count == 1
     assert arxiv.search.await_args.args[0].query == "LLM agents"
+    # H-C5: empty result is degraded → PARTIAL.
+    assert result.run.status is MonitoringRunStatus.PARTIAL
 
 
 # ---------------------------------------------------------------------------
@@ -384,6 +414,29 @@ async def test_check_dedups_papers_by_paper_id_across_providers() -> None:
     )
     result = await monitor.check(sub)
     # Only ONE paper despite both providers returning it.
+    assert result.run.papers_seen == 1
+
+
+@pytest.mark.asyncio
+async def test_check_dedups_same_paper_from_two_query_variants() -> None:
+    """If two query variants return the same paper_id (via the same provider),
+    it appears only once in the final result set (exercises the dedup continue branch).
+    """
+    sub = _make_subscription(query="original")
+    shared = _make_paper("shared-id", title="Same paper, two variants")
+    expander = MagicMock()
+    expander.expand = AsyncMock(return_value=["original", "variant1"])
+    # Return the same paper for both queries.
+    arxiv = _make_provider(return_papers=[shared])
+    monitor = MultiProviderMonitor(
+        providers={PaperSource.ARXIV: arxiv},
+        registry=_make_registry(),
+        query_expander=expander,
+    )
+    result = await monitor.check(sub)
+    # 2 queries × 1 provider = 2 search calls, each returning the same paper.
+    assert arxiv.search.await_count == 2
+    # Dedup yields only 1 unique paper.
     assert result.run.papers_seen == 1
 
 
@@ -553,3 +606,395 @@ def test_from_paths_rejects_arxiv_in_extra_providers(tmp_path) -> None:
             arxiv_provider=MagicMock(),
             extra_providers={PaperSource.ARXIV: _make_provider()},
         )
+
+
+# ---------------------------------------------------------------------------
+# H-C6: empty-dict extra_providers builds MultiProviderMonitor
+# ---------------------------------------------------------------------------
+
+
+def test_from_paths_with_empty_dict_extra_providers_builds_multi_provider(
+    tmp_path,
+) -> None:
+    """H-C6: extra_providers={} (empty dict, not None) explicitly opts the
+    caller into MultiProviderMonitor. The is-not-None check must honour this.
+    """
+    db_path = tmp_path / "monitoring.db"
+    runner = MonitoringRunner.from_paths(
+        db_path=db_path,
+        registry=MagicMock(),
+        arxiv_provider=MagicMock(),
+        extra_providers={},  # empty but explicitly provided
+    )
+    assert isinstance(runner._monitor, MultiProviderMonitor)
+    # Only arXiv (from arxiv_provider); the empty extras dict adds nothing.
+    assert PaperSource.ARXIV in runner._monitor._providers
+    assert len(runner._monitor._providers) == 1
+
+
+# ---------------------------------------------------------------------------
+# H-T1: capture_logs assertions on failure paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_check_query_expansion_failed_emits_log(monkeypatch) -> None:
+    """H-T1: monitor_query_expansion_failed is emitted when expander raises."""
+    sub = _make_subscription(query="LLM agents")
+    expander = MagicMock()
+    expander.expand = AsyncMock(side_effect=RuntimeError("LLM down"))
+    arxiv = _make_provider()
+    monkeypatch.setattr(mpm_module, "logger", structlog.get_logger())
+    monitor = MultiProviderMonitor(
+        providers={PaperSource.ARXIV: arxiv},
+        registry=_make_registry(),
+        query_expander=expander,
+    )
+    with structlog.testing.capture_logs() as logs:
+        await monitor.check(sub)
+    events = [e for e in logs if e.get("event") == "monitor_query_expansion_failed"]
+    assert len(events) == 1
+    assert events[0].get("subscription_id") == sub.subscription_id
+
+
+@pytest.mark.asyncio
+async def test_check_provider_search_failed_emits_log(monkeypatch) -> None:
+    """H-T1: monitor_provider_search_failed is emitted on provider error."""
+    sub = _make_subscription()
+    arxiv = _make_provider(raise_on_search=ConnectionError("timeout"))
+    monkeypatch.setattr(mpm_module, "logger", structlog.get_logger())
+    monitor = MultiProviderMonitor(
+        providers={PaperSource.ARXIV: arxiv},
+        registry=_make_registry(),
+    )
+    with structlog.testing.capture_logs() as logs:
+        result = await monitor.check(sub)
+    events = [e for e in logs if e.get("event") == "monitor_provider_search_failed"]
+    assert len(events) == 1
+    assert result.run.status is MonitoringRunStatus.PARTIAL
+
+
+@pytest.mark.asyncio
+async def test_check_identity_resolution_error_emits_log(monkeypatch) -> None:
+    """H-T1: monitor_identity_resolution_error is emitted on resolve failure."""
+    sub = _make_subscription()
+    arxiv = _make_provider(return_papers=[_make_paper("p1")])
+    registry = _make_registry(resolve_side_effect=RuntimeError("bad row"))
+    monkeypatch.setattr(mpm_module, "logger", structlog.get_logger())
+    monitor = MultiProviderMonitor(
+        providers={PaperSource.ARXIV: arxiv},
+        registry=registry,
+    )
+    with structlog.testing.capture_logs() as logs:
+        await monitor.check(sub)
+    events = [e for e in logs if e.get("event") == "monitor_identity_resolution_error"]
+    assert len(events) == 1
+    assert events[0].get("paper_id") == "p1"
+
+
+@pytest.mark.asyncio
+async def test_check_registry_write_error_emits_log(monkeypatch) -> None:
+    """H-T1: monitor_registry_write_error is emitted on register_paper failure."""
+    sub = _make_subscription()
+    arxiv = _make_provider(return_papers=[_make_paper("p1")])
+    registry = _make_registry(register_side_effect=RuntimeError("disk full"))
+    monkeypatch.setattr(mpm_module, "logger", structlog.get_logger())
+    monitor = MultiProviderMonitor(
+        providers={PaperSource.ARXIV: arxiv},
+        registry=registry,
+    )
+    with structlog.testing.capture_logs() as logs:
+        await monitor.check(sub)
+    events = [e for e in logs if e.get("event") == "monitor_registry_write_error"]
+    assert len(events) == 1
+    assert events[0].get("paper_id") == "p1"
+
+
+# ---------------------------------------------------------------------------
+# H-S1: LLM budget gate for query expansion
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_check_expansion_skipped_when_budget_exhausted(monkeypatch) -> None:
+    """H-S1: When llm_calls_used[0] >= max_calls, the expander is not called
+    and monitor_expansion_budget_exhausted is logged.
+    """
+    sub = _make_subscription(query="agents")
+    expander = MagicMock()
+    expander.expand = AsyncMock(return_value=["agents", "variant"])
+    arxiv = _make_provider()
+    monkeypatch.setattr(mpm_module, "logger", structlog.get_logger())
+    monitor = MultiProviderMonitor(
+        providers={PaperSource.ARXIV: arxiv},
+        registry=_make_registry(),
+        query_expander=expander,
+    )
+    llm_calls_used = [5]  # already at limit
+    with structlog.testing.capture_logs() as logs:
+        result = await monitor.check(sub, llm_calls_used=llm_calls_used, max_calls=5)
+    # Expander must NOT have been called.
+    expander.expand.assert_not_awaited()
+    # Should fall back to literal query (1 search).
+    assert arxiv.search.await_count == 1
+    # Status is PARTIAL due to budget degradation.
+    assert result.run.status is MonitoringRunStatus.PARTIAL
+    budget_events = [
+        e for e in logs if e.get("event") == "monitor_expansion_budget_exhausted"
+    ]
+    assert len(budget_events) == 1
+
+
+@pytest.mark.asyncio
+async def test_check_expansion_increments_budget_counter_on_success() -> None:
+    """H-S1: Successful expander call increments llm_calls_used by 1."""
+    sub = _make_subscription(query="agents")
+    expander = MagicMock()
+    expander.expand = AsyncMock(return_value=["agents", "variant"])
+    arxiv = _make_provider()
+    monitor = MultiProviderMonitor(
+        providers={PaperSource.ARXIV: arxiv},
+        registry=_make_registry(),
+        query_expander=expander,
+    )
+    llm_calls_used = [0]
+    await monitor.check(sub, llm_calls_used=llm_calls_used, max_calls=100)
+    # Counter incremented by 1 for the expansion call.
+    assert llm_calls_used[0] == 1
+
+
+# ---------------------------------------------------------------------------
+# H-S2: variant validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_check_variant_with_injection_chars_is_rejected(monkeypatch) -> None:
+    """H-S2: A variant containing injection-risk characters is dropped and
+    monitor_expansion_variant_rejected is logged. The cycle continues with
+    the valid variants.
+    """
+    sub = _make_subscription(query="agents")
+    expander = MagicMock()
+    # First variant is valid, second contains shell injection.
+    expander.expand = AsyncMock(return_value=["agents", "agents && rm -rf /"])
+    arxiv = _make_provider()
+    monkeypatch.setattr(mpm_module, "logger", structlog.get_logger())
+    monitor = MultiProviderMonitor(
+        providers={PaperSource.ARXIV: arxiv},
+        registry=_make_registry(),
+        query_expander=expander,
+    )
+    with structlog.testing.capture_logs() as logs:
+        result = await monitor.check(sub)
+
+    # Only valid variant searched.
+    assert arxiv.search.await_count == 1
+    topic = arxiv.search.await_args.args[0]
+    assert topic.query == "agents"
+    # Rejection logged for the bad variant.
+    reject_events = [
+        e for e in logs if e.get("event") == "monitor_expansion_variant_rejected"
+    ]
+    assert len(reject_events) == 1
+    # Cycle must succeed with the valid variant.
+    assert result.run.status is MonitoringRunStatus.SUCCESS
+
+
+@pytest.mark.asyncio
+async def test_check_all_variants_rejected_falls_back_to_literal(monkeypatch) -> None:
+    """H-S2: If ALL expanded variants fail validation, the literal query is
+    used and the run is marked PARTIAL.
+    """
+    sub = _make_subscription(query="agents")
+    expander = MagicMock()
+    # All variants contain injection chars.
+    expander.expand = AsyncMock(
+        return_value=["agents && rm /", "agents | cat /etc/passwd"]
+    )
+    arxiv = _make_provider()
+    monkeypatch.setattr(mpm_module, "logger", structlog.get_logger())
+    monitor = MultiProviderMonitor(
+        providers={PaperSource.ARXIV: arxiv},
+        registry=_make_registry(),
+        query_expander=expander,
+    )
+    with structlog.testing.capture_logs() as logs:
+        result = await monitor.check(sub)
+
+    # Fall back to literal query.
+    assert arxiv.search.await_count == 1
+    assert arxiv.search.await_args.args[0].query == "agents"
+    # Both variants should have been rejected.
+    reject_events = [
+        e for e in logs if e.get("event") == "monitor_expansion_variant_rejected"
+    ]
+    assert len(reject_events) == 2
+    # All rejected → degraded → PARTIAL.
+    assert result.run.status is MonitoringRunStatus.PARTIAL
+
+
+# ---------------------------------------------------------------------------
+# H-S5: topic build inside per-provider try/except
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_check_topic_build_failure_treated_as_provider_failure() -> None:
+    """H-S5: If _build_topic_for_query raises (e.g., because ResearchTopic
+    validation fails on a bad variant), the cycle continues for other variants
+    and the run is marked PARTIAL — it does NOT kill the whole subscription.
+
+    We simulate the scenario by patching _build_topic_for_query to raise on
+    the first call, then succeed on the second.
+    """
+    sub = _make_subscription(query="agents")
+    expander = MagicMock()
+    expander.expand = AsyncMock(return_value=["bad-variant", "good-variant"])
+    arxiv = _make_provider(return_papers=[_make_paper("p1")])
+    monitor = MultiProviderMonitor(
+        providers={PaperSource.ARXIV: arxiv},
+        registry=_make_registry(),
+        query_expander=expander,
+    )
+
+    call_count = [0]
+    original_build = monitor._build_topic_for_query
+
+    def flaky_build(subscription, variant):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            raise ValueError("Bad ResearchTopic variant")
+        return original_build(subscription, variant)
+
+    monitor._build_topic_for_query = flaky_build  # type: ignore[method-assign]
+
+    result = await monitor.check(sub)
+    # Second variant still searched (fail-soft).
+    assert arxiv.search.await_count == 1
+    # Failure from topic build → partial.
+    assert result.run.status is MonitoringRunStatus.PARTIAL
+
+
+# ---------------------------------------------------------------------------
+# H-M10: 2-paper test for registry failure continues for the other paper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_check_registry_write_error_continues_for_second_paper() -> None:
+    """H-M10: When register_paper raises for the first paper, the cycle
+    continues to process the second paper (2-paper variant of the single-paper
+    test).
+    """
+    sub = _make_subscription()
+    p1 = _make_paper("p1")
+    p2 = _make_paper("p2")
+    arxiv = _make_provider(return_papers=[p1, p2])
+
+    call_count = [0]
+
+    def selective_fail(*args, **kwargs):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            raise RuntimeError("disk full on first paper")
+        # Second call succeeds (no return value needed for register_paper).
+
+    registry = _make_registry()
+    registry.register_paper = MagicMock(side_effect=selective_fail)
+
+    monitor = MultiProviderMonitor(
+        providers={PaperSource.ARXIV: arxiv},
+        registry=registry,
+    )
+    result = await monitor.check(sub)
+    assert result.run.status is MonitoringRunStatus.PARTIAL
+    # First paper failed registry write → not in new_papers.
+    # Second paper succeeded → in new_papers.
+    assert result.run.papers_new == 1
+    assert result.new_papers[0].paper_id == "p2"
+
+
+# ---------------------------------------------------------------------------
+# H-T6: Pydantic strict-mode tests for MultiProviderMonitorConfig
+# ---------------------------------------------------------------------------
+
+
+def test_config_rejects_extra_fields() -> None:
+    """H-T6: extra='forbid' must reject unknown fields."""
+    import pydantic
+
+    with pytest.raises(pydantic.ValidationError, match="Extra inputs"):
+        MultiProviderMonitorConfig(unknown_field="oops")  # type: ignore[call-arg]
+
+
+def test_config_rejects_non_int_strict_mode() -> None:
+    """H-T6: strict=True must reject float where int is expected."""
+    import pydantic
+
+    with pytest.raises(pydantic.ValidationError):
+        MultiProviderMonitorConfig(max_papers_per_cycle=1.5)  # type: ignore[arg-type]
+
+
+def test_config_rejects_negative_max_papers_per_cycle() -> None:
+    """H-T6: ge=1 rejects zero or negative max_papers_per_cycle."""
+    import pydantic
+
+    with pytest.raises(pydantic.ValidationError, match="greater than or equal"):
+        MultiProviderMonitorConfig(max_papers_per_cycle=0)
+
+
+def test_config_rejects_max_query_variants_below_one() -> None:
+    """H-T6: ge=1 rejects zero or negative max_query_variants."""
+    import pydantic
+
+    with pytest.raises(pydantic.ValidationError, match="greater than or equal"):
+        MultiProviderMonitorConfig(max_query_variants=0)
+
+
+def test_config_rejects_max_papers_above_cap() -> None:
+    """H-T6: le=MAX_PAPERS_PER_CYCLE rejects values above the project cap."""
+    import pydantic
+
+    with pytest.raises(pydantic.ValidationError, match="less than or equal"):
+        MultiProviderMonitorConfig(max_papers_per_cycle=MAX_PAPERS_PER_CYCLE + 1)
+
+
+def test_config_rejects_max_query_variants_above_ten() -> None:
+    """H-T6: le=10 rejects max_query_variants above 10."""
+    import pydantic
+
+    with pytest.raises(pydantic.ValidationError, match="less than or equal"):
+        MultiProviderMonitorConfig(max_query_variants=11)
+
+
+# ---------------------------------------------------------------------------
+# H-C4: build_tier1_extras unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_build_tier1_extras_returns_none_when_no_llm() -> None:
+    """H-C4: build_tier1_extras returns (None, None) when llm_service is None."""
+    from src.services.intelligence.monitoring._tier1_factory import build_tier1_extras
+
+    extra_providers, query_expander = build_tier1_extras(None)
+    assert extra_providers is None
+    assert query_expander is None
+
+
+def test_build_tier1_extras_returns_none_on_construction_failure(
+    monkeypatch,
+) -> None:
+    """H-C4: If provider construction fails, build_tier1_extras returns (None, None)."""
+    # Patch the factory to simulate a construction failure.
+    monkeypatch.setattr(
+        "src.services.intelligence.monitoring._tier1_factory.build_tier1_extras",
+        lambda llm: (None, None),
+    )
+
+    from src.services.intelligence.monitoring._tier1_factory import build_tier1_extras
+
+    extra_providers, query_expander = build_tier1_extras(MagicMock())
+    # When the factory is patched to always return (None, None), caller receives None.
+    assert extra_providers is None
+    assert query_expander is None

--- a/tests/unit/services/intelligence/monitoring/test_multi_provider_monitor.py
+++ b/tests/unit/services/intelligence/monitoring/test_multi_provider_monitor.py
@@ -15,12 +15,7 @@ Covers:
 - ``check`` skips papers already in the registry.
 - ``check`` survives a single registry write error (PARTIAL).
 - ``check`` survives a single identity-resolution error (PARTIAL).
-- ``MonitoringRunner.from_paths`` builds ``MultiProviderMonitor`` when
-  extra_providers OR query_expander is provided.
-- ``MonitoringRunner.from_paths`` falls back to ``ArxivMonitor`` when
-  neither is provided (backward compatible).
-- ``MonitoringRunner.from_paths`` rejects an attempt to override the
-  arXiv provider via ``extra_providers``.
+- (from_paths monitor-selection tests relocated to test_runner.py, H-M6)
 - H-S1: expansion budget gate.
 - H-S2: variant validation + rejection.
 - H-S5: topic-build inside try/except.
@@ -46,7 +41,6 @@ import pytest
 
 from src.models.paper import PaperMetadata
 from src.services.intelligence.monitoring import multi_provider_monitor as mpm_module
-from src.services.intelligence.monitoring.arxiv_monitor import ArxivMonitor
 from src.services.intelligence.monitoring.models import (
     MAX_PAPERS_PER_CYCLE,
     MonitoringRunStatus,
@@ -59,7 +53,6 @@ from src.services.intelligence.monitoring.multi_provider_monitor import (
     MultiProviderMonitorConfig,
     _DEFAULT_MAX_QUERY_VARIANTS,
 )
-from src.services.intelligence.monitoring.runner import MonitoringRunner
 
 # ---------------------------------------------------------------------------
 # Fixtures / helpers
@@ -169,11 +162,12 @@ def test_init_defensive_copies_providers_dict() -> None:
     assert PaperSource.SEMANTIC_SCHOLAR not in monitor._providers
 
 
-def test_config_with_defaults_all_fields_set() -> None:
-    """Smoke-test the config helper -- all knobs have sane defaults.
+def test_config_default_construction_all_fields_set() -> None:
+    """Smoke-test default construction -- all knobs have sane defaults.
+    L-1: with_defaults() dropped; MultiProviderMonitorConfig() is equivalent.
     L-2: pin exact default values so accidental changes trip the test.
     """
-    cfg = MultiProviderMonitorConfig.with_defaults()
+    cfg = MultiProviderMonitorConfig()
     assert cfg.max_papers_per_cycle == MAX_PAPERS_PER_CYCLE
     assert cfg.max_query_variants == _DEFAULT_MAX_QUERY_VARIANTS
     assert cfg.topic_slug_prefix == "monitor"
@@ -463,6 +457,32 @@ async def test_check_enforces_max_papers_per_cycle_cap() -> None:
     assert registry.register_paper.call_count == 3
 
 
+@pytest.mark.asyncio
+async def test_check_cap_applied_emits_log(monkeypatch) -> None:
+    """L-3: monitor_per_cycle_cap_applied is logged when the cap clips results."""
+    sub = _make_subscription()
+    papers = [_make_paper(f"p{i}") for i in range(5)]
+    arxiv = _make_provider(return_papers=papers)
+    cfg = MultiProviderMonitorConfig(
+        max_papers_per_cycle=2,
+        max_query_variants=3,
+        topic_slug_prefix="monitor",
+    )
+    monkeypatch.setattr(mpm_module, "logger", structlog.get_logger())
+    monitor = MultiProviderMonitor(
+        providers={PaperSource.ARXIV: arxiv},
+        registry=_make_registry(),
+        config=cfg,
+    )
+    with structlog.testing.capture_logs() as logs:
+        result = await monitor.check(sub)
+    cap_events = [e for e in logs if e.get("event") == "monitor_per_cycle_cap_applied"]
+    assert len(cap_events) == 1
+    assert cap_events[0]["papers_before_cap"] == 5
+    assert cap_events[0]["cap"] == 2
+    assert result.run.papers_seen == 2
+
+
 # ---------------------------------------------------------------------------
 # Registry interaction
 # ---------------------------------------------------------------------------
@@ -541,95 +561,8 @@ async def test_check_identity_resolution_error_marks_partial_and_continues() -> 
     assert result.run.papers_deduplicated == 0
 
 
-# ---------------------------------------------------------------------------
-# MonitoringRunner.from_paths integration: monitor selection
-# ---------------------------------------------------------------------------
-
-
-def test_from_paths_with_no_extras_builds_arxiv_monitor(tmp_path) -> None:
-    """Backward-compatible default: legacy ArxivMonitor when no extras
-    and no expander are provided.
-    """
-    db_path = tmp_path / "monitoring.db"
-    runner = MonitoringRunner.from_paths(
-        db_path=db_path,
-        registry=MagicMock(),
-        arxiv_provider=MagicMock(),
-    )
-    assert isinstance(runner._monitor, ArxivMonitor)
-
-
-def test_from_paths_with_extra_providers_builds_multi_provider_monitor(
-    tmp_path,
-) -> None:
-    """When extra_providers is supplied, MultiProviderMonitor is selected."""
-    db_path = tmp_path / "monitoring.db"
-    extras = {PaperSource.SEMANTIC_SCHOLAR: _make_provider()}
-    runner = MonitoringRunner.from_paths(
-        db_path=db_path,
-        registry=MagicMock(),
-        arxiv_provider=MagicMock(),
-        extra_providers=extras,
-    )
-    assert isinstance(runner._monitor, MultiProviderMonitor)
-    # arXiv plus the one extra
-    assert PaperSource.ARXIV in runner._monitor._providers
-    assert PaperSource.SEMANTIC_SCHOLAR in runner._monitor._providers
-
-
-def test_from_paths_with_only_query_expander_builds_multi_provider(
-    tmp_path,
-) -> None:
-    """Even without extras, providing a query_expander promotes to
-    MultiProviderMonitor (the LLM expansion is the upgrade signal).
-    """
-    db_path = tmp_path / "monitoring.db"
-    runner = MonitoringRunner.from_paths(
-        db_path=db_path,
-        registry=MagicMock(),
-        arxiv_provider=MagicMock(),
-        query_expander=MagicMock(),
-    )
-    assert isinstance(runner._monitor, MultiProviderMonitor)
-
-
-def test_from_paths_rejects_arxiv_in_extra_providers(tmp_path) -> None:
-    """Caller must not pass arXiv via ``extra_providers`` -- the
-    canonical arXiv provider goes through ``arxiv_provider`` to keep
-    the wiring contract single-source.
-    """
-    db_path = tmp_path / "monitoring.db"
-    with pytest.raises(ValueError, match="must not include PaperSource.ARXIV"):
-        MonitoringRunner.from_paths(
-            db_path=db_path,
-            registry=MagicMock(),
-            arxiv_provider=MagicMock(),
-            extra_providers={PaperSource.ARXIV: _make_provider()},
-        )
-
-
-# ---------------------------------------------------------------------------
-# H-C6: empty-dict extra_providers builds MultiProviderMonitor
-# ---------------------------------------------------------------------------
-
-
-def test_from_paths_with_empty_dict_extra_providers_builds_multi_provider(
-    tmp_path,
-) -> None:
-    """H-C6: extra_providers={} (empty dict, not None) explicitly opts the
-    caller into MultiProviderMonitor. The is-not-None check must honour this.
-    """
-    db_path = tmp_path / "monitoring.db"
-    runner = MonitoringRunner.from_paths(
-        db_path=db_path,
-        registry=MagicMock(),
-        arxiv_provider=MagicMock(),
-        extra_providers={},  # empty but explicitly provided
-    )
-    assert isinstance(runner._monitor, MultiProviderMonitor)
-    # Only arXiv (from arxiv_provider); the empty extras dict adds nothing.
-    assert PaperSource.ARXIV in runner._monitor._providers
-    assert len(runner._monitor._providers) == 1
+# (from_paths monitor-selection tests have been relocated to test_runner.py
+#  under TestFromPathsFactory — see H-M6)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/intelligence/monitoring/test_multi_provider_monitor.py
+++ b/tests/unit/services/intelligence/monitoring/test_multi_provider_monitor.py
@@ -1,0 +1,488 @@
+"""Tests for ``MultiProviderMonitor`` (Tier 1, Issue #139).
+
+Covers:
+- Constructor validates inputs (rejects empty providers).
+- ``check`` short-circuits paused subscriptions.
+- ``check`` skips query expansion when no expander configured.
+- ``check`` expands queries when an expander IS configured.
+- ``check`` falls back to the literal query when expander.expand raises.
+- ``check`` falls back to the literal query when expander returns empty.
+- ``check`` fans out across all configured providers per query variant.
+- ``check`` survives a single provider failure (Fail-Soft Boundary).
+- ``check`` deduplicates papers by ``paper_id``.
+- ``check`` enforces ``max_papers_per_cycle`` cap.
+- ``check`` registers new papers ``discovery_only=True``.
+- ``check`` skips papers already in the registry.
+- ``check`` survives a single registry write error (PARTIAL).
+- ``check`` survives a single identity-resolution error (PARTIAL).
+- ``MonitoringRunner.from_paths`` builds ``MultiProviderMonitor`` when
+  extra_providers OR query_expander is provided.
+- ``MonitoringRunner.from_paths`` falls back to ``ArxivMonitor`` when
+  neither is provided (backward compatible).
+- ``MonitoringRunner.from_paths`` rejects an attempt to override the
+  arXiv provider via ``extra_providers``.
+
+Note: ``ArxivMonitorResult`` is intentionally reused as the return DTO
+so both monitors are duck-type compatible from the runner's POV.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.models.paper import PaperMetadata
+from src.services.intelligence.monitoring.arxiv_monitor import ArxivMonitor
+from src.services.intelligence.monitoring.models import (
+    MonitoringRunStatus,
+    PaperSource,
+    ResearchSubscription,
+    SubscriptionStatus,
+)
+from src.services.intelligence.monitoring.multi_provider_monitor import (
+    MultiProviderMonitor,
+    MultiProviderMonitorConfig,
+)
+from src.services.intelligence.monitoring.runner import MonitoringRunner
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_subscription(
+    *,
+    subscription_id: str = "sub-aaa",
+    user_id: str = "alice",
+    query: str = "tree of thoughts",
+    status: SubscriptionStatus = SubscriptionStatus.ACTIVE,
+    sources: list[PaperSource] | None = None,
+) -> ResearchSubscription:
+    return ResearchSubscription(
+        subscription_id=subscription_id,
+        user_id=user_id,
+        name="Sub",
+        query=query,
+        status=status,
+        sources=sources or [PaperSource.ARXIV],
+    )
+
+
+def _make_paper(paper_id: str, title: str = "Title") -> PaperMetadata:
+    return PaperMetadata(
+        paper_id=paper_id,
+        title=title,
+        url=f"https://arxiv.org/abs/{paper_id}",  # type: ignore[arg-type]
+    )
+
+
+def _make_provider(
+    return_papers: list[PaperMetadata] | None = None,
+    raise_on_search: Exception | None = None,
+) -> MagicMock:
+    provider = MagicMock()
+    if raise_on_search is not None:
+        provider.search = AsyncMock(side_effect=raise_on_search)
+    else:
+        provider.search = AsyncMock(return_value=return_papers or [])
+    return provider
+
+
+def _make_registry(
+    *,
+    matched_paper_ids: set[str] | None = None,
+    register_side_effect: Exception | None = None,
+    resolve_side_effect: Exception | None = None,
+) -> MagicMock:
+    """Build a registry mock that mimics ``RegistryService``'s small contract.
+
+    - ``resolve_identity(paper)`` returns an object with a ``.matched``
+      bool — True iff paper.paper_id is in ``matched_paper_ids``.
+    - ``register_paper(...)`` is a no-op (or raises if configured).
+    """
+    registry = MagicMock()
+    matched_ids = matched_paper_ids or set()
+
+    def _resolve(paper: PaperMetadata) -> object:
+        if resolve_side_effect is not None:
+            raise resolve_side_effect
+        m = MagicMock()
+        m.matched = paper.paper_id in matched_ids
+        return m
+
+    registry.resolve_identity = MagicMock(side_effect=_resolve)
+    if register_side_effect is not None:
+        registry.register_paper = MagicMock(side_effect=register_side_effect)
+    else:
+        registry.register_paper = MagicMock()
+    return registry
+
+
+# ---------------------------------------------------------------------------
+# Constructor validation
+# ---------------------------------------------------------------------------
+
+
+def test_init_rejects_empty_providers() -> None:
+    """Constructor must reject ``providers={}`` -- a misconfiguration
+    would silently produce zero results every cycle.
+    """
+    with pytest.raises(ValueError, match="at least one provider"):
+        MultiProviderMonitor(providers={}, registry=MagicMock())
+
+
+def test_init_accepts_single_provider() -> None:
+    """One provider is enough -- e.g., a deployment with only arXiv."""
+    monitor = MultiProviderMonitor(
+        providers={PaperSource.ARXIV: _make_provider()},
+        registry=MagicMock(),
+    )
+    assert monitor is not None
+
+
+def test_init_defensive_copies_providers_dict() -> None:
+    """Mutations to the caller's dict after construction must NOT
+    affect the monitor's internal provider set.
+    """
+    caller_dict = {PaperSource.ARXIV: _make_provider()}
+    monitor = MultiProviderMonitor(providers=caller_dict, registry=MagicMock())
+    caller_dict[PaperSource.SEMANTIC_SCHOLAR] = _make_provider()
+    # Internal dict was copied at construction; caller's mutation is invisible.
+    assert PaperSource.SEMANTIC_SCHOLAR not in monitor._providers
+
+
+def test_config_with_defaults_all_fields_set() -> None:
+    """Smoke-test the config helper -- all knobs have sane defaults."""
+    cfg = MultiProviderMonitorConfig.with_defaults()
+    assert cfg.max_papers_per_cycle > 0
+    assert cfg.max_query_variants > 0
+    assert cfg.topic_slug_prefix == "monitor"
+
+
+# ---------------------------------------------------------------------------
+# Subscription gating
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_check_paused_subscription_short_circuits() -> None:
+    """Paused subscriptions return SUCCESS without touching providers."""
+    sub = _make_subscription(status=SubscriptionStatus.PAUSED)
+    arxiv = _make_provider(return_papers=[_make_paper("p1")])
+    monitor = MultiProviderMonitor(
+        providers={PaperSource.ARXIV: arxiv},
+        registry=_make_registry(),
+    )
+    result = await monitor.check(sub)
+    assert result.run.status is MonitoringRunStatus.SUCCESS
+    assert result.run.papers_seen == 0
+    arxiv.search.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Query expansion
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_check_no_expander_uses_literal_query_only() -> None:
+    """Without an expander, only the literal query is searched (cost-free)."""
+    sub = _make_subscription(query="LLM agents")
+    arxiv = _make_provider()
+    monitor = MultiProviderMonitor(
+        providers={PaperSource.ARXIV: arxiv},
+        registry=_make_registry(),
+    )
+    await monitor.check(sub)
+    assert arxiv.search.await_count == 1
+    # Verify the topic carried the literal query (the topic is the
+    # first positional arg to provider.search).
+    topic = arxiv.search.await_args.args[0]
+    assert topic.query == "LLM agents"
+
+
+@pytest.mark.asyncio
+async def test_check_with_expander_searches_all_variants() -> None:
+    """With an expander, each variant fans out to every provider."""
+    sub = _make_subscription(query="original")
+    expander = MagicMock()
+    expander.expand = AsyncMock(return_value=["original", "variant1", "variant2"])
+    arxiv = _make_provider()
+    s2 = _make_provider()
+    monitor = MultiProviderMonitor(
+        providers={
+            PaperSource.ARXIV: arxiv,
+            PaperSource.SEMANTIC_SCHOLAR: s2,
+        },
+        registry=_make_registry(),
+        query_expander=expander,
+    )
+    await monitor.check(sub)
+    # 3 variants × 2 providers = 6 searches total
+    assert arxiv.search.await_count == 3
+    assert s2.search.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_check_expander_failure_falls_back_to_literal_query() -> None:
+    """If expander.expand() raises, fall back to the literal query (Fail-Soft)."""
+    sub = _make_subscription(query="LLM agents")
+    expander = MagicMock()
+    expander.expand = AsyncMock(side_effect=RuntimeError("LLM down"))
+    arxiv = _make_provider()
+    monitor = MultiProviderMonitor(
+        providers={PaperSource.ARXIV: arxiv},
+        registry=_make_registry(),
+        query_expander=expander,
+    )
+    await monitor.check(sub)
+    # Despite the expander failure, the cycle still searches the literal query.
+    assert arxiv.search.await_count == 1
+    assert arxiv.search.await_args.args[0].query == "LLM agents"
+
+
+@pytest.mark.asyncio
+async def test_check_expander_returns_empty_falls_back_to_literal() -> None:
+    """If expander returns an empty list, fall back to literal query."""
+    sub = _make_subscription(query="LLM agents")
+    expander = MagicMock()
+    expander.expand = AsyncMock(return_value=[])  # pathological case
+    arxiv = _make_provider()
+    monitor = MultiProviderMonitor(
+        providers={PaperSource.ARXIV: arxiv},
+        registry=_make_registry(),
+        query_expander=expander,
+    )
+    await monitor.check(sub)
+    assert arxiv.search.await_count == 1
+    assert arxiv.search.await_args.args[0].query == "LLM agents"
+
+
+# ---------------------------------------------------------------------------
+# Provider fan-out + Fail-Soft Boundary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_check_one_provider_failure_does_not_abort_cycle() -> None:
+    """A single provider raising must NOT abort the cycle (Fail-Soft).
+    Status becomes PARTIAL and the surviving provider's papers land.
+    """
+    sub = _make_subscription()
+    arxiv = _make_provider(return_papers=[_make_paper("arxiv-1")])
+    s2 = _make_provider(raise_on_search=ConnectionError("S2 timeout"))
+    monitor = MultiProviderMonitor(
+        providers={
+            PaperSource.ARXIV: arxiv,
+            PaperSource.SEMANTIC_SCHOLAR: s2,
+        },
+        registry=_make_registry(),
+    )
+    result = await monitor.check(sub)
+    assert result.run.status is MonitoringRunStatus.PARTIAL
+    assert result.run.papers_seen == 1  # the arXiv result survived
+    assert result.run.error is not None  # explained
+
+
+@pytest.mark.asyncio
+async def test_check_all_providers_succeed_returns_success_status() -> None:
+    """If everything succeeds, status is SUCCESS (not PARTIAL)."""
+    sub = _make_subscription()
+    arxiv = _make_provider(return_papers=[_make_paper("p1")])
+    monitor = MultiProviderMonitor(
+        providers={PaperSource.ARXIV: arxiv},
+        registry=_make_registry(),
+    )
+    result = await monitor.check(sub)
+    assert result.run.status is MonitoringRunStatus.SUCCESS
+    assert result.run.error is None
+
+
+# ---------------------------------------------------------------------------
+# Deduplication + cap enforcement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_check_dedups_papers_by_paper_id_across_providers() -> None:
+    """If two providers return the same paper_id, it appears once."""
+    sub = _make_subscription()
+    shared = _make_paper("shared-id", title="Same paper, both providers")
+    arxiv = _make_provider(return_papers=[shared])
+    s2 = _make_provider(return_papers=[shared])
+    monitor = MultiProviderMonitor(
+        providers={
+            PaperSource.ARXIV: arxiv,
+            PaperSource.SEMANTIC_SCHOLAR: s2,
+        },
+        registry=_make_registry(),
+    )
+    result = await monitor.check(sub)
+    # Only ONE paper despite both providers returning it.
+    assert result.run.papers_seen == 1
+
+
+@pytest.mark.asyncio
+async def test_check_enforces_max_papers_per_cycle_cap() -> None:
+    """The per-cycle cap clips overflow even if providers return more."""
+    sub = _make_subscription()
+    papers = [_make_paper(f"p{i}") for i in range(10)]
+    arxiv = _make_provider(return_papers=papers)
+    cfg = MultiProviderMonitorConfig(
+        max_papers_per_cycle=3,
+        max_query_variants=3,
+        topic_slug_prefix="monitor",
+    )
+    monitor = MultiProviderMonitor(
+        providers={PaperSource.ARXIV: arxiv},
+        registry=_make_registry(),
+        config=cfg,
+    )
+    result = await monitor.check(sub)
+    assert result.run.papers_seen == 3
+
+
+# ---------------------------------------------------------------------------
+# Registry interaction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_check_registers_new_papers_discovery_only() -> None:
+    """New papers (not in registry) are registered with discovery_only=True."""
+    sub = _make_subscription(subscription_id="sub-xyz")
+    p = _make_paper("new-paper")
+    arxiv = _make_provider(return_papers=[p])
+    registry = _make_registry()  # no matched_ids → all new
+    monitor = MultiProviderMonitor(
+        providers={PaperSource.ARXIV: arxiv},
+        registry=registry,
+    )
+    result = await monitor.check(sub)
+    assert result.run.papers_new == 1
+    assert result.run.papers_deduplicated == 0
+    registry.register_paper.assert_called_once()
+    kwargs = registry.register_paper.call_args.kwargs
+    assert kwargs["discovery_only"] is True
+    assert kwargs["topic_slug"] == "monitor-sub-xyz"
+
+
+@pytest.mark.asyncio
+async def test_check_skips_papers_already_in_registry() -> None:
+    """Papers already in the registry are tagged deduplicated, not re-registered."""
+    sub = _make_subscription()
+    p = _make_paper("known")
+    arxiv = _make_provider(return_papers=[p])
+    registry = _make_registry(matched_paper_ids={"known"})
+    monitor = MultiProviderMonitor(
+        providers={PaperSource.ARXIV: arxiv},
+        registry=registry,
+    )
+    result = await monitor.check(sub)
+    assert result.run.papers_new == 0
+    assert result.run.papers_deduplicated == 1
+    registry.register_paper.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_check_registry_write_error_marks_partial_and_continues() -> None:
+    """If register_paper raises for one paper, status becomes PARTIAL but
+    the cycle continues with the remaining papers (Fail-Soft).
+    """
+    sub = _make_subscription()
+    p1 = _make_paper("p1")
+    arxiv = _make_provider(return_papers=[p1])
+    registry = _make_registry(register_side_effect=RuntimeError("disk full"))
+    monitor = MultiProviderMonitor(
+        providers={PaperSource.ARXIV: arxiv},
+        registry=registry,
+    )
+    result = await monitor.check(sub)
+    assert result.run.status is MonitoringRunStatus.PARTIAL
+    assert result.run.papers_new == 0  # the failed write was NOT counted as new
+
+
+@pytest.mark.asyncio
+async def test_check_identity_resolution_error_marks_partial_and_continues() -> None:
+    """If resolve_identity raises for one paper, status becomes PARTIAL
+    but the cycle continues -- the broken paper is skipped.
+    """
+    sub = _make_subscription()
+    arxiv = _make_provider(return_papers=[_make_paper("p1")])
+    registry = _make_registry(resolve_side_effect=RuntimeError("bad row"))
+    monitor = MultiProviderMonitor(
+        providers={PaperSource.ARXIV: arxiv},
+        registry=registry,
+    )
+    result = await monitor.check(sub)
+    assert result.run.status is MonitoringRunStatus.PARTIAL
+    assert result.run.papers_new == 0
+    assert result.run.papers_deduplicated == 0
+
+
+# ---------------------------------------------------------------------------
+# MonitoringRunner.from_paths integration: monitor selection
+# ---------------------------------------------------------------------------
+
+
+def test_from_paths_with_no_extras_builds_arxiv_monitor(tmp_path) -> None:
+    """Backward-compatible default: legacy ArxivMonitor when no extras
+    and no expander are provided.
+    """
+    db_path = tmp_path / "monitoring.db"
+    runner = MonitoringRunner.from_paths(
+        db_path=db_path,
+        registry=MagicMock(),
+        arxiv_provider=MagicMock(),
+    )
+    assert isinstance(runner._monitor, ArxivMonitor)
+
+
+def test_from_paths_with_extra_providers_builds_multi_provider_monitor(
+    tmp_path,
+) -> None:
+    """When extra_providers is supplied, MultiProviderMonitor is selected."""
+    db_path = tmp_path / "monitoring.db"
+    extras = {PaperSource.SEMANTIC_SCHOLAR: _make_provider()}
+    runner = MonitoringRunner.from_paths(
+        db_path=db_path,
+        registry=MagicMock(),
+        arxiv_provider=MagicMock(),
+        extra_providers=extras,
+    )
+    assert isinstance(runner._monitor, MultiProviderMonitor)
+    # arXiv plus the one extra
+    assert PaperSource.ARXIV in runner._monitor._providers
+    assert PaperSource.SEMANTIC_SCHOLAR in runner._monitor._providers
+
+
+def test_from_paths_with_only_query_expander_builds_multi_provider(
+    tmp_path,
+) -> None:
+    """Even without extras, providing a query_expander promotes to
+    MultiProviderMonitor (the LLM expansion is the upgrade signal).
+    """
+    db_path = tmp_path / "monitoring.db"
+    runner = MonitoringRunner.from_paths(
+        db_path=db_path,
+        registry=MagicMock(),
+        arxiv_provider=MagicMock(),
+        query_expander=MagicMock(),
+    )
+    assert isinstance(runner._monitor, MultiProviderMonitor)
+
+
+def test_from_paths_rejects_arxiv_in_extra_providers(tmp_path) -> None:
+    """Caller must not pass arXiv via ``extra_providers`` -- the
+    canonical arXiv provider goes through ``arxiv_provider`` to keep
+    the wiring contract single-source.
+    """
+    db_path = tmp_path / "monitoring.db"
+    with pytest.raises(ValueError, match="must not include PaperSource.ARXIV"):
+        MonitoringRunner.from_paths(
+            db_path=db_path,
+            registry=MagicMock(),
+            arxiv_provider=MagicMock(),
+            extra_providers={PaperSource.ARXIV: _make_provider()},
+        )

--- a/tests/unit/services/intelligence/monitoring/test_multi_provider_monitor.py
+++ b/tests/unit/services/intelligence/monitoring/test_multi_provider_monitor.py
@@ -138,7 +138,9 @@ def test_init_accepts_single_provider() -> None:
         providers={PaperSource.ARXIV: _make_provider()},
         registry=MagicMock(),
     )
-    assert monitor is not None
+    # H-T4: Assert specific structure instead of vacuous `is not None`
+    assert PaperSource.ARXIV in monitor._providers
+    assert len(monitor._providers) == 1
 
 
 def test_init_defensive_copies_providers_dict() -> None:
@@ -204,7 +206,12 @@ async def test_check_no_expander_uses_literal_query_only() -> None:
 
 @pytest.mark.asyncio
 async def test_check_with_expander_searches_all_variants() -> None:
-    """With an expander, each variant fans out to every provider."""
+    """With an expander, each variant fans out to every allowlisted provider.
+
+    The subscription has only PaperSource.ARXIV in sources (MVP default),
+    so only the arXiv provider is searched for each of the 3 variants;
+    the S2 provider is skipped by the H-S3 allowlist filter.
+    """
     sub = _make_subscription(query="original")
     expander = MagicMock()
     expander.expand = AsyncMock(return_value=["original", "variant1", "variant2"])
@@ -219,9 +226,14 @@ async def test_check_with_expander_searches_all_variants() -> None:
         query_expander=expander,
     )
     await monitor.check(sub)
-    # 3 variants × 2 providers = 6 searches total
+    # 3 variants × 1 allowed provider (ARXIV) = 3 searches
+    # expander was called with max_variants = config.max_query_variants (C-1 fix)
     assert arxiv.search.await_count == 3
-    assert s2.search.await_count == 3
+    # S2 is not in subscription.sources → skipped by H-S3 filter
+    assert s2.search.await_count == 0
+    expander.expand.assert_awaited_once_with(
+        "original", max_variants=monitor._config.max_query_variants
+    )
 
 
 @pytest.mark.asyncio
@@ -260,18 +272,23 @@ async def test_check_expander_returns_empty_falls_back_to_literal() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Provider fan-out + Fail-Soft Boundary
+# H-S3: subscription.sources allowlist honored
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_check_one_provider_failure_does_not_abort_cycle() -> None:
-    """A single provider raising must NOT abort the cycle (Fail-Soft).
-    Status becomes PARTIAL and the surviving provider's papers land.
+async def test_check_respects_subscription_sources_allowlist() -> None:
+    """H-S3: Providers not in subscription.sources must not be searched.
+
+    The MVP ResearchSubscription only allows PaperSource.ARXIV in sources.
+    A multi-provider monitor configured with both ARXIV and S2 must only
+    search ARXIV for subscriptions that only allow ARXIV.
     """
-    sub = _make_subscription()
-    arxiv = _make_provider(return_papers=[_make_paper("arxiv-1")])
-    s2 = _make_provider(raise_on_search=ConnectionError("S2 timeout"))
+    sub = _make_subscription()  # sources=[PaperSource.ARXIV] by default
+    assert sub.sources == [PaperSource.ARXIV]
+
+    arxiv = _make_provider(return_papers=[_make_paper("p1")])
+    s2 = _make_provider(return_papers=[_make_paper("p2")])
     monitor = MultiProviderMonitor(
         providers={
             PaperSource.ARXIV: arxiv,
@@ -280,9 +297,56 @@ async def test_check_one_provider_failure_does_not_abort_cycle() -> None:
         registry=_make_registry(),
     )
     result = await monitor.check(sub)
+
+    # ARXIV is in sources → searched; S2 is not → skipped
+    arxiv.search.assert_awaited_once()
+    s2.search.assert_not_called()
+    # Only the ARXIV paper landed
+    assert result.run.papers_seen == 1
+
+
+# ---------------------------------------------------------------------------
+# Provider fan-out + Fail-Soft Boundary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_check_one_provider_failure_does_not_abort_cycle() -> None:
+    """A single provider raising must NOT abort the cycle (Fail-Soft).
+    Status becomes PARTIAL and the surviving provider's papers land.
+
+    Since subscription.sources is [ARXIV] (MVP default), ARXIV is the only
+    provider searched. We test fail-soft by having the ARXIV provider raise
+    on one call in a multi-variant setup, so the second variant still proceeds.
+    H-S3: S2 provider is skipped because it is not in subscription.sources.
+    """
+    sub = _make_subscription()
+    # ARXIV raises on first call, returns papers on second
+    call_count = [0]
+
+    async def arxiv_search(topic):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            raise ConnectionError("arxiv timeout on first variant")
+        return [_make_paper("arxiv-1")]
+
+    arxiv = MagicMock()
+    arxiv.search = AsyncMock(side_effect=arxiv_search)
+    expander = MagicMock()
+    expander.expand = AsyncMock(return_value=["original", "variant2"])
+    monitor = MultiProviderMonitor(
+        providers={
+            PaperSource.ARXIV: arxiv,
+        },
+        registry=_make_registry(),
+        query_expander=expander,
+    )
+    result = await monitor.check(sub)
     assert result.run.status is MonitoringRunStatus.PARTIAL
-    assert result.run.papers_seen == 1  # the arXiv result survived
+    assert result.run.papers_seen == 1  # the second-variant arXiv result survived
     assert result.run.error is not None  # explained
+    # H-T3: assert that the paper_id from the surviving call is present
+    assert result.new_papers[0].paper_id == "arxiv-1"
 
 
 @pytest.mark.asyncio
@@ -334,13 +398,16 @@ async def test_check_enforces_max_papers_per_cycle_cap() -> None:
         max_query_variants=3,
         topic_slug_prefix="monitor",
     )
+    registry = _make_registry()
     monitor = MultiProviderMonitor(
         providers={PaperSource.ARXIV: arxiv},
-        registry=_make_registry(),
+        registry=registry,
         config=cfg,
     )
     result = await monitor.check(sub)
     assert result.run.papers_seen == 3
+    # H-T5: exactly 3 papers registered (cap enforced before registry calls)
+    assert registry.register_paper.call_count == 3
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/intelligence/monitoring/test_runner.py
+++ b/tests/unit/services/intelligence/monitoring/test_runner.py
@@ -1016,3 +1016,59 @@ class TestLLMBudgetCap:
             e for e in logs if e.get("event") == "monitoring_llm_budget_exhausted"
         ]
         assert len(exhausted_events) >= 1
+
+
+# ---------------------------------------------------------------------------
+# H-S1: Runner passes budget counters to MultiProviderMonitor
+# ---------------------------------------------------------------------------
+
+
+class TestMultiProviderMonitorBudgetPassthrough:
+    """H-S1: When the runner's monitor is a MultiProviderMonitor, _run_one
+    passes llm_calls_used and max_calls to monitor.check.
+    """
+
+    @pytest.mark.asyncio
+    async def test_run_once_passes_budget_to_multi_provider_monitor(self) -> None:
+        """The runner passes the cycle-wide llm_calls_used counter and
+        MAX_LLM_CALLS_PER_CYCLE to MultiProviderMonitor.check so the
+        expander is gated against the cycle budget.
+        """
+        from unittest.mock import AsyncMock as _AsyncMock, MagicMock as _MagicMock
+        from src.services.intelligence.monitoring.multi_provider_monitor import (
+            MultiProviderMonitor,
+        )
+
+        sub = _make_subscription(subscription_id="sub-budget-passthrough")
+
+        # Build a MultiProviderMonitor mock that records what was passed.
+        received_kwargs: dict = {}
+
+        async def mock_check(subscription, *, llm_calls_used=None, max_calls=None):
+            received_kwargs["llm_calls_used"] = llm_calls_used
+            received_kwargs["max_calls"] = max_calls
+            run = _make_run(subscription_id=subscription.subscription_id)
+            return ArxivMonitorResult(run=run, new_papers=[], deduplicated_papers=[])
+
+        monitor_mock = _MagicMock(spec=MultiProviderMonitor)
+        monitor_mock.check = _AsyncMock(side_effect=mock_check)
+
+        sub_mgr = _MagicMock()
+        sub_mgr.list_subscriptions = _MagicMock(return_value=[sub])
+        sub_mgr.mark_checked = _MagicMock()
+        repo = _MagicMock()
+        repo.record_run = _MagicMock()
+
+        runner = MonitoringRunner(
+            subscription_manager=sub_mgr,
+            monitor=monitor_mock,
+            run_repo=repo,
+        )
+        await runner.run_once()
+
+        # The runner must have passed the budget counter and max cap.
+        assert received_kwargs.get("llm_calls_used") is not None
+        assert received_kwargs["llm_calls_used"][0] == 0  # starts at 0
+        from src.services.intelligence.monitoring.runner import MAX_LLM_CALLS_PER_CYCLE
+
+        assert received_kwargs.get("max_calls") == MAX_LLM_CALLS_PER_CYCLE

--- a/tests/unit/services/intelligence/monitoring/test_runner.py
+++ b/tests/unit/services/intelligence/monitoring/test_runner.py
@@ -14,6 +14,10 @@ Covers:
   -- the in-memory run is still returned.
 - ``mark_checked`` errors are logged but don't break the cycle.
 - Empty active list returns ``[]`` and does not touch monitor / repo.
+- ``from_paths`` monitor selection: ArxivMonitor vs MultiProviderMonitor
+  based on extra_providers / query_expander (H-M6: relocated from
+  test_multi_provider_monitor.py so all from_paths tests live here).
+- H-S1: Runner passes budget counters to MultiProviderMonitor.
 """
 
 from __future__ import annotations
@@ -23,12 +27,19 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from src.services.intelligence.monitoring.arxiv_monitor import ArxivMonitorResult
+from src.services.intelligence.monitoring.arxiv_monitor import (
+    ArxivMonitor,
+    ArxivMonitorResult,
+)
 from src.services.intelligence.monitoring.models import (
     MonitoringRun,
     MonitoringRunStatus,
+    PaperSource,
     ResearchSubscription,
     SubscriptionStatus,
+)
+from src.services.intelligence.monitoring.multi_provider_monitor import (
+    MultiProviderMonitor,
 )
 from src.services.intelligence.monitoring.run_repository import (
     MonitoringRunRepository,
@@ -270,6 +281,87 @@ class TestFromPathsFactory:
                 arxiv_provider=MagicMock(),
             )
         assert runner is not None
+
+    # H-M6: relocated from test_multi_provider_monitor.py so all from_paths
+    # monitor-selection tests live together in test_runner.py.
+
+    def test_from_paths_with_no_extras_builds_arxiv_monitor(
+        self, tmp_path: Path
+    ) -> None:
+        """Backward-compatible default: legacy ArxivMonitor when no extras
+        and no expander are provided.
+        """
+        db_path = tmp_path / "monitoring.db"
+        runner = MonitoringRunner.from_paths(
+            db_path=db_path,
+            registry=MagicMock(),
+            arxiv_provider=MagicMock(),
+        )
+        assert isinstance(runner._monitor, ArxivMonitor)
+
+    def test_from_paths_with_extra_providers_builds_multi_provider_monitor(
+        self, tmp_path: Path
+    ) -> None:
+        """When extra_providers is supplied, MultiProviderMonitor is selected."""
+        db_path = tmp_path / "monitoring.db"
+        extras = {PaperSource.SEMANTIC_SCHOLAR: MagicMock()}
+        runner = MonitoringRunner.from_paths(
+            db_path=db_path,
+            registry=MagicMock(),
+            arxiv_provider=MagicMock(),
+            extra_providers=extras,
+        )
+        assert isinstance(runner._monitor, MultiProviderMonitor)
+        # arXiv plus the one extra.
+        assert PaperSource.ARXIV in runner._monitor._providers
+        assert PaperSource.SEMANTIC_SCHOLAR in runner._monitor._providers
+
+    def test_from_paths_with_only_query_expander_builds_multi_provider(
+        self, tmp_path: Path
+    ) -> None:
+        """Even without extras, providing a query_expander promotes to
+        MultiProviderMonitor (the LLM expansion is the upgrade signal).
+        """
+        db_path = tmp_path / "monitoring.db"
+        runner = MonitoringRunner.from_paths(
+            db_path=db_path,
+            registry=MagicMock(),
+            arxiv_provider=MagicMock(),
+            query_expander=MagicMock(),
+        )
+        assert isinstance(runner._monitor, MultiProviderMonitor)
+
+    def test_from_paths_rejects_arxiv_in_extra_providers(self, tmp_path: Path) -> None:
+        """Caller must not pass arXiv via ``extra_providers`` -- the
+        canonical arXiv provider goes through ``arxiv_provider`` to keep
+        the wiring contract single-source.
+        """
+        db_path = tmp_path / "monitoring.db"
+        with pytest.raises(ValueError, match="must not include PaperSource.ARXIV"):
+            MonitoringRunner.from_paths(
+                db_path=db_path,
+                registry=MagicMock(),
+                arxiv_provider=MagicMock(),
+                extra_providers={PaperSource.ARXIV: MagicMock()},
+            )
+
+    def test_from_paths_with_empty_dict_extra_providers_builds_multi_provider(
+        self, tmp_path: Path
+    ) -> None:
+        """H-C6: extra_providers={} (empty dict, not None) explicitly opts the
+        caller into MultiProviderMonitor. The is-not-None check must honour this.
+        """
+        db_path = tmp_path / "monitoring.db"
+        runner = MonitoringRunner.from_paths(
+            db_path=db_path,
+            registry=MagicMock(),
+            arxiv_provider=MagicMock(),
+            extra_providers={},  # empty but explicitly provided
+        )
+        assert isinstance(runner._monitor, MultiProviderMonitor)
+        # Only arXiv (from arxiv_provider); the empty extras dict adds nothing.
+        assert PaperSource.ARXIV in runner._monitor._providers
+        assert len(runner._monitor._providers) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/intelligence/monitoring/test_runner.py
+++ b/tests/unit/services/intelligence/monitoring/test_runner.py
@@ -649,8 +649,18 @@ class TestScorerIntegration:
         from src.services.intelligence.monitoring.runner import MonitoringRunner
 
         sub = _make_subscription(subscription_id="sub-scorer")
-        paper1 = MonitoringPaperRecord(paper_id="p1", title="Paper 1", is_new=True)
-        paper2 = MonitoringPaperRecord(paper_id="p2", title="Paper 2", is_new=True)
+        paper1 = MonitoringPaperRecord(
+            paper_id="p1",
+            title="Paper 1",
+            is_new=True,
+            url="https://arxiv.org/abs/p1",
+        )
+        paper2 = MonitoringPaperRecord(
+            paper_id="p2",
+            title="Paper 2",
+            is_new=True,
+            url="https://arxiv.org/abs/p2",
+        )
         run_obj = _make_run(subscription_id="sub-scorer")
         run_obj = run_obj.model_copy(update={"papers": [paper1, paper2]})
 
@@ -701,8 +711,18 @@ class TestScorerIntegration:
         from src.services.intelligence.monitoring.runner import MonitoringRunner
 
         sub = _make_subscription(subscription_id="sub-scorer2")
-        paper1 = MonitoringPaperRecord(paper_id="p1", title="Paper 1", is_new=True)
-        paper2 = MonitoringPaperRecord(paper_id="p2", title="Paper 2", is_new=True)
+        paper1 = MonitoringPaperRecord(
+            paper_id="p1",
+            title="Paper 1",
+            is_new=True,
+            url="https://arxiv.org/abs/p1",
+        )
+        paper2 = MonitoringPaperRecord(
+            paper_id="p2",
+            title="Paper 2",
+            is_new=True,
+            url="https://arxiv.org/abs/p2",
+        )
         run_obj = _make_run(subscription_id="sub-scorer2")
         run_obj = run_obj.model_copy(update={"papers": [paper1, paper2]})
         result = ArxivMonitorResult(run=run_obj, new_papers=[], deduplicated_papers=[])
@@ -772,6 +792,81 @@ class TestScorerIntegration:
         runs = await runner.run_once()
 
         assert runs[0].papers[0].relevance_score is None
+
+    @pytest.mark.asyncio
+    async def test_scorer_skips_paper_with_no_url(self) -> None:
+        """C-2: Papers with url=None are skipped before scoring rather than
+        fabricating an arXiv URL for non-arXiv papers.
+        The ``monitoring_relevance_score_skipped_no_url`` event is emitted.
+        """
+        import structlog.testing
+        from unittest.mock import AsyncMock as _AsyncMock, MagicMock as _MagicMock
+
+        from src.services.intelligence.monitoring.models import MonitoringPaperRecord
+        from src.services.intelligence.monitoring.relevance_scorer import (
+            RelevanceScoreResult,
+        )
+        from src.services.intelligence.monitoring.runner import MonitoringRunner
+
+        sub = _make_subscription(subscription_id="sub-nourl")
+        paper_no_url = MonitoringPaperRecord(
+            paper_id="p-nourl", title="No URL Paper", is_new=True, url=None
+        )
+        paper_with_url = MonitoringPaperRecord(
+            paper_id="p-url",
+            title="Has URL Paper",
+            is_new=True,
+            url="https://arxiv.org/abs/p-url",
+        )
+        run_obj = _make_run(subscription_id="sub-nourl")
+        run_obj = run_obj.model_copy(update={"papers": [paper_no_url, paper_with_url]})
+        result = ArxivMonitorResult(run=run_obj, new_papers=[], deduplicated_papers=[])
+
+        ok_result = RelevanceScoreResult(
+            score=0.7,
+            reasoning="Some match found in paper",
+            model_used="gemini-1.5-flash",
+            cost_usd=0.0,
+        )
+        scorer = _MagicMock()
+        scorer.score = _AsyncMock(return_value=ok_result)
+
+        sub_mgr = _MagicMock()
+        sub_mgr.list_subscriptions = _MagicMock(return_value=[sub])
+        sub_mgr.mark_checked = _MagicMock()
+        monitor = _MagicMock()
+        monitor.check = _AsyncMock(return_value=result)
+        repo = _MagicMock()
+        repo.record_run = _MagicMock()
+
+        runner = MonitoringRunner(
+            subscription_manager=sub_mgr,
+            monitor=monitor,
+            run_repo=repo,
+            scorer=scorer,
+        )
+
+        import structlog
+        import src.services.intelligence.monitoring.runner as runner_module2
+
+        runner_module2.logger = structlog.get_logger()
+
+        with structlog.testing.capture_logs() as logs:
+            runs = await runner.run_once()
+
+        # The paper with URL is scored; the paper without URL is skipped.
+        assert runs[0].papers[0].relevance_score is None  # no URL → skipped
+        assert runs[0].papers[1].relevance_score == pytest.approx(0.7)
+        # Scorer is called only once (for the URL paper).
+        assert scorer.score.await_count == 1
+
+        skip_events = [
+            e
+            for e in logs
+            if e.get("event") == "monitoring_relevance_score_skipped_no_url"
+        ]
+        assert len(skip_events) == 1
+        assert skip_events[0]["paper_id"] == "p-nourl"
 
 
 # ---------------------------------------------------------------------------
@@ -867,8 +962,14 @@ class TestLLMBudgetCap:
 
         sub = _make_subscription(subscription_id="sub-budget")
         # Create 3 papers but set the budget cap to 1 so only 1 gets scored.
+        # Include URLs so the C-2 url-check does not skip these papers.
         papers = [
-            MonitoringPaperRecord(paper_id=f"p{i}", title=f"Paper {i}", is_new=True)
+            MonitoringPaperRecord(
+                paper_id=f"p{i}",
+                title=f"Paper {i}",
+                is_new=True,
+                url=f"https://arxiv.org/abs/p{i}",
+            )
             for i in range(3)
         ]
         run_obj = _make_run(subscription_id="sub-budget")

--- a/tests/unit/test_scheduling/test_monitoring_check_job.py
+++ b/tests/unit/test_scheduling/test_monitoring_check_job.py
@@ -586,3 +586,111 @@ class TestSchedulerHelper:
         )
         assert job_id == "custom_id"
         assert scheduler.scheduler.get_job("custom_id") is not None
+
+
+# ---------------------------------------------------------------------------
+# C-3 regression: LLM init failure must NOT leak API key in job logs
+# ---------------------------------------------------------------------------
+
+
+class TestJobApiKeyLeakageRegression:
+    """C-3: MonitoringCheckJob LLM init exception must NOT log the key."""
+
+    def test_init_llm_failure_does_not_leak_api_key_to_logs(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When LLMService raises an exception whose message contains the
+        API key (e.g., Pydantic ValidationError embedding the key),
+        the job logs ``error_type`` only — the raw key must NOT appear.
+        """
+        import structlog
+        import structlog.testing
+
+        from src.scheduling import jobs as jobs_module
+
+        monkeypatch.setattr(jobs_module, "logger", structlog.get_logger())
+        monkeypatch.setenv("LLM_API_KEY", "test-api-key-12345")
+
+        with (
+            patch(
+                "src.services.intelligence.monitoring.MonitoringRunner.from_paths"
+            ) as from_paths,
+            patch("src.services.providers.arxiv.ArxivProvider"),
+            patch("src.services.registry.service.RegistryService"),
+            patch(
+                "src.services.llm.service.LLMService",
+                side_effect=ValueError("validation error: test-api-key-12345"),
+            ),
+        ):
+            from_paths.return_value = MagicMock()
+            with structlog.testing.capture_logs() as logs:
+                MonitoringCheckJob(db_path=Path("./data/x.db"))
+
+        # The api key must not appear in any log field value.
+        for log_entry in logs:
+            for val in log_entry.values():
+                assert "test-api-key-12345" not in str(
+                    val
+                ), f"API key leaked in log field: {val}"
+
+        # Confirm error_type (not error message) was logged.
+        init_failed_events = [
+            e for e in logs if e.get("event") == "monitoring_check_job_llm_init_failed"
+        ]
+        assert len(init_failed_events) == 1
+        assert "error_type" in init_failed_events[0]
+        assert "error" not in init_failed_events[0]
+
+
+# ---------------------------------------------------------------------------
+# H-S4 regression: whitespace-only env vars in job must fall back to legacy
+# ---------------------------------------------------------------------------
+
+
+class TestJobWhitespaceEnvVarRegression:
+    """H-S4: whitespace-only API key env vars must skip LLM/S2 wiring."""
+
+    def test_whitespace_only_llm_key_skips_tier1_wiring(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A whitespace-only LLM_API_KEY must not wire LLM or Tier 1."""
+        monkeypatch.setenv("LLM_API_KEY", "   ")  # whitespace only
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+
+        with (
+            patch(
+                "src.services.intelligence.monitoring.MonitoringRunner.from_paths"
+            ) as from_paths,
+            patch("src.services.providers.arxiv.ArxivProvider"),
+            patch("src.services.registry.service.RegistryService"),
+        ):
+            from_paths.return_value = MagicMock()
+            MonitoringCheckJob(db_path=Path("./data/x.db"))
+
+        kwargs = from_paths.call_args.kwargs
+        assert kwargs["llm_service"] is None
+        assert kwargs["extra_providers"] is None
+        assert kwargs["query_expander"] is None
+
+    def test_whitespace_only_s2_key_skips_s2_provider(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A whitespace-only SEMANTIC_SCHOLAR_API_KEY must not include S2."""
+        monkeypatch.setenv("LLM_API_KEY", "test-llm-key")
+        monkeypatch.setenv("SEMANTIC_SCHOLAR_API_KEY", "   ")  # whitespace only
+
+        with (
+            patch(
+                "src.services.intelligence.monitoring.MonitoringRunner.from_paths"
+            ) as from_paths,
+            patch("src.services.providers.arxiv.ArxivProvider"),
+            patch("src.services.registry.service.RegistryService"),
+        ):
+            from_paths.return_value = MagicMock()
+            MonitoringCheckJob(db_path=Path("./data/x.db"))
+
+        kwargs = from_paths.call_args.kwargs
+        from src.services.intelligence.monitoring.models import PaperSource
+
+        assert kwargs["extra_providers"] is not None
+        assert PaperSource.SEMANTIC_SCHOLAR not in kwargs["extra_providers"]

--- a/tests/unit/test_scheduling/test_monitoring_check_job.py
+++ b/tests/unit/test_scheduling/test_monitoring_check_job.py
@@ -145,6 +145,139 @@ class TestMonitoringCheckJobInit:
             MonitoringCheckJob(db_path=Path("./data/x.db"))
         from_paths.assert_called_once()
 
+    def test_init_without_llm_key_skips_tier1_wiring(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Tier 1 (Issue #139): when no LLM key is in the env, the job
+        falls back to legacy single-arxiv wiring (no extras, no
+        expander). ``from_paths`` is called with both Tier 1 args
+        ``None`` so it constructs the legacy ``ArxivMonitor``.
+        """
+        monkeypatch.delenv("LLM_API_KEY", raising=False)
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        with (
+            patch(
+                "src.services.intelligence.monitoring.MonitoringRunner.from_paths"
+            ) as from_paths,
+            patch("src.services.providers.arxiv.ArxivProvider"),
+            patch("src.services.registry.service.RegistryService"),
+        ):
+            from_paths.return_value = MagicMock()
+            MonitoringCheckJob(db_path=Path("./data/x.db"))
+        # No LLM → no extras, no expander, no scorer
+        kwargs = from_paths.call_args.kwargs
+        assert kwargs["llm_service"] is None
+        assert kwargs["extra_providers"] is None
+        assert kwargs["query_expander"] is None
+
+    def test_init_with_llm_key_wires_tier1_providers_and_expander(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Tier 1 (Issue #139): when LLM_API_KEY is present, the job
+        wires extra providers (OpenAlex + HuggingFace; S2 only if its
+        own key is present) and a QueryExpander for query expansion.
+        """
+        monkeypatch.setenv("LLM_API_KEY", "test-llm-key")
+        monkeypatch.delenv("SEMANTIC_SCHOLAR_API_KEY", raising=False)
+        with (
+            patch(
+                "src.services.intelligence.monitoring.MonitoringRunner.from_paths"
+            ) as from_paths,
+            patch("src.services.providers.arxiv.ArxivProvider"),
+            patch("src.services.registry.service.RegistryService"),
+        ):
+            from_paths.return_value = MagicMock()
+            MonitoringCheckJob(db_path=Path("./data/x.db"))
+        kwargs = from_paths.call_args.kwargs
+        assert kwargs["llm_service"] is not None
+        # Without S2 key: OpenAlex + HuggingFace, no S2
+        from src.services.intelligence.monitoring.models import PaperSource
+
+        assert kwargs["extra_providers"] is not None
+        assert PaperSource.OPENALEX in kwargs["extra_providers"]
+        assert PaperSource.HUGGINGFACE in kwargs["extra_providers"]
+        assert PaperSource.SEMANTIC_SCHOLAR not in kwargs["extra_providers"]
+        assert kwargs["query_expander"] is not None
+
+    def test_init_with_llm_and_s2_keys_includes_s2_provider(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Tier 1: when SEMANTIC_SCHOLAR_API_KEY is also present,
+        Semantic Scholar joins the multi-provider fan-out.
+        """
+        monkeypatch.setenv("LLM_API_KEY", "test-llm-key")
+        monkeypatch.setenv("SEMANTIC_SCHOLAR_API_KEY", "test-s2-key")
+        with (
+            patch(
+                "src.services.intelligence.monitoring.MonitoringRunner.from_paths"
+            ) as from_paths,
+            patch("src.services.providers.arxiv.ArxivProvider"),
+            patch("src.services.registry.service.RegistryService"),
+        ):
+            from_paths.return_value = MagicMock()
+            MonitoringCheckJob(db_path=Path("./data/x.db"))
+        kwargs = from_paths.call_args.kwargs
+        from src.services.intelligence.monitoring.models import PaperSource
+
+        assert PaperSource.SEMANTIC_SCHOLAR in kwargs["extra_providers"]
+
+    def test_init_llm_construction_failure_falls_back_gracefully(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Tier 1: if LLMService construction raises (e.g., bad config),
+        we log + continue without scoring or expansion (legacy wiring).
+        Pre-PR code already had this defensive handler at jobs.py:786-795
+        — the new test pins it before we trust the fallback in production.
+        """
+        monkeypatch.setenv("LLM_API_KEY", "test-llm-key")
+        with (
+            patch(
+                "src.services.intelligence.monitoring.MonitoringRunner.from_paths"
+            ) as from_paths,
+            patch("src.services.providers.arxiv.ArxivProvider"),
+            patch("src.services.registry.service.RegistryService"),
+            patch(
+                "src.services.llm.service.LLMService",
+                side_effect=RuntimeError("bad llm config"),
+            ),
+        ):
+            from_paths.return_value = MagicMock()
+            MonitoringCheckJob(db_path=Path("./data/x.db"))
+        kwargs = from_paths.call_args.kwargs
+        # LLM init failed → no scorer + no tier 1 wiring (legacy fallback)
+        assert kwargs["llm_service"] is None
+        assert kwargs["extra_providers"] is None
+        assert kwargs["query_expander"] is None
+
+    def test_init_tier1_provider_construction_failure_falls_back(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Tier 1: if extra-provider construction raises (e.g., S2
+        rejects empty key), we log + run with LLM-only (scorer present
+        but legacy single-arxiv monitor). Tests the inner try/except
+        at jobs.py:833-840.
+        """
+        monkeypatch.setenv("LLM_API_KEY", "test-llm-key")
+        monkeypatch.delenv("SEMANTIC_SCHOLAR_API_KEY", raising=False)
+        with (
+            patch(
+                "src.services.intelligence.monitoring.MonitoringRunner.from_paths"
+            ) as from_paths,
+            patch("src.services.providers.arxiv.ArxivProvider"),
+            patch("src.services.registry.service.RegistryService"),
+            patch(
+                "src.services.providers.openalex.OpenAlexProvider",
+                side_effect=RuntimeError("openalex init failed"),
+            ),
+        ):
+            from_paths.return_value = MagicMock()
+            MonitoringCheckJob(db_path=Path("./data/x.db"))
+        kwargs = from_paths.call_args.kwargs
+        # LLM still wired (scoring works), but Tier 1 fan-out not wired
+        assert kwargs["llm_service"] is not None
+        assert kwargs["extra_providers"] is None
+        assert kwargs["query_expander"] is None
+
 
 # ---------------------------------------------------------------------------
 # Run behavior


### PR DESCRIPTION
## Summary

Closes #139. Phase 9.1 monitoring previously used a literal subscription query against arXiv only. This PR wires existing project capabilities (multi-provider search + Phase 7.2 `QueryExpander`) into a new `MultiProviderMonitor` that's a drop-in for `ArxivMonitor`. When `LLM_API_KEY` is in env, monitoring now searches arXiv + OpenAlex + HuggingFace (+ Semantic Scholar when its key is also present), with each subscription's literal query expanded into N variants via Gemini Flash (~$0.0001 per cycle).

## Backward compatibility

Zero. When no LLM key is in env, the legacy `ArxivMonitor` path runs unchanged. Both monitors return the same `ArxivMonitorResult` so `MonitoringRunner` is duck-type compatible across both implementations.

## Architecture

- **New module** `src/services/intelligence/monitoring/multi_provider_monitor.py` (~280 LOC)
  - `MultiProviderMonitor` class
  - `MultiProviderMonitorConfig` (Pydantic V2 strict)
- **Modified** `runner.py::from_paths()` accepts `extra_providers` and `query_expander`. Selects monitor based on inputs.
- **Modified** `cli/monitor.py::_build_runner()` and `scheduling/jobs.py::MonitoringCheckJob.__init__()` build the wiring when LLM is wired.

## Failure semantics (mirrored from PR #126)

- Provider failure on one query variant → log + skip (Fail-Soft, status PARTIAL).
- Query expander failure → log + fall back to literal query (Fail-Soft).
- Registry write error per paper → log + mark cycle PARTIAL.
- Identity resolution error per paper → log + mark cycle PARTIAL.
- Extra-provider construction failure → log + fall back to legacy single-arxiv (LLM scorer still wired).

## Verification

- **5046 tests passing** (+25 net new)
- **99.12% combined line+branch coverage** (was 99.06%)
- New module `multi_provider_monitor.py` at **100%** line+branch
- Pre-push `./verify.sh` ✅ (Black/Flake8/Mypy/Pytest all green)

## Test plan

- [ ] CI green (5 gates)
- [ ] After merge: tomorrow's 02:30 monitor-check digest reflects multi-provider coverage (papers from S2/OpenAlex/HF in addition to arXiv)
- [ ] After merge: structured log event `monitor_query_expansion_complete` shows `variant_count > 1` per cycle
- [ ] Self-reviewed via 4-agent OMC workflow before requesting team review