### PR TITLE
refactor(phase-9.2): extract CitationInfluenceRepository (closes #134)

### DIFF
--- a/src/services/intelligence/citation/influence_repository.py
+++ b/src/services/intelligence/citation/influence_repository.py
@@ -1,0 +1,382 @@
+"""Persistence for ``InfluenceMetrics`` (V4 ``citation_influence_metrics``).
+
+Why a standalone repository
+---------------------------
+PR #132 self-review surfaced H-A3: :class:`InfluenceScorer` reached
+around :class:`SQLiteGraphStore` directly (via
+``open_connection(self.store.db_path)``) to manage the V4 cache table
+that the graph store does not know about. Folding cache CRUD into the
+service blurred the layering -- services owning their own SQL schemas
+sets a precedent that erodes the repository pattern (compare
+:class:`MonitoringRunRepository`'s motivation).
+
+This module hosts the canonical owner of the
+``citation_influence_metrics`` table introduced by
+``MIGRATION_V4_CITATION_INFLUENCE_METRICS``. The scorer (writer) and
+the recommender (Issue #130, future reader) both go through this
+class -- no other module should touch the table directly.
+
+Schema (created by ``MIGRATION_V4_CITATION_INFLUENCE_METRICS``)
+---------------------------------------------------------------
+::
+
+    citation_influence_metrics(
+        paper_id           TEXT PRIMARY KEY,
+        citation_count     INTEGER NOT NULL DEFAULT 0,
+        citation_velocity  REAL    NOT NULL DEFAULT 0.0,
+        pagerank_score     REAL    NOT NULL DEFAULT 0.0,
+        hub_score          REAL    NOT NULL DEFAULT 0.0,
+        authority_score    REAL    NOT NULL DEFAULT 0.0,
+        computed_at        TEXT    NOT NULL,
+        version            INTEGER NOT NULL DEFAULT 1
+    )
+
+TTL semantics
+-------------
+``get_metrics`` filters out rows whose ``computed_at`` is older than
+``max_age_days`` ago (default 7 to match the spec REQ-9.2.4 ``CACHE_TTL``).
+Callers receive ``None`` for stale rows so they can decide whether to
+recompute. The stale row itself is *not* deleted on read -- that is
+:meth:`delete_stale`'s job (a Phase 10 cleanup hook will call it on a
+schedule).
+
+Concurrency model
+-----------------
+Same approach as :class:`MonitoringRunRepository`: each method opens a
+fresh connection through :func:`open_connection`, applies the standard
+PRAGMAs, and closes on exit. ``record_metrics`` uses
+:func:`retry_on_lock_contention` (issue #133) so transient
+SQLITE_BUSY/SQLITE_LOCKED contention from a colliding writer does not
+silently drop a cache row. **Async callers MUST wrap
+``record_metrics`` / ``get_metrics`` / ``delete_stale`` in
+``asyncio.to_thread(...)``** -- the retry helper sleeps via
+``time.sleep`` and the connection helper itself is sync.
+
+Failure semantics
+-----------------
+``record_metrics``'s outer ``try`` catches ``sqlite3.Error`` (the
+common ancestor of ``OperationalError``, ``IntegrityError``,
+``DatabaseError``, ...) so the don't-fail-the-API-call contract from
+the original ``_write_cache`` is preserved. The retry helper itself
+only retries lock contention; any other ``sqlite3.Error`` propagates
+out of the helper, lands in the outer try, and is logged via the
+``citation_influence_repo_write_failed`` event. The caller still gets
+its in-memory metrics back.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, Iterator, Optional
+
+import structlog
+
+from src.storage.intelligence_graph.connection import (
+    DEFAULT_BACKOFF_SECONDS,
+    DEFAULT_MAX_ATTEMPTS,
+    open_connection,
+    retry_on_lock_contention,
+)
+from src.storage.intelligence_graph.migrations import MigrationManager
+from src.storage.intelligence_graph.path_utils import sanitize_storage_path
+
+if TYPE_CHECKING:
+    from src.services.intelligence.citation.influence_scorer import InfluenceMetrics
+
+logger = structlog.get_logger(__name__)
+
+
+# Default freshness window for ``get_metrics``. Mirrors
+# ``DEFAULT_CACHE_TTL`` in influence_scorer.py (REQ-9.2.4) so the
+# scorer's read path semantics are preserved when callers do not
+# supply ``max_age_days`` explicitly.
+DEFAULT_MAX_AGE_DAYS: int = 7
+
+
+class CitationInfluenceRepository:
+    """Owns the V4 ``citation_influence_metrics`` SQLite table.
+
+    Provides a small, repository-shaped surface for callers:
+
+    - :meth:`record_metrics` upsert one :class:`InfluenceMetrics` row.
+    - :meth:`get_metrics` fetch by ``paper_id`` honouring a TTL.
+    - :meth:`delete_stale` bulk delete rows older than a cutoff.
+
+    Async safety:
+        ALL methods are SYNC -- they open a SQLite connection,
+        possibly sleep on retry, and return. **Async callers MUST
+        wrap invocations in** ``asyncio.to_thread(...)`` per the
+        canonical pattern documented in CLAUDE.md "SQLite write retry"
+        section. Forgetting the wrap will block the event loop for the
+        full retry budget on every contended write (and any read that
+        races a writer).
+    """
+
+    def __init__(self, db_path: Path | str) -> None:
+        """Initialise the repository.
+
+        Args:
+            db_path: SQLite database path. Must lie under one of the
+                approved storage roots -- enforced by
+                :func:`sanitize_storage_path`. The same database file
+                also hosts the citation graph and (in the long-term
+                Phase 10 plan) the monitoring tables, so this points
+                at the shared intelligence DB.
+        """
+        self.db_path = sanitize_storage_path(db_path)
+        self._migrations = MigrationManager(self.db_path)
+        self._initialized = False
+
+    # ------------------------------------------------------------------
+    # Bookkeeping
+    # ------------------------------------------------------------------
+    def initialize(self) -> None:
+        """Apply pending schema migrations.
+
+        Idempotent -- safe to call multiple times. Must be called
+        before any read/write operation. Mirrors
+        :meth:`MonitoringRunRepository.initialize` so callers that
+        already use that pattern have no surprises.
+        """
+        applied = self._migrations.migrate()
+        if applied > 0:
+            logger.info(
+                "citation_influence_repository_migrations_applied",
+                count=applied,
+                db_path=str(self.db_path),
+            )
+        self._initialized = True
+
+    @classmethod
+    def from_path(cls, db_path: Path | str) -> "CitationInfluenceRepository":
+        """Construct + initialise in one call.
+
+        Convenience factory mirroring
+        :meth:`MonitoringRunner.from_paths`. Used by
+        :meth:`InfluenceScorer.from_paths` when no repository is
+        injected by the caller.
+        """
+        repo = cls(db_path)
+        repo.initialize()
+        return repo
+
+    @contextmanager
+    def _connect(self) -> Iterator[sqlite3.Connection]:
+        """Open + auto-close a SQLite connection with the standard PRAGMAs.
+
+        Delegates to :func:`open_connection` so the PRAGMA set is
+        defined in exactly one place across the intelligence-graph
+        layer.
+        """
+        if not self._initialized:
+            raise RuntimeError(
+                "CitationInfluenceRepository not initialized. "
+                "Call initialize() first."
+            )
+        with open_connection(self.db_path) as conn:
+            yield conn
+
+    # ------------------------------------------------------------------
+    # Writes
+    # ------------------------------------------------------------------
+    def record_metrics(self, metrics: "InfluenceMetrics") -> None:
+        """Upsert one ``InfluenceMetrics`` row.
+
+        Concurrency:
+            Uses ``BEGIN IMMEDIATE`` (matching
+            :meth:`MonitoringRunRepository.record_run`) so the write
+            lock is acquired up front. Transient
+            ``OperationalError("database is locked")`` are retried
+            up to :data:`DEFAULT_MAX_ATTEMPTS` times via
+            :func:`retry_on_lock_contention` (issue #133).
+
+            **Async callers MUST wrap this call in
+            ``asyncio.to_thread(...)``** -- the retry loop uses
+            ``time.sleep`` which would block the event loop. The
+            scorer's ``compute_for_paper`` / ``compute_for_graph`` do
+            this at every call site.
+
+        Failure semantics:
+            The outer ``try`` catches ``sqlite3.Error`` (superclass of
+            ``OperationalError``, ``IntegrityError``, ``DatabaseError``,
+            ...) so the don't-fail-the-API-call contract from the
+            original ``_write_cache`` is preserved. Any non-contention
+            ``sqlite3.Error`` is logged via
+            ``citation_influence_repo_write_failed`` and swallowed --
+            the caller still receives its in-memory metrics. The retry
+            helper handles only contention; everything else propagates
+            out of the helper, lands in the outer try, and is logged.
+
+        Args:
+            metrics: Single :class:`InfluenceMetrics` row to upsert.
+        """
+        try:
+            retry_on_lock_contention(
+                lambda: self._record_metrics_once(metrics),
+                max_attempts=DEFAULT_MAX_ATTEMPTS,
+                backoff_seconds=DEFAULT_BACKOFF_SECONDS,
+                operation_name="influence_record_metrics",
+                paper_id=metrics.paper_id,
+            )
+        except sqlite3.Error as exc:
+            # Audit-write the failure path so ops can grep for cache
+            # write outages. We swallow the exception so the caller
+            # still receives its in-memory metrics (matches the
+            # original ``_write_cache`` contract).
+            logger.error(
+                "citation_influence_repo_write_failed",
+                paper_id=metrics.paper_id,
+                error=str(exc),
+            )
+
+    def _record_metrics_once(self, metrics: "InfluenceMetrics") -> None:
+        """Single-attempt upsert of one row.
+
+        Extracted so the retry loop is the only place that catches
+        contention errors -- keeps the success path tidy and the
+        retry boundary explicit. Mirrors
+        :meth:`MonitoringRunRepository._record_run_once`.
+        """
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                conn.execute(
+                    """
+                    INSERT INTO citation_influence_metrics (
+                        paper_id, citation_count, citation_velocity,
+                        pagerank_score, hub_score, authority_score,
+                        computed_at
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(paper_id) DO UPDATE SET
+                        citation_count = excluded.citation_count,
+                        citation_velocity = excluded.citation_velocity,
+                        pagerank_score = excluded.pagerank_score,
+                        hub_score = excluded.hub_score,
+                        authority_score = excluded.authority_score,
+                        computed_at = excluded.computed_at
+                    """,
+                    (
+                        metrics.paper_id,
+                        metrics.citation_count,
+                        metrics.citation_velocity,
+                        metrics.pagerank_score,
+                        metrics.hub_score,
+                        metrics.authority_score,
+                        metrics.computed_at.isoformat(),
+                    ),
+                )
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                raise
+
+    def delete_stale(self, older_than: datetime) -> int:
+        """Bulk delete rows whose ``computed_at`` predates ``older_than``.
+
+        Returns:
+            The number of rows actually deleted, for ops visibility.
+            A Phase 10 cleanup hook will surface this number to its
+            scheduler so persistent backlog growth is observable.
+
+        Concurrency:
+            Same retry semantics as :meth:`record_metrics`. Async
+            callers must wrap in ``asyncio.to_thread(...)``.
+        """
+
+        def _delete_once() -> int:
+            with self._connect() as conn:
+                conn.execute("BEGIN IMMEDIATE")
+                try:
+                    cursor = conn.execute(
+                        """
+                        DELETE FROM citation_influence_metrics
+                        WHERE computed_at < ?
+                        """,
+                        (older_than.isoformat(),),
+                    )
+                    affected = cursor.rowcount
+                    conn.commit()
+                    return int(affected)
+                except Exception:
+                    conn.rollback()
+                    raise
+
+        return retry_on_lock_contention(
+            _delete_once,
+            max_attempts=DEFAULT_MAX_ATTEMPTS,
+            backoff_seconds=DEFAULT_BACKOFF_SECONDS,
+            operation_name="influence_delete_stale",
+            cutoff=older_than.isoformat(),
+        )
+
+    # ------------------------------------------------------------------
+    # Reads
+    # ------------------------------------------------------------------
+    def get_metrics(
+        self,
+        paper_id: str,
+        max_age_days: int = DEFAULT_MAX_AGE_DAYS,
+    ) -> Optional["InfluenceMetrics"]:
+        """Fetch a single cached row or ``None``.
+
+        TTL semantics:
+            Rows whose ``computed_at`` is older than ``max_age_days``
+            ago are treated as cache misses and ``None`` is returned.
+            The stale row is *not* deleted -- callers can choose to
+            recompute and overwrite, and a future Phase 10 cleanup
+            hook calls :meth:`delete_stale` on a schedule.
+
+        Args:
+            paper_id: The canonical paper id (validated by the
+                scorer before reaching this layer).
+            max_age_days: Freshness window. Must be > 0. Default
+                is :data:`DEFAULT_MAX_AGE_DAYS` (7) to mirror the
+                original scorer's ``CACHE_TTL``.
+
+        Returns:
+            ``InfluenceMetrics`` if a fresh row exists, else ``None``.
+
+        Raises:
+            ValueError: If ``max_age_days`` is not positive.
+        """
+        # Local import to avoid a circular import between
+        # influence_scorer (which imports the repository) and
+        # influence_repository (which would otherwise import the
+        # metrics model from the scorer at module load time).
+        from src.services.intelligence.citation.influence_scorer import (
+            InfluenceMetrics,
+        )
+
+        if max_age_days <= 0:
+            raise ValueError("max_age_days must be positive")
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                SELECT paper_id, citation_count, citation_velocity,
+                       pagerank_score, hub_score, authority_score,
+                       computed_at
+                FROM citation_influence_metrics
+                WHERE paper_id = ?
+                """,
+                (paper_id,),
+            )
+            row = cursor.fetchone()
+        if row is None:
+            return None
+        computed_at = datetime.fromisoformat(row["computed_at"])
+        cutoff = datetime.now(timezone.utc) - timedelta(days=max_age_days)
+        if computed_at < cutoff:
+            return None
+        return InfluenceMetrics(
+            paper_id=row["paper_id"],
+            citation_count=row["citation_count"],
+            citation_velocity=row["citation_velocity"],
+            pagerank_score=row["pagerank_score"],
+            hub_score=row["hub_score"],
+            authority_score=row["authority_score"],
+            computed_at=computed_at,
+        )

--- a/src/services/intelligence/citation/influence_repository.py
+++ b/src/services/intelligence/citation/influence_repository.py
@@ -77,6 +77,7 @@ import structlog
 from src.storage.intelligence_graph.connection import (
     DEFAULT_BACKOFF_SECONDS,
     DEFAULT_MAX_ATTEMPTS,
+    _trunc,
     open_connection,
     retry_on_lock_contention,
 )
@@ -229,7 +230,7 @@ class CitationInfluenceRepository:
             logger.error(
                 "citation_influence_repo_write_failed",
                 paper_id=metrics.paper_id,
-                error=str(exc),
+                error=_trunc(exc),
             )
 
     def _record_metrics_once(self, metrics: "InfluenceMetrics") -> None:

--- a/src/services/intelligence/citation/influence_repository.py
+++ b/src/services/intelligence/citation/influence_repository.py
@@ -152,17 +152,39 @@ class CitationInfluenceRepository:
         self._initialized = True
 
     @classmethod
-    def from_path(cls, db_path: Path | str) -> "CitationInfluenceRepository":
-        """Construct + initialise in one call.
+    def connect(cls, db_path: Path | str) -> "CitationInfluenceRepository":
+        """Construct, run pending migrations, and return a ready repo.
 
-        Convenience factory mirroring
-        :meth:`MonitoringRunner.from_paths`. Used by
-        :meth:`InfluenceScorer.from_paths` when no repository is
-        injected by the caller.
+        Side effects (disclosed):
+            1. Calls :meth:`initialize` which invokes
+               :class:`~src.storage.intelligence_graph.migrations.MigrationManager`
+               ``migrate()`` -- applies any pending schema migrations up
+               to the latest version (including V4 ``citation_influence_metrics``
+               if the DB was created by an older version of the code).
+            2. Issues PRAGMA statements (via :func:`open_connection`) to
+               configure WAL mode, foreign-key enforcement, and busy
+               timeout on a temporary connection opened during
+               ``migrate()``.
+
+        This is the intended entry-point for production callers. Use
+        direct :class:`CitationInfluenceRepository` construction + a
+        separate :meth:`initialize` call only when you need finer
+        control (e.g. test fixtures that isolate migration side-effects).
+
+        Mirrors :meth:`MonitoringRunner.from_paths`.
         """
         repo = cls(db_path)
         repo.initialize()
         return repo
+
+    @classmethod
+    def from_path(cls, db_path: Path | str) -> "CitationInfluenceRepository":
+        """Alias for :meth:`connect` (backward compatibility).
+
+        Prefer :meth:`connect` for new call sites -- it discloses the
+        migration + PRAGMA side-effects in its docstring (H-3).
+        """
+        return cls.connect(db_path)
 
     @contextmanager
     def _connect(self) -> Iterator[sqlite3.Connection]:

--- a/src/services/intelligence/citation/influence_repository.py
+++ b/src/services/intelligence/citation/influence_repository.py
@@ -70,7 +70,7 @@ import sqlite3
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Iterator, Optional
+from typing import TYPE_CHECKING, Callable, Iterator, Optional, TypeVar
 
 import structlog
 
@@ -88,6 +88,8 @@ if TYPE_CHECKING:
     from src.services.intelligence.citation.influence_scorer import InfluenceMetrics
 
 logger = structlog.get_logger(__name__)
+
+_T = TypeVar("_T")
 
 
 # Default freshness window for ``get_metrics``. Mirrors
@@ -202,6 +204,40 @@ class CitationInfluenceRepository:
         with open_connection(self.db_path) as conn:
             yield conn
 
+    def _retry(
+        self,
+        operation: Callable[[], _T],
+        *,
+        operation_name: str,
+        **extra_log_fields: object,
+    ) -> _T:
+        """Thin wrapper around :func:`retry_on_lock_contention`.
+
+        Applies the repository's standard retry budget
+        (:data:`DEFAULT_MAX_ATTEMPTS`, :data:`DEFAULT_BACKOFF_SECONDS`)
+        so each method only has to supply the ``operation_name`` and
+        any extra log fields, keeping the retry boilerplate DRY.
+
+        Args:
+            operation: Zero-arg callable to execute and retry on
+                lock contention.
+            operation_name: Passed through to
+                :func:`retry_on_lock_contention` for log correlation.
+            **extra_log_fields: Additional structured log fields
+                (e.g. ``paper_id=...``) merged into every log event.
+
+        Returns:
+            Whatever ``operation()`` returns on its first successful
+            attempt.
+        """
+        return retry_on_lock_contention(
+            operation,
+            max_attempts=DEFAULT_MAX_ATTEMPTS,
+            backoff_seconds=DEFAULT_BACKOFF_SECONDS,
+            operation_name=operation_name,
+            **extra_log_fields,
+        )
+
     # ------------------------------------------------------------------
     # Writes
     # ------------------------------------------------------------------
@@ -237,10 +273,8 @@ class CitationInfluenceRepository:
             metrics: Single :class:`InfluenceMetrics` row to upsert.
         """
         try:
-            retry_on_lock_contention(
+            self._retry(
                 lambda: self._record_metrics_once(metrics),
-                max_attempts=DEFAULT_MAX_ATTEMPTS,
-                backoff_seconds=DEFAULT_BACKOFF_SECONDS,
                 operation_name="influence_record_metrics",
                 paper_id=metrics.paper_id,
             )
@@ -328,10 +362,8 @@ class CitationInfluenceRepository:
                     conn.rollback()
                     raise
 
-        return retry_on_lock_contention(
+        return self._retry(
             _delete_once,
-            max_attempts=DEFAULT_MAX_ATTEMPTS,
-            backoff_seconds=DEFAULT_BACKOFF_SECONDS,
             operation_name="influence_delete_stale",
             cutoff=older_than.isoformat(),
         )
@@ -422,10 +454,8 @@ class CitationInfluenceRepository:
                 computed_at=computed_at,
             )
 
-        return retry_on_lock_contention(
+        return self._retry(
             _get_once,
-            max_attempts=DEFAULT_MAX_ATTEMPTS,
-            backoff_seconds=DEFAULT_BACKOFF_SECONDS,
             operation_name="influence_get_metrics",
             paper_id=paper_id,
         )

--- a/src/services/intelligence/citation/influence_repository.py
+++ b/src/services/intelligence/citation/influence_repository.py
@@ -331,6 +331,13 @@ class CitationInfluenceRepository:
             recompute and overwrite, and a future Phase 10 cleanup
             hook calls :meth:`delete_stale` on a schedule.
 
+        Concurrency:
+            Wrapped in :func:`retry_on_lock_contention` so transient
+            SQLITE_BUSY/SQLITE_LOCKED contention from a colliding
+            writer does not cause a spurious cache miss. Async callers
+            MUST wrap this call in ``asyncio.to_thread(...)`` -- the
+            retry helper sleeps via ``time.sleep``.
+
         Args:
             paper_id: The canonical paper id (validated by the
                 scorer before reaching this layer).
@@ -354,30 +361,49 @@ class CitationInfluenceRepository:
 
         if max_age_days <= 0:
             raise ValueError("max_age_days must be positive")
-        with self._connect() as conn:
-            cursor = conn.execute(
-                """
-                SELECT paper_id, citation_count, citation_velocity,
-                       pagerank_score, hub_score, authority_score,
-                       computed_at
-                FROM citation_influence_metrics
-                WHERE paper_id = ?
-                """,
-                (paper_id,),
+
+        def _get_once() -> Optional["InfluenceMetrics"]:
+            with self._connect() as conn:
+                cursor = conn.execute(
+                    """
+                    SELECT paper_id, citation_count, citation_velocity,
+                           pagerank_score, hub_score, authority_score,
+                           computed_at
+                    FROM citation_influence_metrics
+                    WHERE paper_id = ?
+                    """,
+                    (paper_id,),
+                )
+                row = cursor.fetchone()
+            if row is None:
+                return None
+            computed_at = datetime.fromisoformat(row["computed_at"])
+            # H-1: ensure both sides of the comparison are timezone-aware
+            # UTC datetimes. ``computed_at`` is stored via
+            # ``.isoformat()`` from a ``datetime.now(timezone.utc)`` so
+            # it carries the "+00:00" suffix on Python 3.11+. Force UTC
+            # if the parsed value is somehow naive (older SQLite rows,
+            # test fixtures without tz suffix) so the comparison is
+            # always apples-to-apples.
+            if computed_at.tzinfo is None:
+                computed_at = computed_at.replace(tzinfo=timezone.utc)
+            cutoff = datetime.now(timezone.utc) - timedelta(days=max_age_days)
+            if computed_at < cutoff:
+                return None
+            return InfluenceMetrics(
+                paper_id=row["paper_id"],
+                citation_count=row["citation_count"],
+                citation_velocity=row["citation_velocity"],
+                pagerank_score=row["pagerank_score"],
+                hub_score=row["hub_score"],
+                authority_score=row["authority_score"],
+                computed_at=computed_at,
             )
-            row = cursor.fetchone()
-        if row is None:
-            return None
-        computed_at = datetime.fromisoformat(row["computed_at"])
-        cutoff = datetime.now(timezone.utc) - timedelta(days=max_age_days)
-        if computed_at < cutoff:
-            return None
-        return InfluenceMetrics(
-            paper_id=row["paper_id"],
-            citation_count=row["citation_count"],
-            citation_velocity=row["citation_velocity"],
-            pagerank_score=row["pagerank_score"],
-            hub_score=row["hub_score"],
-            authority_score=row["authority_score"],
-            computed_at=computed_at,
+
+        return retry_on_lock_contention(
+            _get_once,
+            max_attempts=DEFAULT_MAX_ATTEMPTS,
+            backoff_seconds=DEFAULT_BACKOFF_SECONDS,
+            operation_name="influence_get_metrics",
+            paper_id=paper_id,
         )

--- a/src/services/intelligence/citation/influence_scorer.py
+++ b/src/services/intelligence/citation/influence_scorer.py
@@ -14,13 +14,25 @@ Computes per-paper influence metrics over the citation graph:
 Persistence
 -----------
 Results are cached in the ``citation_influence_metrics`` table
-introduced by V4 of the migration manager. ``compute_for_paper`` checks
+introduced by V4 of the migration manager. CRUD on that table is
+delegated to :class:`CitationInfluenceRepository` (issue #134) so the
+scorer no longer reaches around :class:`SQLiteGraphStore` to manage
+schemas the graph store does not own. ``compute_for_paper`` checks
 the cache first; if the row's ``computed_at`` is within ``CACHE_TTL``
 (7 days), the cached row is returned and the expensive PageRank /
 HITS work is skipped. ``compute_for_graph`` is the bulk variant: a
-single PageRank invocation covers all requested nodes, then the rows
-are upserted in one ``BEGIN IMMEDIATE`` transaction so partial-write
-recovery is straightforward.
+single PageRank invocation covers all requested nodes, then each row
+is upserted via the repository.
+
+Async safety
+------------
+The repository's read and write paths are SYNC (the write path uses
+:func:`retry_on_lock_contention` which calls ``time.sleep``). All
+calls into the repository from the async ``compute_for_paper`` /
+``compute_for_graph`` methods are wrapped in
+``await asyncio.to_thread(...)`` so contention backoff (or any
+incidental I/O) does not stall the event loop -- the canonical
+async-wrapping pattern documented in CLAUDE.md "SQLite write retry".
 
 Failure semantics
 -----------------
@@ -31,15 +43,14 @@ Failure semantics
   ``influence_scorer_velocity_skipped_missing_date`` and returns
   velocity = 0.0.
 - Cache write failures DO NOT cause the API call to fail — the
-  computed metrics are still returned to the caller. The cache miss
-  is logged via ``influence_scorer_cache_write_failed`` so ops can
-  investigate disk pressure / migration drift.
+  repository swallows non-contention ``sqlite3.Error`` after logging
+  ``citation_influence_repo_write_failed`` so the computed metrics are
+  still returned to the caller.
 """
 
 from __future__ import annotations
 
 import asyncio
-import sqlite3
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Optional
@@ -51,12 +62,11 @@ from src.services.intelligence.citation._id_validation import (
     CANONICAL_NODE_ID_PATTERN,
     PAPER_ID_MAX_LENGTH,
 )
-from src.services.intelligence.models import EdgeType, NodeType
-from src.storage.intelligence_graph import (
-    GraphAlgorithms,
-    SQLiteGraphStore,
-    open_connection,
+from src.services.intelligence.citation.influence_repository import (
+    CitationInfluenceRepository,
 )
+from src.services.intelligence.models import EdgeType, NodeType
+from src.storage.intelligence_graph import GraphAlgorithms, SQLiteGraphStore
 
 logger = structlog.get_logger(__name__)
 
@@ -130,6 +140,7 @@ class InfluenceScorer:
         *,
         cache_ttl: timedelta = DEFAULT_CACHE_TTL,
         now: Optional[datetime] = None,
+        repo: Optional[CitationInfluenceRepository] = None,
     ) -> None:
         """Initialise the scorer.
 
@@ -142,10 +153,20 @@ class InfluenceScorer:
                 7 days per spec.
             now: Injectable "current time" for tests. Defaults to
                 ``datetime.now(timezone.utc)`` evaluated on each lookup.
+            repo: Pre-built :class:`CitationInfluenceRepository` for
+                dependency injection (tests, alternative wiring). When
+                ``None`` (the backward-compat default), a repository is
+                constructed against ``store.db_path`` and initialised --
+                preserving the legacy "scorer manages its own DB"
+                surface for callers that haven't migrated to explicit
+                injection yet.
         """
         self.store = store
         self.cache_ttl = cache_ttl
         self._now_override = now
+        if repo is None:
+            repo = CitationInfluenceRepository.from_path(store.db_path)
+        self._repo = repo
 
     @classmethod
     def from_paths(
@@ -154,10 +175,17 @@ class InfluenceScorer:
         db_path: Path | str,
         cache_ttl: timedelta = DEFAULT_CACHE_TTL,
     ) -> "InfluenceScorer":
-        """Convenience factory mirroring CitationCrawler.from_paths."""
+        """Convenience factory mirroring CitationCrawler.from_paths.
+
+        Constructs the underlying :class:`SQLiteGraphStore` *and* a
+        matching :class:`CitationInfluenceRepository` against the same
+        ``db_path`` (issue #134) so callers no longer need to know
+        the cache table exists.
+        """
         store = SQLiteGraphStore(db_path)
         store.initialize()
-        return cls(store=store, cache_ttl=cache_ttl)
+        repo = CitationInfluenceRepository.from_path(db_path)
+        return cls(store=store, cache_ttl=cache_ttl, repo=repo)
 
     def _now(self) -> datetime:
         """Return the current UTC time, honoring the test override."""
@@ -174,15 +202,29 @@ class InfluenceScorer:
 
         Cache hit: returns the stored row without invoking PageRank.
         Cache miss: runs PageRank + HITS over the whole graph, writes
-        the row, and returns the computed metrics.
+        the row via :class:`CitationInfluenceRepository`, and returns
+        the computed metrics.
+
+        Async safety:
+            The repository's read and write paths are SYNC (the write
+            path uses ``time.sleep`` for retry backoff). Both calls
+            below are wrapped in ``asyncio.to_thread`` so contention
+            does not stall the event loop -- canonical pattern from
+            CLAUDE.md "SQLite write retry".
 
         Raises:
             ValueError: If ``paper_id`` is malformed.
         """
         self._validate_paper_id(paper_id)
 
-        cached = self._read_cache(paper_id)
-        if cached is not None and self._is_fresh(cached.computed_at):
+        cached = await asyncio.to_thread(
+            self._repo.get_metrics,
+            paper_id,
+            self._max_age_days(),
+        )
+        if cached is not None:
+            # The repo's TTL filter already returned ``None`` for stale
+            # rows, so any non-None hit is fresh by construction.
             return cached
 
         # Cache miss → compute over the whole graph (PageRank is
@@ -193,14 +235,16 @@ class InfluenceScorer:
             paper_id,
             InfluenceMetrics(paper_id=paper_id, computed_at=self._now()),
         )
-        self._write_cache([metrics])
+        await asyncio.to_thread(self._repo.record_metrics, metrics)
         return metrics
 
     async def compute_for_graph(self, node_ids: list[str]) -> list[InfluenceMetrics]:
         """Bulk compute metrics for a set of papers.
 
-        One PageRank invocation; one HITS invocation; one batched
-        upsert. Returns metrics in the same order as ``node_ids``.
+        One PageRank invocation; one HITS invocation; one
+        ``record_metrics`` call per row (each in
+        ``asyncio.to_thread`` so the event loop is never blocked).
+        Returns metrics in the same order as ``node_ids``.
 
         Raises:
             ValueError: If any ``node_id`` is malformed.
@@ -222,8 +266,24 @@ class InfluenceScorer:
                 InfluenceMetrics(paper_id=nid, computed_at=self._now()),
             )
             out.append(metrics)
-        self._write_cache(out)
+        for metrics in out:
+            await asyncio.to_thread(self._repo.record_metrics, metrics)
         return out
+
+    def _max_age_days(self) -> int:
+        """Convert the scorer's ``cache_ttl`` to whole days for the repo.
+
+        The repository expresses freshness as an integer day count.
+        Round up so a TTL of (e.g.) 7 days + 1 second still treats a
+        7-day-old row as fresh -- preserves the original
+        ``timedelta``-based ``_is_fresh`` semantics for callers that
+        haven't moved off the legacy ``cache_ttl`` constructor arg.
+        Anything sub-day rounds up to 1 to keep the repo's
+        ``max_age_days > 0`` precondition satisfied.
+        """
+        seconds = self.cache_ttl.total_seconds()
+        days = int(-(-seconds // 86_400))  # ceil division on integers
+        return max(1, days)
 
     # ------------------------------------------------------------------
     # Internals
@@ -243,10 +303,6 @@ class InfluenceScorer:
                 f"Invalid paper_id format: {paper_id!r}. "
                 "Allowed: alphanumeric, colons, periods, hyphens, underscores."
             )
-
-    def _is_fresh(self, computed_at: datetime) -> bool:
-        """True iff ``computed_at`` is within the TTL window."""
-        return self._now() - computed_at < self.cache_ttl
 
     async def _compute_metrics_for_graph(
         self, target_ids: set[str]
@@ -429,87 +485,3 @@ class InfluenceScorer:
         if node is None:
             return 0
         return int((node.properties or {}).get("citation_count") or 0)
-
-    # ------------------------------------------------------------------
-    # Persistence
-    # ------------------------------------------------------------------
-
-    def _read_cache(self, paper_id: str) -> Optional[InfluenceMetrics]:
-        """Read a cached metrics row by paper_id; None if absent."""
-        with open_connection(self.store.db_path) as conn:
-            cursor = conn.execute(
-                """
-                SELECT paper_id, citation_count, citation_velocity,
-                       pagerank_score, hub_score, authority_score,
-                       computed_at
-                FROM citation_influence_metrics
-                WHERE paper_id = ?
-                """,
-                (paper_id,),
-            )
-            row = cursor.fetchone()
-        if row is None:
-            return None
-        return InfluenceMetrics(
-            paper_id=row["paper_id"],
-            citation_count=row["citation_count"],
-            citation_velocity=row["citation_velocity"],
-            pagerank_score=row["pagerank_score"],
-            hub_score=row["hub_score"],
-            authority_score=row["authority_score"],
-            computed_at=datetime.fromisoformat(row["computed_at"]),
-        )
-
-    def _write_cache(self, rows: list[InfluenceMetrics]) -> None:
-        """Upsert metrics rows in a single BEGIN IMMEDIATE transaction.
-
-        Failure here is logged but does NOT propagate — the computed
-        metrics are still returned to the caller. The next read will
-        see the cache miss and recompute.
-        """
-        if not rows:
-            return
-        payload = [
-            (
-                m.paper_id,
-                m.citation_count,
-                m.citation_velocity,
-                m.pagerank_score,
-                m.hub_score,
-                m.authority_score,
-                m.computed_at.isoformat(),
-            )
-            for m in rows
-        ]
-        try:
-            with open_connection(self.store.db_path) as conn:
-                # TODO(#134): wrap in retry_on_lock_contention
-                conn.execute("BEGIN IMMEDIATE")
-                conn.executemany(
-                    """
-                    INSERT INTO citation_influence_metrics (
-                        paper_id, citation_count, citation_velocity,
-                        pagerank_score, hub_score, authority_score,
-                        computed_at
-                    )
-                    VALUES (?, ?, ?, ?, ?, ?, ?)
-                    ON CONFLICT(paper_id) DO UPDATE SET
-                        citation_count = excluded.citation_count,
-                        citation_velocity = excluded.citation_velocity,
-                        pagerank_score = excluded.pagerank_score,
-                        hub_score = excluded.hub_score,
-                        authority_score = excluded.authority_score,
-                        computed_at = excluded.computed_at
-                    """,
-                    payload,
-                )
-                conn.commit()
-        except sqlite3.Error as exc:
-            # Audit-write the failure path so ops can grep for cache
-            # write outages. Returning the in-memory metrics preserves
-            # observability for the caller.
-            logger.error(
-                "influence_scorer_cache_write_failed",
-                row_count=len(rows),
-                error=str(exc),
-            )

--- a/src/services/intelligence/citation/influence_scorer.py
+++ b/src/services/intelligence/citation/influence_scorer.py
@@ -144,6 +144,17 @@ class InfluenceScorer:
     ) -> None:
         """Initialise the scorer.
 
+        Disk I/O note (M-3):
+            When ``repo`` is ``None`` (the backward-compat default),
+            this constructor opens a SQLite connection to
+            ``store.db_path`` to run pending schema migrations.  The
+            cost is small (one ``SELECT COUNT(*)`` per migration version
+            already applied), but callers that construct many
+            ``InfluenceScorer`` instances in a tight loop should inject
+            a pre-built ``repo`` to avoid repeated I/O. The recommended
+            production path is :meth:`from_paths`, which performs
+            migration exactly once.
+
         Args:
             store: A ``SQLiteGraphStore`` whose schema is at V4 or later.
                 We rely on ``citation_influence_metrics`` (V4) and on
@@ -165,7 +176,7 @@ class InfluenceScorer:
         self.cache_ttl = cache_ttl
         self._now_override = now
         if repo is None:
-            repo = CitationInfluenceRepository.from_path(store.db_path)
+            repo = CitationInfluenceRepository.connect(store.db_path)
         self._repo = repo
 
     @classmethod
@@ -179,12 +190,23 @@ class InfluenceScorer:
 
         Constructs the underlying :class:`SQLiteGraphStore` *and* a
         matching :class:`CitationInfluenceRepository` against the same
-        ``db_path`` (issue #134) so callers no longer need to know
-        the cache table exists.
+        ``db_path`` (issue #134) so callers no longer need to know the
+        cache table exists.
+
+        Migration (M-2 / single entry point):
+            ``store.initialize()`` runs :class:`MigrationManager`
+            ``migrate()`` which applies *all* pending migrations (V1
+            through V4). The subsequent
+            :meth:`CitationInfluenceRepository.connect` call also calls
+            ``migrate()``, but the manager is idempotent -- a second
+            pass applies 0 migrations and returns immediately. Both
+            calls are kept intentionally so each component correctly
+            tracks its own initialized state, at the cost of one extra
+            ``SELECT COUNT(*)`` per version.
         """
         store = SQLiteGraphStore(db_path)
         store.initialize()
-        repo = CitationInfluenceRepository.from_path(db_path)
+        repo = CitationInfluenceRepository.connect(db_path)
         return cls(store=store, cache_ttl=cache_ttl, repo=repo)
 
     def _now(self) -> datetime:

--- a/tests/unit/services/intelligence/citation/test_influence_repository.py
+++ b/tests/unit/services/intelligence/citation/test_influence_repository.py
@@ -561,5 +561,5 @@ class TestPathSafety:
         """Paths outside approved bases raise ``SecurityError``."""
         from src.utils.security import SecurityError
 
-        with pytest.raises(SecurityError):
+        with pytest.raises(SecurityError, match="outside approved storage roots"):
             CitationInfluenceRepository("/etc/passwd")

--- a/tests/unit/services/intelligence/citation/test_influence_repository.py
+++ b/tests/unit/services/intelligence/citation/test_influence_repository.py
@@ -148,6 +148,11 @@ class TestInitialize:
             r.get_metrics("paper:s2:x")
 
     def test_initialize_is_idempotent(self, db_path: Path) -> None:
+        # Smoke-only: verify that calling initialize() twice does not
+        # raise and leaves the repo in a usable state. Behavioral
+        # assertions (migration count, log events) live in
+        # test_initialize_logs_when_migrations_apply and
+        # test_initialize_no_log_when_no_migrations_pending.
         r = CitationInfluenceRepository(db_path)
         r.initialize()
         r.initialize()  # second call does nothing surprising
@@ -364,6 +369,9 @@ class TestDeleteStale:
                         if sql.lstrip().startswith("DELETE"):
                             raise sqlite3.OperationalError("disk corruption")
                         return self._c.execute(sql, *args, **kw)
+
+                    def executemany(self, sql: str, *args: Any, **kw: Any) -> Any:
+                        return self._c.executemany(sql, *args, **kw)
 
                     def commit(self) -> None:
                         self._c.commit()

--- a/tests/unit/services/intelligence/citation/test_influence_repository.py
+++ b/tests/unit/services/intelligence/citation/test_influence_repository.py
@@ -552,6 +552,94 @@ class TestRetryOnLockContention:
 
 
 # ---------------------------------------------------------------------------
+# get_metrics retry / contention
+# ---------------------------------------------------------------------------
+
+
+class TestGetMetricsRetry:
+    def test_get_metrics_uses_retry_helper(
+        self, repo: CitationInfluenceRepository, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``get_metrics`` must route through ``retry_on_lock_contention``
+        with the canonical operation_name + paper_id extra log field.
+        """
+        captured: dict[str, object] = {}
+
+        def _spy(operation, **kwargs):  # type: ignore[no-untyped-def]
+            captured.update(kwargs)
+            return operation()
+
+        monkeypatch.setattr(repo_mod, "retry_on_lock_contention", _spy)
+        repo.get_metrics("paper:s2:spy-read")
+        assert captured.get("operation_name") == "influence_get_metrics"
+        assert captured.get("paper_id") == "paper:s2:spy-read"
+
+    def test_get_metrics_succeeds_after_retry_on_lock_contention(
+        self, repo: CitationInfluenceRepository, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Transient SQLITE_BUSY on the read path is retried; the row is
+        returned on the second attempt. Mirrors
+        ``test_record_metrics_succeeds_after_retry_on_lock_contention``.
+
+        ``get_metrics`` issues a SELECT (not BEGIN IMMEDIATE), so we
+        inject contention by raising an OperationalError with
+        SQLITE_BUSY errorcode on the first SELECT attempt.
+        """
+        # Pre-populate a row so there is something to read back.
+        m = _metrics("paper:s2:read-retry")
+        repo.record_metrics(m)
+
+        real_open = conn_mod.open_connection
+        select_attempts: dict[str, int] = {"n": 0, "failures": 0}
+        max_select_failures = 1
+
+        class _SelectFailProxy:
+            def __init__(self, real_conn: sqlite3.Connection) -> None:
+                self._real = real_conn
+
+            def execute(self, sql: str, *args: Any, **kwargs: Any) -> Any:
+                if (
+                    "citation_influence_metrics" in sql
+                    and select_attempts["failures"] < max_select_failures
+                ):
+                    select_attempts["failures"] += 1
+                    exc = sqlite3.OperationalError("database is busy")
+                    exc.sqlite_errorcode = (  # type: ignore[attr-defined]
+                        conn_mod._SQLITE_BUSY
+                    )
+                    raise exc
+                return self._real.execute(sql, *args, **kwargs)
+
+            def executemany(self, sql: str, *args: Any, **kwargs: Any) -> Any:
+                return self._real.executemany(sql, *args, **kwargs)
+
+            def commit(self) -> None:
+                self._real.commit()
+
+            def rollback(self) -> None:
+                self._real.rollback()
+
+        @contextmanager
+        def fake_open(p: Path) -> Iterator[_SelectFailProxy]:
+            with real_open(p) as conn:
+                select_attempts["n"] += 1
+                yield _SelectFailProxy(conn)
+
+        monkeypatch.setattr(repo_mod, "open_connection", fake_open)
+        monkeypatch.setattr(
+            "src.storage.intelligence_graph.connection.time.sleep",
+            lambda _s: None,
+        )
+
+        result = repo.get_metrics("paper:s2:read-retry")
+        # Retry fired before success.
+        assert select_attempts["failures"] == max_select_failures
+        # The row was returned despite the initial contention.
+        assert result is not None
+        assert result.paper_id == "paper:s2:read-retry"
+
+
+# ---------------------------------------------------------------------------
 # Path safety
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/services/intelligence/citation/test_influence_repository.py
+++ b/tests/unit/services/intelligence/citation/test_influence_repository.py
@@ -339,6 +339,46 @@ class TestDeleteStale:
         # Cutoff predates the row → nothing to delete.
         assert repo.delete_stale(now - timedelta(days=365)) == 0
 
+    def test_delete_stale_rolls_back_on_failure(
+        self, repo: CitationInfluenceRepository, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If the DELETE itself raises (e.g. disk corruption), the
+        transaction must roll back AND the exception must propagate
+        so callers see the failure -- ``delete_stale`` is invoked
+        from a Phase 10 cleanup hook that wants to know if it failed.
+        """
+        now = datetime.now(timezone.utc)
+        repo.record_metrics(_metrics("paper:s2:rb", computed_at=now))
+        rollback_calls: list[int] = []
+        real_open = conn_mod.open_connection
+
+        @contextmanager
+        def fake_open(p: Path):  # type: ignore[no-untyped-def]
+            with real_open(p) as conn:
+
+                class _Proxy:
+                    def __init__(self, c: sqlite3.Connection) -> None:
+                        self._c = c
+
+                    def execute(self, sql: str, *args: Any, **kw: Any) -> Any:
+                        if sql.lstrip().startswith("DELETE"):
+                            raise sqlite3.OperationalError("disk corruption")
+                        return self._c.execute(sql, *args, **kw)
+
+                    def commit(self) -> None:
+                        self._c.commit()
+
+                    def rollback(self) -> None:
+                        rollback_calls.append(1)
+                        self._c.rollback()
+
+                yield _Proxy(conn)
+
+        monkeypatch.setattr(repo_mod, "open_connection", fake_open)
+        with pytest.raises(sqlite3.OperationalError, match="disk corruption"):
+            repo.delete_stale(now)
+        assert rollback_calls == [1]
+
 
 # ---------------------------------------------------------------------------
 # Retry / failure semantics

--- a/tests/unit/services/intelligence/citation/test_influence_repository.py
+++ b/tests/unit/services/intelligence/citation/test_influence_repository.py
@@ -1,0 +1,525 @@
+"""Tests for ``CitationInfluenceRepository`` (Issue #134).
+
+Covers:
+- Round-trip persistence (record + get).
+- TTL semantics on the read path -- stale rows return ``None``.
+- ``delete_stale`` row count.
+- ``record_metrics`` retry path on lock contention.
+- ``record_metrics`` swallows non-contention ``sqlite3.Error``
+  (preserves the original ``_write_cache`` don't-fail-the-API-call
+  contract).
+- ``from_path`` factory initialises migrations.
+- All four failure-path log events asserted via
+  ``capture_logs()`` with the canonical "rebind logger before
+  capture" pattern (CLAUDE.md "Test Authoring Conventions").
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Iterator
+
+import pytest
+import structlog
+import structlog.testing
+
+from src.services.intelligence.citation import influence_repository as repo_mod
+from src.services.intelligence.citation.influence_repository import (
+    DEFAULT_MAX_AGE_DAYS,
+    CitationInfluenceRepository,
+)
+from src.services.intelligence.citation.influence_scorer import InfluenceMetrics
+from src.storage.intelligence_graph import connection as conn_mod
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db_path() -> Iterator[Path]:
+    """Fresh on-disk SQLite path per test (auto-cleaned)."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        path = Path(f.name)
+    path.unlink(missing_ok=True)
+    yield path
+    path.unlink(missing_ok=True)
+
+
+@pytest.fixture
+def repo(db_path: Path) -> CitationInfluenceRepository:
+    return CitationInfluenceRepository.from_path(db_path)
+
+
+def _metrics(
+    paper_id: str = "paper:s2:test001",
+    *,
+    citation_count: int = 3,
+    citation_velocity: float = 1.5,
+    pagerank_score: float = 0.25,
+    hub_score: float = 0.4,
+    authority_score: float = 0.6,
+    computed_at: datetime | None = None,
+) -> InfluenceMetrics:
+    """Convenience constructor with explicit defaults for clarity."""
+    return InfluenceMetrics(
+        paper_id=paper_id,
+        citation_count=citation_count,
+        citation_velocity=citation_velocity,
+        pagerank_score=pagerank_score,
+        hub_score=hub_score,
+        authority_score=authority_score,
+        computed_at=computed_at or datetime.now(timezone.utc),
+    )
+
+
+def _make_begin_immediate_failure_open(
+    error_message: str,
+    *,
+    sqlite_errorcode: int | None = None,
+    max_failures: int | None = None,
+):
+    """Proxy ``open_connection`` whose ``BEGIN IMMEDIATE`` raises.
+
+    Mirrors the helper in ``tests/unit/services/intelligence/monitoring/
+    test_run_repository.py`` so the citation repo's contention
+    semantics are exercised the same way.
+    """
+    real_open = conn_mod.open_connection
+    attempts = {"n": 0, "failures": 0}
+
+    class _ConnProxy:
+        def __init__(self, real_conn: sqlite3.Connection) -> None:
+            self._real = real_conn
+
+        def execute(self, sql: str, *args: Any, **kwargs: Any) -> Any:
+            if sql == "BEGIN IMMEDIATE":
+                if max_failures is None or attempts["failures"] < max_failures:
+                    attempts["failures"] += 1
+                    exc = sqlite3.OperationalError(error_message)
+                    if sqlite_errorcode is not None:
+                        exc.sqlite_errorcode = sqlite_errorcode
+                    raise exc
+            return self._real.execute(sql, *args, **kwargs)
+
+        def executemany(self, sql: str, *args: Any, **kwargs: Any) -> Any:
+            return self._real.executemany(sql, *args, **kwargs)
+
+        def commit(self) -> None:
+            self._real.commit()
+
+        def rollback(self) -> None:
+            self._real.rollback()
+
+    @contextmanager
+    def fake_open(p: Path) -> Iterator[_ConnProxy]:
+        with real_open(p) as conn:
+            attempts["n"] += 1
+            yield _ConnProxy(conn)
+
+    return fake_open, attempts
+
+
+# ---------------------------------------------------------------------------
+# Initialization / factory
+# ---------------------------------------------------------------------------
+
+
+class TestInitialize:
+    def test_from_path_initializes_migrations(self, db_path: Path) -> None:
+        """``from_path`` runs the migration manager so the table exists."""
+        r = CitationInfluenceRepository.from_path(db_path)
+        # If migrations ran, recording a row succeeds (no "no such table").
+        r.record_metrics(_metrics())
+        assert r.get_metrics(_metrics().paper_id) is not None
+
+    def test_record_metrics_requires_initialize(self, db_path: Path) -> None:
+        r = CitationInfluenceRepository(db_path)  # no initialize()
+        with pytest.raises(RuntimeError, match="not initialized"):
+            r.record_metrics(_metrics())
+
+    def test_get_metrics_requires_initialize(self, db_path: Path) -> None:
+        r = CitationInfluenceRepository(db_path)  # no initialize()
+        with pytest.raises(RuntimeError, match="not initialized"):
+            r.get_metrics("paper:s2:x")
+
+    def test_initialize_is_idempotent(self, db_path: Path) -> None:
+        r = CitationInfluenceRepository(db_path)
+        r.initialize()
+        r.initialize()  # second call does nothing surprising
+        # And the repo is still usable.
+        r.record_metrics(_metrics())
+
+    def test_initialize_logs_when_migrations_apply(
+        self, db_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Rebind logger so capture_logs sees the event under
+        # cache_logger_on_first_use=True.
+        monkeypatch.setattr(repo_mod, "logger", structlog.get_logger())
+        with structlog.testing.capture_logs() as logs:
+            CitationInfluenceRepository(db_path).initialize()
+        # First-time initialization applies V1..V4 -> exactly one
+        # "migrations_applied" event from the repo.
+        events = [
+            e
+            for e in logs
+            if e.get("event") == "citation_influence_repository_migrations_applied"
+        ]
+        assert len(events) == 1
+        assert events[0]["count"] >= 1
+
+    def test_initialize_no_log_when_no_migrations_pending(
+        self, db_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Run once to apply migrations.
+        CitationInfluenceRepository(db_path).initialize()
+        # Re-bind logger for the second pass.
+        monkeypatch.setattr(repo_mod, "logger", structlog.get_logger())
+        with structlog.testing.capture_logs() as logs:
+            CitationInfluenceRepository(db_path).initialize()
+        events = [
+            e
+            for e in logs
+            if e.get("event") == "citation_influence_repository_migrations_applied"
+        ]
+        assert events == []  # no migrations ⇒ no event
+
+
+# ---------------------------------------------------------------------------
+# CRUD round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestRecordAndGetMetrics:
+    def test_record_metrics_persists_correctly(
+        self, repo: CitationInfluenceRepository
+    ) -> None:
+        m = _metrics(
+            "paper:s2:roundtrip",
+            citation_count=42,
+            citation_velocity=8.4,
+            pagerank_score=0.31,
+            hub_score=0.51,
+            authority_score=0.72,
+        )
+        repo.record_metrics(m)
+        out = repo.get_metrics(m.paper_id)
+        assert out is not None
+        assert out.paper_id == m.paper_id
+        assert out.citation_count == 42
+        assert out.citation_velocity == 8.4
+        assert out.pagerank_score == 0.31
+        assert out.hub_score == 0.51
+        assert out.authority_score == 0.72
+        # Timestamps round-trip via ISO format -- tolerate microsecond
+        # precision.
+        assert out.computed_at == m.computed_at
+
+    def test_record_metrics_upserts_on_conflict(
+        self, repo: CitationInfluenceRepository
+    ) -> None:
+        """Second record_metrics for the same paper_id overwrites."""
+        first = _metrics("paper:s2:upsert", citation_count=1)
+        repo.record_metrics(first)
+        second = _metrics(
+            "paper:s2:upsert",
+            citation_count=99,
+            computed_at=first.computed_at + timedelta(hours=1),
+        )
+        repo.record_metrics(second)
+        out = repo.get_metrics("paper:s2:upsert")
+        assert out is not None
+        assert out.citation_count == 99
+        assert out.computed_at == second.computed_at
+
+    def test_get_metrics_returns_none_when_not_found(
+        self, repo: CitationInfluenceRepository
+    ) -> None:
+        assert repo.get_metrics("paper:s2:missing") is None
+
+    def test_get_metrics_returns_none_when_stale(
+        self, repo: CitationInfluenceRepository
+    ) -> None:
+        """Rows older than max_age_days are treated as cache misses."""
+        stale = _metrics(
+            "paper:s2:stale",
+            computed_at=datetime.now(timezone.utc) - timedelta(days=30),
+        )
+        repo.record_metrics(stale)
+        # Default max_age_days=7 → the 30-day-old row is stale.
+        assert repo.get_metrics("paper:s2:stale") is None
+
+    def test_get_metrics_returns_metrics_when_fresh(
+        self, repo: CitationInfluenceRepository
+    ) -> None:
+        fresh = _metrics(
+            "paper:s2:fresh",
+            computed_at=datetime.now(timezone.utc) - timedelta(hours=2),
+        )
+        repo.record_metrics(fresh)
+        out = repo.get_metrics("paper:s2:fresh")
+        assert out is not None
+        assert out.paper_id == "paper:s2:fresh"
+
+    def test_get_metrics_with_custom_max_age_days(
+        self, repo: CitationInfluenceRepository
+    ) -> None:
+        """Larger max_age_days widens the freshness window."""
+        old = _metrics(
+            "paper:s2:custom",
+            computed_at=datetime.now(timezone.utc) - timedelta(days=20),
+        )
+        repo.record_metrics(old)
+        # Default 7 days → stale.
+        assert repo.get_metrics("paper:s2:custom") is None
+        # 30 days → fresh.
+        assert repo.get_metrics("paper:s2:custom", max_age_days=30) is not None
+
+    def test_get_metrics_rejects_non_positive_max_age_days(
+        self, repo: CitationInfluenceRepository
+    ) -> None:
+        with pytest.raises(ValueError, match="max_age_days must be positive"):
+            repo.get_metrics("paper:s2:x", max_age_days=0)
+        with pytest.raises(ValueError, match="max_age_days must be positive"):
+            repo.get_metrics("paper:s2:x", max_age_days=-1)
+
+    def test_default_max_age_days_constant(self) -> None:
+        """Pin the public default so callers can reason about it."""
+        assert DEFAULT_MAX_AGE_DAYS == 7
+
+
+# ---------------------------------------------------------------------------
+# delete_stale
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteStale:
+    def test_delete_stale_returns_affected_row_count(
+        self, repo: CitationInfluenceRepository
+    ) -> None:
+        """The returned count must equal the number of rows actually
+        removed -- ops dashboards rely on this for backlog tracking.
+        """
+        now = datetime.now(timezone.utc)
+        for i in range(3):
+            repo.record_metrics(
+                _metrics(f"paper:s2:old{i}", computed_at=now - timedelta(days=30))
+            )
+        # cutoff = 7 days ago → all three are older
+        cutoff = now - timedelta(days=7)
+        assert repo.delete_stale(cutoff) == 3
+        for i in range(3):
+            # All three should be gone.
+            assert repo.get_metrics(f"paper:s2:old{i}", max_age_days=365) is None
+
+    def test_delete_stale_does_not_delete_fresh_rows(
+        self, repo: CitationInfluenceRepository
+    ) -> None:
+        now = datetime.now(timezone.utc)
+        repo.record_metrics(_metrics("paper:s2:fresh", computed_at=now))
+        repo.record_metrics(
+            _metrics("paper:s2:stale", computed_at=now - timedelta(days=30))
+        )
+        cutoff = now - timedelta(days=7)
+        assert repo.delete_stale(cutoff) == 1
+        # Fresh row survives.
+        assert repo.get_metrics("paper:s2:fresh") is not None
+        # Stale row is gone.
+        assert repo.get_metrics("paper:s2:stale", max_age_days=365) is None
+
+    def test_delete_stale_returns_zero_when_no_rows_match(
+        self, repo: CitationInfluenceRepository
+    ) -> None:
+        now = datetime.now(timezone.utc)
+        repo.record_metrics(_metrics("paper:s2:keep", computed_at=now))
+        # Cutoff predates the row → nothing to delete.
+        assert repo.delete_stale(now - timedelta(days=365)) == 0
+
+
+# ---------------------------------------------------------------------------
+# Retry / failure semantics
+# ---------------------------------------------------------------------------
+
+
+class TestRetryOnLockContention:
+    def test_record_metrics_uses_retry_helper(
+        self, repo: CitationInfluenceRepository, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``record_metrics`` must route through ``retry_on_lock_contention``
+        with the canonical operation_name + paper_id extra log field so
+        a single audit query can see contention events from this site.
+        """
+        captured: dict[str, object] = {}
+
+        def _spy(operation, **kwargs):  # type: ignore[no-untyped-def]
+            captured.update(kwargs)
+            return operation()
+
+        monkeypatch.setattr(repo_mod, "retry_on_lock_contention", _spy)
+        m = _metrics("paper:s2:spy")
+        repo.record_metrics(m)
+        assert captured.get("operation_name") == "influence_record_metrics"
+        assert captured.get("paper_id") == "paper:s2:spy"
+
+    def test_record_metrics_succeeds_after_retry_on_lock_contention(
+        self, repo: CitationInfluenceRepository, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Transient SQLITE_BUSY is retried; the row is eventually
+        persisted. Mirrors the canonical
+        ``MonitoringRunRepository`` test of the same name.
+        """
+        max_failures = 1  # one BUSY then succeed
+        fake_open, attempts = _make_begin_immediate_failure_open(
+            error_message="database is busy",
+            sqlite_errorcode=conn_mod._SQLITE_BUSY,
+            max_failures=max_failures,
+        )
+        monkeypatch.setattr(repo_mod, "open_connection", fake_open)
+        # Skip real backoff sleep -- helper sleeps in connection module.
+        monkeypatch.setattr(
+            "src.storage.intelligence_graph.connection.time.sleep",
+            lambda _s: None,
+        )
+
+        m = _metrics("paper:s2:retry")
+        repo.record_metrics(m)
+        # The retry actually fired before success.
+        assert attempts["failures"] == max_failures
+        # And the row was actually persisted.
+        assert repo.get_metrics("paper:s2:retry") is not None
+
+    def test_record_metrics_retries_on_locked_error_code(
+        self, repo: CitationInfluenceRepository, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """SQLITE_LOCKED (errorcode 6) -- same retry contract as BUSY."""
+        fake_open, attempts = _make_begin_immediate_failure_open(
+            error_message="some locked-table message",
+            sqlite_errorcode=conn_mod._SQLITE_LOCKED,
+            max_failures=1,
+        )
+        monkeypatch.setattr(repo_mod, "open_connection", fake_open)
+        monkeypatch.setattr(
+            "src.storage.intelligence_graph.connection.time.sleep",
+            lambda _s: None,
+        )
+
+        m = _metrics("paper:s2:locked")
+        repo.record_metrics(m)
+        assert attempts["failures"] == 1
+        assert repo.get_metrics("paper:s2:locked") is not None
+
+    def test_record_metrics_propagates_non_lock_sqlite_error(
+        self, repo: CitationInfluenceRepository, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``IntegrityError`` (a sqlite3.Error subclass) must NOT be
+        retried, must NOT crash the caller, and MUST be logged via
+        ``citation_influence_repo_write_failed``.
+
+        The retry helper only catches contention; everything else
+        propagates out of the helper, lands in the outer ``try``, and
+        is logged + swallowed -- preserves the original
+        ``_write_cache`` contract.
+        """
+        # Rebind logger so capture_logs sees the event.
+        monkeypatch.setattr(repo_mod, "logger", structlog.get_logger())
+
+        real_open = conn_mod.open_connection
+
+        @contextmanager
+        def fake_open(p: Path):  # type: ignore[no-untyped-def]
+            with real_open(p) as conn:
+                # Wrap conn so executemany / execute on the upsert
+                # raises IntegrityError. We just patch executemany on
+                # the proxy.
+                class _Proxy:
+                    def __init__(self, c: sqlite3.Connection) -> None:
+                        self._c = c
+
+                    def execute(self, sql: str, *args: Any, **kw: Any) -> Any:
+                        if sql.lstrip().startswith("INSERT"):
+                            raise sqlite3.IntegrityError("constraint violation")
+                        return self._c.execute(sql, *args, **kw)
+
+                    def executemany(self, sql: str, *args: Any, **kw: Any) -> Any:
+                        return self._c.executemany(sql, *args, **kw)
+
+                    def commit(self) -> None:
+                        self._c.commit()
+
+                    def rollback(self) -> None:
+                        self._c.rollback()
+
+                yield _Proxy(conn)
+
+        monkeypatch.setattr(repo_mod, "open_connection", fake_open)
+
+        with structlog.testing.capture_logs() as logs:
+            # Must not raise -- the don't-fail-the-API-call contract.
+            repo.record_metrics(_metrics("paper:s2:integ"))
+
+        events = [
+            e for e in logs if e.get("event") == "citation_influence_repo_write_failed"
+        ]
+        assert len(events) == 1
+        assert events[0].get("paper_id") == "paper:s2:integ"
+        assert "constraint violation" in events[0].get("error", "")
+
+    def test_record_metrics_gives_up_after_max_attempts(
+        self, repo: CitationInfluenceRepository, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Persistent contention exhausts the retry budget; the
+        ``OperationalError`` propagates *out of the retry helper*, then
+        lands in the outer try and is logged -- the caller does NOT
+        see an exception.
+        """
+        # Re-bind the connection-module logger because capture_logs
+        # needs the processor swap to be visible (CLAUDE.md
+        # "Test Authoring Conventions").
+        monkeypatch.setattr(conn_mod, "logger", structlog.get_logger())
+        monkeypatch.setattr(repo_mod, "logger", structlog.get_logger())
+
+        fake_open, attempts = _make_begin_immediate_failure_open(
+            error_message="database is locked",
+        )
+        monkeypatch.setattr(repo_mod, "open_connection", fake_open)
+        monkeypatch.setattr(
+            "src.storage.intelligence_graph.connection.time.sleep",
+            lambda _s: None,
+        )
+
+        with structlog.testing.capture_logs() as logs:
+            # Must not raise -- contention is logged as a write failure.
+            repo.record_metrics(_metrics("paper:s2:exhaust"))
+
+        assert attempts["n"] == conn_mod.DEFAULT_MAX_ATTEMPTS
+        # The retry helper emits its own exhaustion event AND the
+        # outer try logs the wrapped repo failure event. Both must
+        # fire so ops have an audit trail at both layers.
+        exhausted = [
+            e for e in logs if e.get("event") == "sqlite_lock_contention_exhausted"
+        ]
+        assert len(exhausted) == 1
+        assert exhausted[0]["operation_name"] == "influence_record_metrics"
+        repo_failures = [
+            e for e in logs if e.get("event") == "citation_influence_repo_write_failed"
+        ]
+        assert len(repo_failures) == 1
+        assert repo_failures[0]["paper_id"] == "paper:s2:exhaust"
+
+
+# ---------------------------------------------------------------------------
+# Path safety
+# ---------------------------------------------------------------------------
+
+
+class TestPathSafety:
+    def test_constructor_rejects_unsanitized_path(self) -> None:
+        """Paths outside approved bases raise ``SecurityError``."""
+        from src.utils.security import SecurityError
+
+        with pytest.raises(SecurityError):
+            CitationInfluenceRepository("/etc/passwd")

--- a/tests/unit/services/intelligence/citation/test_influence_scorer.py
+++ b/tests/unit/services/intelligence/citation/test_influence_scorer.py
@@ -126,8 +126,12 @@ def test_constructor_accepts_custom_now(store):
 
 def test_now_defaults_to_real_clock(store):
     s = InfluenceScorer(store=store)
-    # Just check we get a real datetime within reason.
-    assert isinstance(s._now(), datetime)
+    now = s._now()
+    # Check we get a real datetime within reason.
+    assert isinstance(now, datetime)
+    # Must be timezone-aware (UTC) so callers can compare with
+    # timezone-aware timestamps without TypeError.
+    assert now.tzinfo is not None
 
 
 def test_init_accepts_injected_repo(store):
@@ -559,26 +563,57 @@ async def test_cache_write_failure_logs_event_but_returns_metrics(store, monkeyp
     """A repository write failure must NOT bubble to the scorer caller.
 
     The new repository owns the failure-path logging; the scorer just
-    delegates. Verify that an injected repo whose ``record_metrics``
-    raises a non-contention ``sqlite3.Error`` (handled inside the
-    repo's outer ``try``) does not crash ``compute_for_paper`` -- the
-    in-memory metrics still flow back to the caller.
+    delegates. Verify that when ``open_connection`` raises a non-contention
+    ``sqlite3.Error`` on BEGIN IMMEDIATE (propagates straight through the
+    retry helper, lands in the repo's outer ``try``, is logged via
+    ``citation_influence_repo_write_failed``, and is swallowed) the scorer
+    caller still receives its in-memory metrics.
+
+    Mirrors ``test_record_metrics_propagates_non_lock_sqlite_error`` in
+    ``test_influence_repository.py`` -- patches ``open_connection`` with
+    a non-BUSY error so the full retry/failure path is exercised rather
+    than bypassing ``retry_on_lock_contention`` via a private-method patch.
     """
     n = _node("cw", citation_count=1, year=2020)
     _persist_chain(store, n)
 
-    # Build a repo wired to the same DB, then make ``record_metrics``
-    # raise. We use the real repo's outer ``try`` to swallow the
-    # ``sqlite3.Error`` and emit the audit-trail log event so the
-    # scorer caller never sees the exception (the contract preserved
-    # from the original ``_write_cache``).
     repo = CitationInfluenceRepository.from_path(store.db_path)
     monkeypatch.setattr(repo_module, "logger", structlog.get_logger())
 
-    def _raise_on_record(_metrics):
-        raise sqlite3.OperationalError("disk full")
+    from contextlib import contextmanager
+    from pathlib import Path
+    from src.storage.intelligence_graph import connection as conn_mod_scorer
 
-    monkeypatch.setattr(repo, "_record_metrics_once", _raise_on_record)
+    real_open = conn_mod_scorer.open_connection
+    write_attempts: list[int] = []
+
+    class _FailProxy:
+        def __init__(self, real_conn: sqlite3.Connection) -> None:
+            self._real = real_conn
+
+        def execute(self, sql: str, *args, **kwargs):  # type: ignore[no-untyped-def]
+            if sql == "BEGIN IMMEDIATE":
+                write_attempts.append(1)
+                raise sqlite3.OperationalError("disk full")
+            return self._real.execute(sql, *args, **kwargs)
+
+        def executemany(  # type: ignore[no-untyped-def]
+            self, sql: str, *args, **kwargs
+        ):
+            return self._real.executemany(sql, *args, **kwargs)
+
+        def commit(self) -> None:
+            self._real.commit()
+
+        def rollback(self) -> None:
+            self._real.rollback()
+
+    @contextmanager
+    def fake_open(p: Path):  # type: ignore[no-untyped-def]
+        with real_open(p) as conn:
+            yield _FailProxy(conn)
+
+    monkeypatch.setattr(repo_module, "open_connection", fake_open)
     s = InfluenceScorer(store=store, repo=repo)
 
     with structlog.testing.capture_logs() as logs:
@@ -608,7 +643,6 @@ async def test_compute_for_paper_wraps_writes_in_to_thread(store, monkeypatch):
     s = InfluenceScorer(store=store, repo=repo)
 
     record_calls: list[object] = []
-    get_calls: list[object] = []
     real_to_thread = scorer_module.asyncio.to_thread
 
     async def spy_to_thread(func, *args, **kwargs):
@@ -619,8 +653,6 @@ async def test_compute_for_paper_wraps_writes_in_to_thread(store, monkeypatch):
         underlying = getattr(func, "__func__", func)
         if underlying is CitationInfluenceRepository.record_metrics:
             record_calls.append(args[0])
-        elif underlying is CitationInfluenceRepository.get_metrics:
-            get_calls.append(args[0])
         return await real_to_thread(func, *args, **kwargs)
 
     monkeypatch.setattr(scorer_module.asyncio, "to_thread", spy_to_thread)
@@ -710,7 +742,7 @@ async def test_compute_for_paper_uses_repo_get_metrics(store):
 
     out = await s.compute_for_paper(n.paper_id)
     assert out is sentinel
-    mock_repo.get_metrics.assert_called_once()
+    mock_repo.get_metrics.assert_called_once_with(n.paper_id, s._max_age_days())
     # Cache HIT path: record_metrics must NOT be called.
     mock_repo.record_metrics.assert_not_called()
 
@@ -875,6 +907,10 @@ async def test_pagerank_skipped_when_graph_exceeds_limit(store, monkeypatch):
     Monkeypatch MAX_GRAPH_NODES_FOR_PAGERANK to 2, insert 3 nodes, verify the
     warning is logged and the returned pagerank_score is 0.0 (empty dict fallback).
     """
+    # Rebind logger before capture_logs() so the cached production
+    # logger picks up the testing processor swap (mirrors line 302 pattern
+    # from test_hits_skipped_for_oversize_graph_logs_event).
+    monkeypatch.setattr(scorer_module, "logger", structlog.get_logger())
     # Lower the limit so 3 nodes trip it.
     monkeypatch.setattr(scorer_module, "MAX_GRAPH_NODES_FOR_PAGERANK", 2)
 

--- a/tests/unit/services/intelligence/citation/test_influence_scorer.py
+++ b/tests/unit/services/intelligence/citation/test_influence_scorer.py
@@ -6,13 +6,17 @@ import sqlite3
 import tempfile
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import structlog
 import structlog.testing
 
+from src.services.intelligence.citation import influence_repository as repo_module
 from src.services.intelligence.citation import influence_scorer as scorer_module
+from src.services.intelligence.citation.influence_repository import (
+    CitationInfluenceRepository,
+)
 from src.services.intelligence.citation.influence_scorer import (
     DEFAULT_CACHE_TTL,
     MAX_GRAPH_NODES_FOR_HITS,
@@ -103,6 +107,17 @@ def test_from_paths_factory_initialises_store(temp_db):
     assert s.cache_ttl == DEFAULT_CACHE_TTL
 
 
+def test_from_paths_factory_constructs_repo(temp_db):
+    """``from_paths`` must build the repository alongside the store
+    (issue #134) so callers don't need to know the cache table exists.
+    """
+    s = InfluenceScorer.from_paths(db_path=temp_db)
+    assert isinstance(s._repo, CitationInfluenceRepository)
+    # And it should be initialised (record_metrics doesn't raise
+    # "not initialized").
+    s._repo.record_metrics(InfluenceMetrics(paper_id="paper:s2:from-paths-test"))
+
+
 def test_constructor_accepts_custom_now(store):
     fixed = datetime(2026, 1, 1, tzinfo=timezone.utc)
     s = InfluenceScorer(store=store, now=fixed)
@@ -113,6 +128,44 @@ def test_now_defaults_to_real_clock(store):
     s = InfluenceScorer(store=store)
     # Just check we get a real datetime within reason.
     assert isinstance(s._now(), datetime)
+
+
+def test_init_accepts_injected_repo(store):
+    """DI seam (issue #134): callers may inject their own repo
+    (tests, alternative backends) and the scorer must use that
+    instance verbatim instead of constructing a default.
+    """
+    repo = CitationInfluenceRepository.from_path(store.db_path)
+    s = InfluenceScorer(store=store, repo=repo)
+    assert s._repo is repo
+
+
+def test_init_builds_default_repo_when_none_passed(store):
+    """Backward compatibility (issue #134): callers that haven't
+    migrated to explicit injection must keep working -- the scorer
+    constructs a repo against ``store.db_path`` and initialises it.
+    """
+    s = InfluenceScorer(store=store)
+    assert isinstance(s._repo, CitationInfluenceRepository)
+    # And the constructed repo points at the store's DB.
+    assert s._repo.db_path == store.db_path
+    # And it is initialised (record_metrics doesn't raise
+    # "not initialized").
+    s._repo.record_metrics(InfluenceMetrics(paper_id="paper:s2:default-repo-test"))
+
+
+def test_max_age_days_rounds_up_from_subday_ttl(store):
+    """``cache_ttl`` is a ``timedelta`` (legacy); the repo expects an
+    integer day count. ``_max_age_days`` ceiling-divides so a 7-day
+    TTL doesn't reject a 7-day-old row, and any sub-day TTL still
+    satisfies the repo's ``max_age_days > 0`` precondition.
+    """
+    s = InfluenceScorer(store=store, cache_ttl=timedelta(seconds=10))
+    assert s._max_age_days() == 1
+    s = InfluenceScorer(store=store, cache_ttl=timedelta(days=7))
+    assert s._max_age_days() == 7
+    s = InfluenceScorer(store=store, cache_ttl=timedelta(days=7, seconds=1))
+    assert s._max_age_days() == 8
 
 
 # ---------------------------------------------------------------------------
@@ -382,17 +435,24 @@ def test_velocity_helper_handles_invalid_year(store):
 
 @pytest.mark.asyncio
 async def test_persistence_cache_hit_within_ttl(store):
-    """Second call within TTL reuses cached row; PageRank not re-invoked."""
+    """Second call within TTL reuses cached row; PageRank not re-invoked.
+
+    The cache is now owned by ``CitationInfluenceRepository``; when the
+    repo returns a fresh row the scorer must short-circuit before
+    invoking ``GraphAlgorithms.pagerank``.
+    """
     n = _node("c1", citation_count=5, year=2020)
     _persist_chain(store, n)
 
-    fixed_now = datetime(2025, 1, 1, tzinfo=timezone.utc)
-    s = _frozen_scorer(store, fixed_now)
+    # ``now`` defaults to the real clock so the row written on the
+    # first call is genuinely "fresh" (within max_age_days=7) on the
+    # second call -- the repo's TTL filter is wall-clock based.
+    s = InfluenceScorer(store=store)
 
     first = await s.compute_for_paper(n.paper_id)
 
     # Patch GraphAlgorithms.pagerank: if the second call invokes it,
-    # we'll know.
+    # we'll know the cache short-circuit failed.
     with patch.object(scorer_module.GraphAlgorithms, "pagerank") as mock_pr:
         second = await s.compute_for_paper(n.paper_id)
     mock_pr.assert_not_called()
@@ -496,44 +556,184 @@ async def test_compute_for_paper_unknown_node_returns_baseline(store):
 
 @pytest.mark.asyncio
 async def test_cache_write_failure_logs_event_but_returns_metrics(store, monkeypatch):
-    monkeypatch.setattr(scorer_module, "logger", structlog.get_logger())
+    """A repository write failure must NOT bubble to the scorer caller.
+
+    The new repository owns the failure-path logging; the scorer just
+    delegates. Verify that an injected repo whose ``record_metrics``
+    raises a non-contention ``sqlite3.Error`` (handled inside the
+    repo's outer ``try``) does not crash ``compute_for_paper`` -- the
+    in-memory metrics still flow back to the caller.
+    """
     n = _node("cw", citation_count=1, year=2020)
     _persist_chain(store, n)
 
-    s = InfluenceScorer(store=store)
+    # Build a repo wired to the same DB, then make ``record_metrics``
+    # raise. We use the real repo's outer ``try`` to swallow the
+    # ``sqlite3.Error`` and emit the audit-trail log event so the
+    # scorer caller never sees the exception (the contract preserved
+    # from the original ``_write_cache``).
+    repo = CitationInfluenceRepository.from_path(store.db_path)
+    monkeypatch.setattr(repo_module, "logger", structlog.get_logger())
 
-    def _raise(*args, **kwargs):
+    def _raise_on_record(_metrics):
         raise sqlite3.OperationalError("disk full")
 
-    # Patch open_connection inside the scorer module so the cache write
-    # path raises but the read path stays untouched (it ran before).
-    call_count = {"n": 0}
-    real_open = scorer_module.open_connection
-
-    from contextlib import contextmanager
-
-    @contextmanager
-    def fake_open(path):
-        call_count["n"] += 1
-        if call_count["n"] == 1:
-            with real_open(path) as c:
-                yield c
-        else:
-            raise sqlite3.OperationalError("disk full")
-
-    monkeypatch.setattr(scorer_module, "open_connection", fake_open)
+    monkeypatch.setattr(repo, "_record_metrics_once", _raise_on_record)
+    s = InfluenceScorer(store=store, repo=repo)
 
     with structlog.testing.capture_logs() as logs:
         metrics = await s.compute_for_paper(n.paper_id)
     # Caller still receives in-memory metrics.
     assert metrics.paper_id == n.paper_id
-    assert any(e.get("event") == "influence_scorer_cache_write_failed" for e in logs)
+    # Repo's failure-path event must be present.
+    assert any(e.get("event") == "citation_influence_repo_write_failed" for e in logs)
 
 
-def test_write_cache_no_op_on_empty_input(store):
-    s = InfluenceScorer(store=store)
-    # Should not raise and should not open any connection.
-    s._write_cache([])
+# ---------------------------------------------------------------------------
+# Async wrapping (issue #134)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_compute_for_paper_wraps_writes_in_to_thread(store, monkeypatch):
+    """``record_metrics`` is sync (uses ``time.sleep`` for retry); the
+    scorer MUST wrap it in ``asyncio.to_thread`` so contention backoff
+    does not block the event loop. Spy on ``asyncio.to_thread`` to
+    confirm the write goes through the thread pool.
+    """
+    n = _node("at1", citation_count=1, year=2020)
+    _persist_chain(store, n)
+
+    repo = CitationInfluenceRepository.from_path(store.db_path)
+    s = InfluenceScorer(store=store, repo=repo)
+
+    record_calls: list[object] = []
+    get_calls: list[object] = []
+    real_to_thread = scorer_module.asyncio.to_thread
+
+    async def spy_to_thread(func, *args, **kwargs):
+        # Bound-method identity (``func is repo.record_metrics``) is
+        # unreliable because Python rebuilds the bound method on every
+        # attribute access; compare ``__func__`` against the unbound
+        # method instead.
+        underlying = getattr(func, "__func__", func)
+        if underlying is CitationInfluenceRepository.record_metrics:
+            record_calls.append(args[0])
+        elif underlying is CitationInfluenceRepository.get_metrics:
+            get_calls.append(args[0])
+        return await real_to_thread(func, *args, **kwargs)
+
+    monkeypatch.setattr(scorer_module.asyncio, "to_thread", spy_to_thread)
+    await s.compute_for_paper(n.paper_id)
+    # The repo's record_metrics was invoked exactly once via
+    # asyncio.to_thread.
+    assert len(record_calls) == 1
+    assert record_calls[0].paper_id == n.paper_id
+
+
+@pytest.mark.asyncio
+async def test_compute_for_paper_wraps_reads_in_to_thread(store, monkeypatch):
+    """``get_metrics`` is sync; the scorer MUST wrap the cache lookup
+    in ``asyncio.to_thread`` for the same reason -- a colliding writer
+    could hold the lock long enough to matter on the read path too.
+    """
+    n = _node("at2", citation_count=1, year=2020)
+    _persist_chain(store, n)
+
+    repo = CitationInfluenceRepository.from_path(store.db_path)
+    s = InfluenceScorer(store=store, repo=repo)
+
+    get_calls: list[object] = []
+    real_to_thread = scorer_module.asyncio.to_thread
+
+    async def spy_to_thread(func, *args, **kwargs):
+        underlying = getattr(func, "__func__", func)
+        if underlying is CitationInfluenceRepository.get_metrics:
+            get_calls.append(args[0])
+        return await real_to_thread(func, *args, **kwargs)
+
+    monkeypatch.setattr(scorer_module.asyncio, "to_thread", spy_to_thread)
+    await s.compute_for_paper(n.paper_id)
+    # The repo's get_metrics was invoked exactly once via
+    # asyncio.to_thread.
+    assert get_calls == [n.paper_id]
+
+
+@pytest.mark.asyncio
+async def test_compute_for_graph_wraps_each_write_in_to_thread(store, monkeypatch):
+    """``compute_for_graph`` writes one row per requested paper -- each
+    must be wrapped in ``asyncio.to_thread``.
+    """
+    nodes = [_node(f"atg{i}", citation_count=i, year=2020) for i in range(3)]
+    _persist_chain(store, *nodes)
+
+    repo = CitationInfluenceRepository.from_path(store.db_path)
+    s = InfluenceScorer(store=store, repo=repo)
+
+    record_calls: list[object] = []
+    real_to_thread = scorer_module.asyncio.to_thread
+
+    async def spy_to_thread(func, *args, **kwargs):
+        underlying = getattr(func, "__func__", func)
+        if underlying is CitationInfluenceRepository.record_metrics:
+            record_calls.append(args[0])
+        return await real_to_thread(func, *args, **kwargs)
+
+    monkeypatch.setattr(scorer_module.asyncio, "to_thread", spy_to_thread)
+    await s.compute_for_graph([n.paper_id for n in nodes])
+    assert len(record_calls) == 3
+    assert {m.paper_id for m in record_calls} == {n.paper_id for n in nodes}
+
+
+@pytest.mark.asyncio
+async def test_compute_for_paper_uses_repo_get_metrics(store):
+    """The cache hit path must come from ``repo.get_metrics`` -- not
+    a private scorer method. Inject a mock repo whose ``get_metrics``
+    returns a recognizable sentinel and verify the scorer returns
+    that exact instance.
+    """
+    n = _node("rg", citation_count=1, year=2020)
+    _persist_chain(store, n)
+
+    sentinel = InfluenceMetrics(
+        paper_id=n.paper_id,
+        citation_count=999,
+        citation_velocity=88.0,
+        pagerank_score=0.42,
+        hub_score=0.5,
+        authority_score=0.6,
+        computed_at=datetime.now(timezone.utc),
+    )
+    mock_repo = MagicMock(spec=CitationInfluenceRepository)
+    mock_repo.get_metrics.return_value = sentinel
+    s = InfluenceScorer(store=store, repo=mock_repo)
+
+    out = await s.compute_for_paper(n.paper_id)
+    assert out is sentinel
+    mock_repo.get_metrics.assert_called_once()
+    # Cache HIT path: record_metrics must NOT be called.
+    mock_repo.record_metrics.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_compute_for_paper_calls_repo_record_metrics_on_miss(store):
+    """On cache miss the scorer must call ``repo.record_metrics`` --
+    not any private write method on itself. Inject a mock repo that
+    returns ``None`` (miss) and verify ``record_metrics`` is invoked.
+    """
+    n = _node("rm", citation_count=2, year=2020)
+    _persist_chain(store, n)
+
+    mock_repo = MagicMock(spec=CitationInfluenceRepository)
+    mock_repo.get_metrics.return_value = None  # cache miss
+    s = InfluenceScorer(store=store, repo=mock_repo)
+
+    out = await s.compute_for_paper(n.paper_id)
+    mock_repo.record_metrics.assert_called_once()
+    written = mock_repo.record_metrics.call_args.args[0]
+    assert written.paper_id == n.paper_id
+    # Returned metrics match what was just written.
+    assert out.paper_id == n.paper_id
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/intelligence/citation/test_influence_scorer.py
+++ b/tests/unit/services/intelligence/citation/test_influence_scorer.py
@@ -204,7 +204,7 @@ async def test_non_string_paper_id_raises(store):
 @pytest.mark.asyncio
 async def test_compute_for_graph_validates_each_id(store):
     s = InfluenceScorer(store=store)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Invalid paper_id"):
         await s.compute_for_graph(["paper:s2:ok", "bad space"])
 
 
@@ -754,14 +754,14 @@ def test_influence_metrics_defaults():
 def test_influence_metrics_pagerank_clamped_to_one():
     from pydantic import ValidationError
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match="pagerank_score"):
         InfluenceMetrics(paper_id="paper:s2:x", pagerank_score=1.5)
 
 
 def test_influence_metrics_rejects_extra_fields():
     from pydantic import ValidationError
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
         InfluenceMetrics(paper_id="paper:s2:x", foo=1)
 
 


### PR DESCRIPTION
## Summary

Extract the V4 ``citation_influence_metrics`` cache CRUD out of
``InfluenceScorer`` into a dedicated ``CitationInfluenceRepository``,
restoring the layering boundary that ``MonitoringRunRepository``
already established for monitoring data. Closes #134 (Phase 9.2 H-A3
self-review item from PR #132).

- **New module** ``src/services/intelligence/citation/influence_repository.py``
  - ``record_metrics(metrics)`` — upsert via ``retry_on_lock_contention`` (issue #133)
  - ``get_metrics(paper_id, max_age_days=7)`` — TTL-filtered read; returns ``None`` for stale rows
  - ``delete_stale(older_than)`` — returns affected row count for ops visibility
  - ``CitationInfluenceRepository.from_path(db_path)`` factory mirrors ``MonitoringRunner.from_paths``
- **Refactor** ``InfluenceScorer`` to delegate cache I/O to the repo
  - DI seam: ``__init__`` accepts optional ``repo`` (backward-compat default builds one from ``store.db_path``)
  - ``from_paths`` constructs the repo alongside the store
  - All repo calls in ``compute_for_paper`` and ``compute_for_graph`` are wrapped in ``await asyncio.to_thread(...)`` per the canonical CLAUDE.md "SQLite write retry" pattern
  - Drops ``_read_cache`` / ``_write_cache`` / the dead ``_is_fresh`` helper
- **Tests**: +48 new tests (23 repo + 8 scorer DI/async-wrap + 17 updated). Project coverage: **99.13% → 99.14%** (5126 passing).

## Architecture / contracts preserved

- **Don't-fail-the-API-call cache write contract** preserved: the repo's outer ``try`` catches ``sqlite3.Error`` (superclass — covers ``OperationalError``, ``IntegrityError``, ``DatabaseError``), logs ``citation_influence_repo_write_failed``, and swallows. The retry helper handles only contention; non-contention errors propagate to the outer try.
- **Async safety**: ``record_metrics`` uses ``time.sleep`` for retry backoff. All sync-from-async call sites are wrapped in ``asyncio.to_thread`` so the event loop is never blocked. New async-wrap regression tests assert this with ``__func__``-based identity matching.
- **Pragma Prohibition**: zero ``# pragma: no cover`` introduced; both new modules at 100% line+branch coverage.
- **No schema migration changes** — V4 migration stays in ``migrations.py``; the repo just queries the existing table.

## Commit log

- ``b78e226`` refactor(phase-9.2): introduce CitationInfluenceRepository (#134)
- ``c2a8636`` refactor(phase-9.2): InfluenceScorer delegates cache I/O to repo (#134)
- ``6077f4b`` test(phase-9.2): add CitationInfluenceRepository unit suite (#134)
- ``576e8a4`` test(phase-9.2): update InfluenceScorer suite for repository DI (#134)

## Test plan

- [x] ``pytest tests/unit/services/intelligence/citation/`` — 423 passed
- [x] ``./verify.sh`` — Black + Flake8 + Mypy clean; 5126 tests pass; project coverage 99.14% (≥99%)
- [x] New module coverage: ``influence_repository.py`` 100%, ``influence_scorer.py`` 100% (line + branch)
- [x] Async wrapping verified by spy on ``asyncio.to_thread`` for both ``record_metrics`` and ``get_metrics`` call sites
- [x] Retry helper invocation verified with ``operation_name="influence_record_metrics"`` + ``paper_id`` extra log field
- [x] Lock-contention success / give-up / non-lock-error paths all asserted via ``capture_logs()`` with the canonical rebind-before-enter pattern
- [x] Backward compat: existing scorer callers that pass only ``store=`` continue to work (default repo is constructed transparently)