### PR TITLE
feat(phase-9.1): per-paper source provenance + V5 schema migration (closes #141)

### DIFF
--- a/src/services/intelligence/monitoring/_paper_records.py
+++ b/src/services/intelligence/monitoring/_paper_records.py
@@ -17,13 +17,16 @@ from typing import Optional
 
 from src.models.config.core import ResearchTopic, TimeframeRecent, TimeframeType
 from src.models.paper import PaperMetadata
+from src.services.intelligence.models.monitoring import PaperSource
 from src.services.intelligence.monitoring.models import (
     MAX_POLL_HOURS,
     MonitoringPaperRecord,
 )
 
 
-def to_paper_record(paper: PaperMetadata, is_new: bool) -> MonitoringPaperRecord:
+def to_paper_record(
+    paper: PaperMetadata, *, is_new: bool, source: PaperSource
+) -> MonitoringPaperRecord:
     """Convert a :class:`PaperMetadata` into a :class:`MonitoringPaperRecord`.
 
     ``PaperMetadata.url`` and ``open_access_pdf`` are Pydantic ``HttpUrl``
@@ -35,6 +38,10 @@ def to_paper_record(paper: PaperMetadata, is_new: bool) -> MonitoringPaperRecord
         paper: Source paper metadata from a discovery provider.
         is_new: ``True`` if the paper was not yet known to the registry
             before this cycle.
+        source: Discovery provider this paper came from (issue #141).
+            Required keyword arg so callers must explicitly thread the
+            actual provider through — never falls back to a hardcoded
+            default (which is what #141 is fixing).
 
     Returns:
         A ``MonitoringPaperRecord`` ready to be appended to
@@ -48,6 +55,7 @@ def to_paper_record(paper: PaperMetadata, is_new: bool) -> MonitoringPaperRecord
         pdf_url=str(paper.open_access_pdf) if paper.open_access_pdf else None,
         published_at=published,
         is_new=is_new,
+        source=source,
     )
 
 

--- a/src/services/intelligence/monitoring/arxiv_monitor.py
+++ b/src/services/intelligence/monitoring/arxiv_monitor.py
@@ -283,5 +283,9 @@ class ArxivMonitor:
 
     @staticmethod
     def _to_record(paper: PaperMetadata, is_new: bool) -> MonitoringPaperRecord:
-        """Delegate to the shared :func:`to_paper_record` helper (H-C1)."""
-        return to_paper_record(paper, is_new)
+        """Delegate to the shared :func:`to_paper_record` helper (H-C1).
+
+        ArXiv-only monitor — every paper's ``source`` is by construction
+        :attr:`PaperSource.ARXIV` (issue #141).
+        """
+        return to_paper_record(paper, is_new=is_new, source=PaperSource.ARXIV)

--- a/src/services/intelligence/monitoring/digest_generator.py
+++ b/src/services/intelligence/monitoring/digest_generator.py
@@ -342,6 +342,10 @@ class DigestGenerator:
                 f"{index}. **{score_str}** -- {link}{new_marker} "
                 f"(`{paper.paper_id}`)"
             )
+            # Issue #141: surface per-paper provenance so a digest reader
+            # can immediately see which provider each paper came from
+            # without round-tripping through the audit DB.
+            lines.append(f"   - Source: `{paper.source.value}`")
         lines.append("")
         return lines
 

--- a/src/services/intelligence/monitoring/models.py
+++ b/src/services/intelligence/monitoring/models.py
@@ -396,12 +396,13 @@ class MonitoringPaperAudit(BaseModel):
         ),
     )
     source: PaperSource = Field(
-        default=PaperSource.ARXIV,
+        ...,
         description=(
             "Discovery provider for this paper (issue #141). "
-            "Backwards-compatible default of ARXIV matches the V5 "
-            "schema's column default — pre-Tier-1 audit rows that have "
-            "no recorded source are arXiv by definition."
+            "Required — callers must always pass the per-paper provenance "
+            "explicitly so the audit log is never ambiguous. The V5 schema "
+            "backfills legacy rows to 'arxiv'; the repository read-path must "
+            "pass PaperSource.ARXIV for those rows."
         ),
     )
     relevance_score: Optional[float] = Field(

--- a/src/services/intelligence/monitoring/models.py
+++ b/src/services/intelligence/monitoring/models.py
@@ -469,7 +469,17 @@ class MonitoringRun(BaseModel):
         max_length=64,
     )
     subscription_id: str = Field(..., min_length=1, max_length=64)
-    source: PaperSource = Field(default=PaperSource.ARXIV)
+    source: PaperSource = Field(
+        default=PaperSource.ARXIV,
+        description=(
+            "Primary / first-seen source for this monitoring cycle; "
+            "in-memory only — never persisted to the database (no "
+            "``monitoring_runs.source`` column exists). Per-paper "
+            "provenance lives on ``MonitoringPaperRecord.source``, "
+            "which is the authoritative record of where each paper "
+            "actually came from."
+        ),
+    )
     started_at: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),
     )

--- a/src/services/intelligence/monitoring/models.py
+++ b/src/services/intelligence/monitoring/models.py
@@ -298,6 +298,13 @@ class MonitoringPaperRecord(BaseModel):
 
     ``relevance_score`` and ``relevance_reasoning`` are populated by the
     Week 2 ``RelevanceScorer``; for Week 1 they remain ``None``.
+
+    ``source`` (issue #141) is REQUIRED — every record must carry the
+    discovery provider the paper came from so the audit log is honest
+    about provenance. The ``MultiProviderMonitor`` (PR #140) fans out
+    across arXiv + OpenAlex + HuggingFace + Semantic Scholar; before
+    this field existed the cycle-level ``MonitoringRun.source`` was
+    hardcoded to ARXIV which silently misattributed non-arXiv papers.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -317,6 +324,15 @@ class MonitoringPaperRecord(BaseModel):
         description=(
             "True if the paper was unknown to the global PaperRegistry "
             "before this cycle (i.e., not deduplicated)."
+        ),
+    )
+    source: PaperSource = Field(
+        ...,
+        description=(
+            "Discovery provider for this paper (issue #141). REQUIRED — "
+            "callers must specify the actual source rather than relying "
+            "on a default so multi-provider audit rows can never silently "
+            "fall back to a hardcoded value."
         ),
     )
     relevance_score: Optional[float] = Field(
@@ -377,6 +393,15 @@ class MonitoringPaperAudit(BaseModel):
             "True if the paper was newly registered with the global "
             "PaperRegistry during this run. Mirrors the ``is_new`` "
             "flag on ``MonitoringPaperRecord``."
+        ),
+    )
+    source: PaperSource = Field(
+        default=PaperSource.ARXIV,
+        description=(
+            "Discovery provider for this paper (issue #141). "
+            "Backwards-compatible default of ARXIV matches the V5 "
+            "schema's column default — pre-Tier-1 audit rows that have "
+            "no recorded source are arXiv by definition."
         ),
     )
     relevance_score: Optional[float] = Field(

--- a/src/services/intelligence/monitoring/multi_provider_monitor.py
+++ b/src/services/intelligence/monitoring/multi_provider_monitor.py
@@ -27,10 +27,10 @@ Backward compatibility:
 - Returns an :class:`ArxivMonitorResult` (same DTO as the legacy
   monitor) so :class:`MonitoringRunner._run_one` can consume either
   monitor implementation without branching.
-- The cycle-level ``source`` field on the produced :class:`MonitoringRun`
-  remains ``PaperSource.ARXIV`` for backward compatibility — its
-  semantics are now "primary / first-seen source" rather than "all
-  sources". Per-paper provenance (issue #141) lives on each
+- :attr:`MonitoringRun.source` (in-memory only — no ``monitoring_runs.source``
+  column exists) is left alone; its semantics are widened in code to
+  mean "primary / first-seen source" rather than "all sources".
+  Per-paper provenance (issue #141) lives on each
   :class:`~MonitoringPaperRecord`'s ``source`` field which is the
   authoritative record of where each paper actually came from.
 

--- a/src/services/intelligence/monitoring/multi_provider_monitor.py
+++ b/src/services/intelligence/monitoring/multi_provider_monitor.py
@@ -27,9 +27,12 @@ Backward compatibility:
 - Returns an :class:`ArxivMonitorResult` (same DTO as the legacy
   monitor) so :class:`MonitoringRunner._run_one` can consume either
   monitor implementation without branching.
-- The ``source`` field on the produced :class:`MonitoringRun` remains
-  ``PaperSource.ARXIV`` for now — Tier 1 keeps schema compat; a
-  future iteration will add per-source provenance tracking.
+- The cycle-level ``source`` field on the produced :class:`MonitoringRun`
+  remains ``PaperSource.ARXIV`` for backward compatibility — its
+  semantics are now "primary / first-seen source" rather than "all
+  sources". Per-paper provenance (issue #141) lives on each
+  :class:`~MonitoringPaperRecord`'s ``source`` field which is the
+  authoritative record of where each paper actually came from.
 
 Note on threshold-based ingestion: this monitor does the *discovery*
 half (find candidate papers, register them with ``discovery_only=True``).
@@ -212,11 +215,10 @@ class MultiProviderMonitor:
         """
         run = MonitoringRun(
             subscription_id=subscription.subscription_id,
-            # See Tier 1 schema-compat note in module docstring.
-            # TODO(issue #141): per-paper source tracking — add
-            # MonitoringPaperRecord.source field + schema migration so
-            # each paper records its actual discovery provider instead of
-            # hardcoding PaperSource.ARXIV for schema compatibility.
+            # Cycle-level source is kept as ARXIV for backward
+            # compatibility with the V1-V4 schema; per-paper provenance
+            # (issue #141, V5) lives on each MonitoringPaperRecord.source
+            # which is now the authoritative attribution.
             source=PaperSource.ARXIV,
         )
 
@@ -252,7 +254,12 @@ class MultiProviderMonitor:
         # providers would also complicate partial-failure accounting without
         # meaningful latency gains at small provider counts (≤4). Change
         # only after profiling confirms fan-out latency is the bottleneck.
-        fetched: list[PaperMetadata] = []
+        # ``fetched`` carries (paper, source) tuples so each paper retains
+        # the provenance of the provider it actually came from (issue #141).
+        # When the same paper_id appears from two providers, the dedup
+        # step below preserves the first-seen entry — including its
+        # source — to keep behavior deterministic.
+        fetched: list[tuple[PaperMetadata, PaperSource]] = []
         partial_failure = expansion_degraded  # H-C5: expander degradation → PARTIAL
         for variant in queries:
             for source, provider in self._providers.items():
@@ -275,7 +282,8 @@ class MultiProviderMonitor:
                         error=repr(str(exc)[:512]),
                     )
                     continue
-                fetched.extend(results)
+                for paper in results:
+                    fetched.append((paper, source))
 
         # Step 4: dedup by paper_id (preserving first-seen order so the
         # original-query results land first when relevance scoring caps
@@ -443,20 +451,28 @@ class MultiProviderMonitor:
         return build_topic(query, subscription.poll_interval_hours)
 
     @staticmethod
-    def _dedup_by_paper_id(papers: list[PaperMetadata]) -> list[PaperMetadata]:
-        """Dedup a list of papers by ``paper_id`` while preserving order."""
+    def _dedup_by_paper_id(
+        papers: list[tuple[PaperMetadata, PaperSource]],
+    ) -> list[tuple[PaperMetadata, PaperSource]]:
+        """Dedup ``(paper, source)`` tuples by ``paper_id``, preserving order.
+
+        First-seen wins — both the paper metadata AND its source come
+        from the earliest occurrence (issue #141). If arXiv and OpenAlex
+        both return the same paper and the iteration visited arXiv
+        first, the audit row records ``source=ARXIV``.
+        """
         seen: set[str] = set()
-        result: list[PaperMetadata] = []
-        for paper in papers:
+        result: list[tuple[PaperMetadata, PaperSource]] = []
+        for paper, source in papers:
             if paper.paper_id in seen:
                 continue
             seen.add(paper.paper_id)
-            result.append(paper)
+            result.append((paper, source))
         return result
 
     def _resolve_and_register(
         self,
-        papers: list[PaperMetadata],
+        papers: list[tuple[PaperMetadata, PaperSource]],
         subscription: ResearchSubscription,
         run: MonitoringRun,
     ) -> tuple[list[PaperMetadata], list[PaperMetadata], bool]:
@@ -467,13 +483,17 @@ class MultiProviderMonitor:
         True if any single paper triggered a registry / identity error
         — those are individually survivable but flag the overall cycle
         as PARTIAL.
+
+        Issue #141: each :class:`MonitoringPaperRecord` appended to
+        ``run.papers`` carries the actual discovery provider via the
+        ``source=`` argument threaded through ``to_paper_record``.
         """
         new_papers: list[PaperMetadata] = []
         deduped: list[PaperMetadata] = []
         partial_failure = False
         topic_slug = f"{self._config.topic_slug_prefix}-{subscription.subscription_id}"
 
-        for paper in papers:
+        for paper, source in papers:
             try:
                 match = self._registry.resolve_identity(paper)
             except Exception as exc:
@@ -482,13 +502,14 @@ class MultiProviderMonitor:
                     "monitor_identity_resolution_error",
                     subscription_id=subscription.subscription_id,
                     paper_id=paper.paper_id,
+                    source=source.value,
                     error=repr(str(exc)[:512]),
                 )
                 continue
 
             if match.matched:
                 deduped.append(paper)
-                run.papers.append(to_paper_record(paper, is_new=False))
+                run.papers.append(to_paper_record(paper, is_new=False, source=source))
                 continue
 
             try:
@@ -503,11 +524,12 @@ class MultiProviderMonitor:
                     "monitor_registry_write_error",
                     subscription_id=subscription.subscription_id,
                     paper_id=paper.paper_id,
+                    source=source.value,
                     error=repr(str(exc)[:512]),
                 )
                 continue
 
             new_papers.append(paper)
-            run.papers.append(to_paper_record(paper, is_new=True))
+            run.papers.append(to_paper_record(paper, is_new=True, source=source))
 
         return new_papers, deduped, partial_failure

--- a/src/services/intelligence/monitoring/run_repository.py
+++ b/src/services/intelligence/monitoring/run_repository.py
@@ -33,6 +33,7 @@ Schema (created by ``MIGRATION_V2_MONITORING_RUNS``)
         registered          INTEGER NOT NULL DEFAULT 0,
         relevance_score     REAL,
         relevance_reasoning TEXT,
+        source              TEXT NOT NULL DEFAULT 'arxiv',  -- V5 / #141
         PRIMARY KEY (run_id, paper_id),
         FOREIGN KEY (run_id) REFERENCES monitoring_runs(run_id) ON DELETE CASCADE
     )
@@ -72,6 +73,7 @@ from typing import Iterator, Optional
 
 import structlog
 
+from src.services.intelligence.models.monitoring import PaperSource
 from src.services.intelligence.monitoring.models import (
     MonitoringPaperAudit,
     MonitoringRun,
@@ -279,8 +281,9 @@ class MonitoringRunRepository:
                         """
                         INSERT INTO monitoring_papers (
                             run_id, paper_id, registered,
-                            relevance_score, relevance_reasoning
-                        ) VALUES (?, ?, ?, ?, ?)
+                            relevance_score, relevance_reasoning,
+                            source
+                        ) VALUES (?, ?, ?, ?, ?, ?)
                         """,
                         [
                             (
@@ -289,6 +292,8 @@ class MonitoringRunRepository:
                                 1 if paper.is_new else 0,
                                 paper.relevance_score,
                                 paper.relevance_reasoning,
+                                # V5 / issue #141: per-paper provenance.
+                                paper.source.value,
                             )
                             for paper in run.papers
                         ],
@@ -395,7 +400,8 @@ class MonitoringRunRepository:
         """
         cursor = conn.execute(
             """
-            SELECT paper_id, registered, relevance_score, relevance_reasoning
+            SELECT paper_id, registered, relevance_score, relevance_reasoning,
+                   source
             FROM monitoring_papers
             WHERE run_id = ?
             ORDER BY paper_id ASC
@@ -408,6 +414,8 @@ class MonitoringRunRepository:
                 registered=bool(row["registered"]),
                 relevance_score=row["relevance_score"],
                 relevance_reasoning=row["relevance_reasoning"],
+                # V5 / issue #141: per-paper provenance round-trip.
+                source=PaperSource(row["source"]),
             )
             for row in cursor.fetchall()
         ]

--- a/src/services/intelligence/monitoring/run_repository.py
+++ b/src/services/intelligence/monitoring/run_repository.py
@@ -408,17 +408,29 @@ class MonitoringRunRepository:
             """,
             (run_id,),
         )
-        result: list[MonitoringPaperAudit] = [
-            MonitoringPaperAudit(
-                paper_id=row["paper_id"],
-                registered=bool(row["registered"]),
-                relevance_score=row["relevance_score"],
-                relevance_reasoning=row["relevance_reasoning"],
-                # V5 / issue #141: per-paper provenance round-trip.
-                source=PaperSource(row["source"]),
+        rows = cursor.fetchall()
+        result: list[MonitoringPaperAudit] = []
+        for row in rows:
+            raw_source = row["source"]
+            try:
+                source = PaperSource(raw_source)
+            except ValueError:
+                logger.error(
+                    "monitoring_paper_unknown_source",
+                    paper_id=row["paper_id"],
+                    raw_value=raw_source,
+                )
+                raise
+            result.append(
+                MonitoringPaperAudit(
+                    paper_id=row["paper_id"],
+                    registered=bool(row["registered"]),
+                    relevance_score=row["relevance_score"],
+                    relevance_reasoning=row["relevance_reasoning"],
+                    # V5 / issue #141: per-paper provenance round-trip.
+                    source=source,
+                )
             )
-            for row in cursor.fetchall()
-        ]
         # Defense-in-depth: pin the typed-DTO contract so a future
         # refactor (e.g., introducing a "fast path" that returns rows
         # directly) cannot silently leak dicts to the caller.

--- a/src/services/intelligence/monitoring/runner.py
+++ b/src/services/intelligence/monitoring/runner.py
@@ -383,10 +383,16 @@ class MonitoringRunner:
         from src.models.paper import PaperMetadata
 
         if paper.url is None:
+            # Issue #141: include per-paper source so "why was this
+            # paper skipped?" queries can pivot on provider — non-arXiv
+            # papers more frequently land here because their feeds may
+            # not include URLs that pass PaperMetadata's HttpUrl
+            # validator.
             logger.info(
                 "monitoring_relevance_score_skipped_no_url",
                 subscription_id=subscription.subscription_id,
                 paper_id=paper.paper_id,
+                source=paper.source.value,
             )
             return
 

--- a/src/storage/intelligence_graph/migrations.py
+++ b/src/storage/intelligence_graph/migrations.py
@@ -411,13 +411,71 @@ MIGRATION_V4_CITATION_INFLUENCE_METRICS = Migration(
 )
 
 
+# Schema version 5: Per-paper source provenance on monitoring_papers.
+# Phase 9.1 Tier 1 follow-up — Issue #141.
+#
+# Background
+# ----------
+# PR #140 shipped ``MultiProviderMonitor`` (arXiv + OpenAlex + HuggingFace
+# + Semantic Scholar fan-out) but kept ``MonitoringRun.source =
+# PaperSource.ARXIV`` hardcoded for schema-compatibility. The audit log
+# silently misattributed any paper that came from a non-arXiv provider.
+#
+# This migration adds a per-paper ``source`` column to
+# ``monitoring_papers`` so each row records its actual discovery
+# provider. The cycle-level ``monitoring_runs.source`` column is left
+# alone (semantics widened in code: it now means "primary / first-seen
+# source", not "all sources" — the per-paper row is the source of
+# truth).
+#
+# Backfill
+# --------
+# Existing rows default to ``'arxiv'``. This is correct because every
+# paper persisted before PR #140 came from arXiv (the monitor was
+# arXiv-only). Pre-Tier-1 audit rows that fell into the gap between
+# PR #140 and this migration are also backfilled to arXiv — at worst,
+# a handful of OpenAlex/HF/S2 papers from a few PR #140 cycles get
+# attributed to arXiv. That's the same lie that prompted #141, but
+# bounded to a small cohort and easy to identify (those rows have
+# the V5 default rather than an explicit per-source write).
+#
+# Why ``DEFAULT 'arxiv'`` (not NULL)
+# ----------------------------------
+# A NULL source would force every consumer (digest generator, future
+# CLI / REST surface) to handle "unknown source" as a special case.
+# Using a sentinel default means downstream code can treat the column
+# as required without a None branch. The PaperSource enum already has
+# ``ARXIV`` so the default lines up with the enum's first member.
+MIGRATION_V5_PAPER_SOURCE_TRACKING = Migration(
+    version=5,
+    name="paper_source_tracking",
+    description=(
+        "Add monitoring_papers.source column for per-paper provenance "
+        "(Phase 9.1 Tier 1 follow-up / Issue #141). Backfills existing "
+        "rows to 'arxiv' since pre-Tier-1 monitoring was arXiv-only."
+    ),
+    up="""
+    ALTER TABLE monitoring_papers
+        ADD COLUMN source TEXT NOT NULL DEFAULT 'arxiv';
+    """,
+)
+
+
 # All migrations in order
 ALL_MIGRATIONS: list[Migration] = [
     MIGRATION_V1_INITIAL,
     MIGRATION_V2_MONITORING_RUNS,
     MIGRATION_V3_MONITORING_RUNS_FK,
     MIGRATION_V4_CITATION_INFLUENCE_METRICS,
+    MIGRATION_V5_PAPER_SOURCE_TRACKING,
 ]
+
+
+# The latest migration version known to the codebase. Modules that
+# need to assert "we are on the canonical schema" import this rather
+# than counting ``ALL_MIGRATIONS`` so a future migration addition is
+# a single-line update.
+LATEST_MIGRATION_VERSION = 5
 
 
 class MigrationManager:

--- a/src/storage/intelligence_graph/migrations.py
+++ b/src/storage/intelligence_graph/migrations.py
@@ -423,10 +423,10 @@ MIGRATION_V4_CITATION_INFLUENCE_METRICS = Migration(
 #
 # This migration adds a per-paper ``source`` column to
 # ``monitoring_papers`` so each row records its actual discovery
-# provider. The cycle-level ``monitoring_runs.source`` column is left
-# alone (semantics widened in code: it now means "primary / first-seen
-# source", not "all sources" — the per-paper row is the source of
-# truth).
+# provider. ``MonitoringRun.source`` (in-memory only — no
+# ``monitoring_runs.source`` column exists) is left alone; its semantics
+# are widened in code to mean "primary / first-seen source" rather than
+# "all sources". The per-paper row is the authoritative record.
 #
 # Backfill
 # --------
@@ -446,17 +446,54 @@ MIGRATION_V4_CITATION_INFLUENCE_METRICS = Migration(
 # Using a sentinel default means downstream code can treat the column
 # as required without a None branch. The PaperSource enum already has
 # ``ARXIV`` so the default lines up with the enum's first member.
+#
+# Why table-swap (not ALTER TABLE ADD COLUMN)
+# -------------------------------------------
+# SQLite's ``ALTER TABLE ... ADD COLUMN`` cannot add a column with a
+# CHECK constraint. The table-swap pattern (CREATE new → INSERT from old
+# → DROP old → RENAME) is the only SQLite-portable way to add a CHECK to
+# an existing table. Mirrors the approach used in V3.
+#
+# CHECK constraint mirrors ``PaperSource`` enum exactly so that any future
+# enum addition that forgets a corresponding V6 widening is caught at
+# INSERT time rather than silently storing garbage. The drift-guard test
+# ``test_migrate_v5_check_constraint_matches_paper_source_enum`` pins the
+# enum-vs-CHECK pairing.
 MIGRATION_V5_PAPER_SOURCE_TRACKING = Migration(
     version=5,
     name="paper_source_tracking",
     description=(
         "Add monitoring_papers.source column for per-paper provenance "
         "(Phase 9.1 Tier 1 follow-up / Issue #141). Backfills existing "
-        "rows to 'arxiv' since pre-Tier-1 monitoring was arXiv-only."
+        "rows to 'arxiv' since pre-Tier-1 monitoring was arXiv-only. "
+        "Uses table-swap to add CHECK (source IN (...)) constraint."
     ),
     up="""
-    ALTER TABLE monitoring_papers
-        ADD COLUMN source TEXT NOT NULL DEFAULT 'arxiv';
+    CREATE TABLE monitoring_papers_new (
+        run_id TEXT NOT NULL,
+        paper_id TEXT NOT NULL,
+        registered INTEGER NOT NULL DEFAULT 0,
+        relevance_score REAL,
+        relevance_reasoning TEXT,
+        source TEXT NOT NULL DEFAULT 'arxiv'
+            CHECK (source IN (
+                'arxiv', 'semantic_scholar', 'huggingface', 'openalex'
+            )),
+        PRIMARY KEY (run_id, paper_id),
+        FOREIGN KEY (run_id) REFERENCES monitoring_runs(run_id)
+            ON DELETE CASCADE
+    );
+
+    INSERT INTO monitoring_papers_new (
+        run_id, paper_id, registered, relevance_score, relevance_reasoning, source
+    )
+    SELECT
+        run_id, paper_id, registered, relevance_score, relevance_reasoning, 'arxiv'
+    FROM monitoring_papers;
+
+    DROP TABLE monitoring_papers;
+
+    ALTER TABLE monitoring_papers_new RENAME TO monitoring_papers;
     """,
 )
 

--- a/tests/unit/cli/test_monitor_cli.py
+++ b/tests/unit/cli/test_monitor_cli.py
@@ -28,6 +28,7 @@ from src.services.intelligence.monitoring.models import (
     MonitoringPaperRecord,
     MonitoringRun,
     MonitoringRunStatus,
+    PaperSource,
     ResearchSubscription,
 )
 
@@ -83,6 +84,7 @@ def _make_paper_record(
         title=title,
         is_new=is_new,
         relevance_score=relevance_score,
+        source=PaperSource.ARXIV,
     )
 
 

--- a/tests/unit/services/intelligence/monitoring/test_digest_generator.py
+++ b/tests/unit/services/intelligence/monitoring/test_digest_generator.py
@@ -620,9 +620,18 @@ class TestOutputRootEnvVar:
     def test_structlog_monitoring_digest_written(
         self,
         tmp_output: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """H-T1: ``monitoring_digest_written`` is logged by DigestGenerator."""
+        import structlog
         import structlog.testing
+        from src.services.intelligence.monitoring import digest_generator as dg_mod
+
+        # Rebind the module-level logger before entering capture_logs() so
+        # the cached production logger is replaced and events are intercepted.
+        # Required because cache_logger_on_first_use=True freezes the bound
+        # logger at first call, bypassing the capture_logs() processor swap.
+        monkeypatch.setattr(dg_mod, "logger", structlog.get_logger())
 
         gen = DigestGenerator(tmp_output)
         sub = _make_subscription()

--- a/tests/unit/services/intelligence/monitoring/test_digest_generator.py
+++ b/tests/unit/services/intelligence/monitoring/test_digest_generator.py
@@ -31,6 +31,7 @@ from src.services.intelligence.monitoring.digest_generator import (
     DigestGenerator,
     REASONING_TRUNCATE_CHARS,
 )
+from src.services.intelligence.models.monitoring import PaperSource
 from src.services.intelligence.monitoring.models import (
     MonitoringPaperAudit,
     MonitoringRunAudit,
@@ -63,12 +64,14 @@ def _make_paper_audit(
     relevance_score: Optional[float] = 0.8,
     relevance_reasoning: Optional[str] = "Highly relevant",
     registered: bool = False,
+    source: PaperSource = PaperSource.ARXIV,
 ) -> MonitoringPaperAudit:
     return MonitoringPaperAudit(
         paper_id=paper_id,
         registered=registered,
         relevance_score=relevance_score,
         relevance_reasoning=relevance_reasoning,
+        source=source,
     )
 
 
@@ -572,6 +575,8 @@ class TestRenderedSnapshot:
         assert "Direct match on PEFT keyword." in text
         assert "## Stats\n" in text
         assert text.endswith("\n")
+        # M-4 / issue #141: per-paper Source: line must appear in the digest.
+        assert "Source: `arxiv`" in text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/intelligence/monitoring/test_digest_generator.py
+++ b/tests/unit/services/intelligence/monitoring/test_digest_generator.py
@@ -631,3 +631,59 @@ class TestOutputRootEnvVar:
         assert len(written_events) == 1
         assert written_events[0].get("run_id") == run.run_id
         assert written_events[0].get("subscription_id") == sub.subscription_id
+
+
+# ---------------------------------------------------------------------------
+# Issue #141: per-paper source rendering
+# ---------------------------------------------------------------------------
+
+
+class TestDigestSourceRendering:
+    """The Top Papers section must surface each paper's source provider."""
+
+    def test_per_paper_source_appears_in_markdown(self, tmp_output: Path) -> None:
+        """Each Top Papers entry includes a ``Source: ...`` line.
+
+        Issue #141: a digest reader can immediately see that paper X came
+        from arXiv and paper Y came from OpenAlex without round-tripping
+        through the audit DB.
+        """
+        from src.services.intelligence.models.monitoring import PaperSource
+
+        gen = DigestGenerator(tmp_output)
+        sub = _make_subscription()
+        run = _make_run(
+            papers_seen=2,
+            papers_new=2,
+            papers=[
+                MonitoringPaperAudit(
+                    paper_id="arxiv-1",
+                    registered=True,
+                    relevance_score=0.9,
+                    source=PaperSource.ARXIV,
+                ),
+                MonitoringPaperAudit(
+                    paper_id="oa-1",
+                    registered=True,
+                    relevance_score=0.85,
+                    source=PaperSource.OPENALEX,
+                ),
+            ],
+        )
+        path = gen.generate(run, sub)
+        text = path.read_text(encoding="utf-8")
+
+        # Both source labels must appear under their respective papers.
+        assert "Source: `arxiv`" in text
+        assert "Source: `openalex`" in text
+
+    def test_source_line_omitted_when_no_papers(self, tmp_output: Path) -> None:
+        """The empty-papers code path must not render any source lines."""
+        gen = DigestGenerator(tmp_output)
+        sub = _make_subscription()
+        run = _make_run()  # no papers
+        text = gen.generate(run, sub).read_text(encoding="utf-8")
+        # The empty section's "no papers" sentinel is present...
+        assert "_No papers were seen in this run._" in text
+        # ...and no spurious Source line was rendered.
+        assert "Source:" not in text

--- a/tests/unit/services/intelligence/monitoring/test_models.py
+++ b/tests/unit/services/intelligence/monitoring/test_models.py
@@ -469,13 +469,12 @@ class TestMonitoringPaperAudit:
     """
 
     def test_audit_minimal_defaults(self) -> None:
-        rec = MonitoringPaperAudit(paper_id="2301.12345")
+        rec = MonitoringPaperAudit(paper_id="2301.12345", source=PaperSource.ARXIV)
         assert rec.paper_id == "2301.12345"
         assert rec.registered is False
         assert rec.relevance_score is None
         assert rec.relevance_reasoning is None
-        # Issue #141: backwards-compat default for legacy V1-V4 audit rows
-        # whose schema column would have been backfilled to 'arxiv'.
+        # Issue #141: source is now required; callers must always supply it.
         assert rec.source is PaperSource.ARXIV
 
     def test_audit_full_construction(self) -> None:
@@ -498,13 +497,18 @@ class TestMonitoringPaperAudit:
             rec = MonitoringPaperAudit(paper_id="x", source=src)
             assert rec.source is src
 
+    def test_audit_source_is_required(self) -> None:
+        """M-2: source is required — omitting it must raise ValidationError."""
+        with pytest.raises(ValidationError, match="source"):
+            MonitoringPaperAudit(paper_id="2301.12345")  # type: ignore[call-arg]
+
     def test_audit_paper_id_rejects_empty(self) -> None:
         with pytest.raises(ValidationError, match="at least 1 character"):
-            MonitoringPaperAudit(paper_id="")
+            MonitoringPaperAudit(paper_id="")  # type: ignore[call-arg]
 
     def test_audit_paper_id_at_boundary_accepted(self) -> None:
         # 512 chars exactly -- the post-#S6 cap.
-        rec = MonitoringPaperAudit(paper_id="x" * 512)
+        rec = MonitoringPaperAudit(paper_id="x" * 512, source=PaperSource.ARXIV)
         assert len(rec.paper_id) == 512
 
     def test_audit_paper_id_above_boundary_rejected(self) -> None:
@@ -514,26 +518,36 @@ class TestMonitoringPaperAudit:
 
     def test_audit_relevance_score_below_range_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            MonitoringPaperAudit(paper_id="x", relevance_score=-0.01)
+            MonitoringPaperAudit(
+                paper_id="x", source=PaperSource.ARXIV, relevance_score=-0.01
+            )
 
     def test_audit_relevance_score_above_range_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            MonitoringPaperAudit(paper_id="x", relevance_score=1.01)
+            MonitoringPaperAudit(
+                paper_id="x", source=PaperSource.ARXIV, relevance_score=1.01
+            )
 
     def test_audit_relevance_reasoning_at_boundary_accepted(self) -> None:
-        rec = MonitoringPaperAudit(paper_id="x", relevance_reasoning="r" * 4096)
+        rec = MonitoringPaperAudit(
+            paper_id="x", source=PaperSource.ARXIV, relevance_reasoning="r" * 4096
+        )
         assert len(rec.relevance_reasoning or "") == 4096
 
     def test_audit_relevance_reasoning_above_boundary_rejected(self) -> None:
         with pytest.raises(ValidationError, match="at most 4096 character"):
-            MonitoringPaperAudit(paper_id="x", relevance_reasoning="r" * 4097)
+            MonitoringPaperAudit(
+                paper_id="x", source=PaperSource.ARXIV, relevance_reasoning="r" * 4097
+            )
 
     def test_audit_extra_field_forbidden(self) -> None:
         # Pinning ``extra="forbid"`` -- unknown fields like ``unknown=...``
         # must raise so callers can't silently smuggle data the audit
         # table cannot store.
         with pytest.raises(ValidationError):
-            MonitoringPaperAudit(paper_id="x", unknown="y")  # type: ignore[call-arg]
+            MonitoringPaperAudit(  # type: ignore[call-arg]
+                paper_id="x", source=PaperSource.ARXIV, unknown="y"
+            )
 
 
 class TestMonitoringRunAudit:
@@ -568,13 +582,20 @@ class TestMonitoringRunAudit:
         assert run.error is None
 
     def test_audit_run_with_one_paper(self) -> None:
-        papers = [MonitoringPaperAudit(paper_id="2301.0001", registered=True)]
+        papers = [
+            MonitoringPaperAudit(
+                paper_id="2301.0001", registered=True, source=PaperSource.ARXIV
+            )
+        ]
         run = self._audit(papers=papers)
         assert len(run.papers) == 1
         assert run.papers[0].paper_id == "2301.0001"
 
     def test_audit_run_with_many_papers(self) -> None:
-        papers = [MonitoringPaperAudit(paper_id=f"p-{i}") for i in range(5)]
+        papers = [
+            MonitoringPaperAudit(paper_id=f"p-{i}", source=PaperSource.ARXIV)
+            for i in range(5)
+        ]
         run = self._audit(papers=papers)
         assert len(run.papers) == 5
 
@@ -624,11 +645,14 @@ class TestMonitoringRunAudit:
     def test_audit_run_round_trip_via_model_dump(self) -> None:
         original = self._audit(
             papers=[
-                MonitoringPaperAudit(paper_id="p-1", registered=True),
+                MonitoringPaperAudit(
+                    paper_id="p-1", registered=True, source=PaperSource.ARXIV
+                ),
                 MonitoringPaperAudit(
                     paper_id="p-2",
                     relevance_score=0.5,
                     relevance_reasoning="ok",
+                    source=PaperSource.ARXIV,
                 ),
             ]
         )

--- a/tests/unit/services/intelligence/monitoring/test_models.py
+++ b/tests/unit/services/intelligence/monitoring/test_models.py
@@ -297,7 +297,12 @@ class TestRangeValidators:
 
 class TestMonitoringPaperRecord:
     def test_paper_record_minimal(self) -> None:
-        rec = MonitoringPaperRecord(paper_id="2301.12345", title="A Paper", is_new=True)
+        rec = MonitoringPaperRecord(
+            paper_id="2301.12345",
+            title="A Paper",
+            is_new=True,
+            source=PaperSource.ARXIV,
+        )
         assert rec.paper_id == "2301.12345"
         assert rec.title == "A Paper"
         assert rec.is_new is True
@@ -306,6 +311,7 @@ class TestMonitoringPaperRecord:
         assert rec.published_at is None
         assert rec.relevance_score is None
         assert rec.relevance_reasoning is None
+        assert rec.source is PaperSource.ARXIV
 
     def test_paper_record_full(self) -> None:
         rec = MonitoringPaperRecord(
@@ -317,9 +323,25 @@ class TestMonitoringPaperRecord:
             is_new=False,
             relevance_score=0.9,
             relevance_reasoning="strong match",
+            source=PaperSource.OPENALEX,
         )
         assert rec.url == "https://arxiv.org/abs/2301.12345"
         assert rec.relevance_score == 0.9
+        assert rec.source is PaperSource.OPENALEX
+
+    def test_paper_record_source_required(self) -> None:
+        """Issue #141: ``source`` has no default — callers must specify it.
+
+        Pinning the required-ness here means a future refactor that
+        re-introduces a default (e.g. PaperSource.ARXIV) fails loudly,
+        catching exactly the silent-misattribution regression we're
+        guarding against.
+        """
+        with pytest.raises(ValidationError) as excinfo:
+            MonitoringPaperRecord(  # type: ignore[call-arg]
+                paper_id="x", title="t", is_new=True
+            )
+        assert "source" in str(excinfo.value)
 
     def test_paper_record_extra_forbidden(self) -> None:
         with pytest.raises(ValidationError):
@@ -327,14 +349,27 @@ class TestMonitoringPaperRecord:
                 paper_id="x",
                 title="t",
                 is_new=True,
+                source=PaperSource.ARXIV,
                 junk="bad",  # type: ignore[call-arg]
             )
 
     def test_paper_record_relevance_score_out_of_range(self) -> None:
         with pytest.raises(ValidationError):
             MonitoringPaperRecord(
-                paper_id="x", title="t", is_new=True, relevance_score=1.5
+                paper_id="x",
+                title="t",
+                is_new=True,
+                source=PaperSource.ARXIV,
+                relevance_score=1.5,
             )
+
+    def test_paper_record_accepts_each_paper_source(self) -> None:
+        """Issue #141: every ``PaperSource`` enum member is a valid value."""
+        for src in PaperSource:
+            rec = MonitoringPaperRecord(
+                paper_id="x", title="t", is_new=True, source=src
+            )
+            assert rec.source is src
 
 
 # ---------------------------------------------------------------------------
@@ -355,7 +390,9 @@ class TestMonitoringRun:
 
     def test_monitoring_run_below_paper_cap(self) -> None:
         records = [
-            MonitoringPaperRecord(paper_id=f"p-{i}", title="t", is_new=True)
+            MonitoringPaperRecord(
+                paper_id=f"p-{i}", title="t", is_new=True, source=PaperSource.ARXIV
+            )
             for i in range(3)
         ]
         run = MonitoringRun(subscription_id="sub-1", papers=records)
@@ -363,7 +400,9 @@ class TestMonitoringRun:
 
     def test_monitoring_run_at_paper_cap_accepted(self) -> None:
         records = [
-            MonitoringPaperRecord(paper_id=f"p-{i}", title="t", is_new=True)
+            MonitoringPaperRecord(
+                paper_id=f"p-{i}", title="t", is_new=True, source=PaperSource.ARXIV
+            )
             for i in range(MAX_PAPERS_PER_CYCLE)
         ]
         run = MonitoringRun(subscription_id="sub-1", papers=records)
@@ -371,7 +410,9 @@ class TestMonitoringRun:
 
     def test_monitoring_run_above_paper_cap_raises(self) -> None:
         records = [
-            MonitoringPaperRecord(paper_id=f"p-{i}", title="t", is_new=True)
+            MonitoringPaperRecord(
+                paper_id=f"p-{i}", title="t", is_new=True, source=PaperSource.ARXIV
+            )
             for i in range(MAX_PAPERS_PER_CYCLE + 1)
         ]
         with pytest.raises(ValidationError) as excinfo:
@@ -433,6 +474,9 @@ class TestMonitoringPaperAudit:
         assert rec.registered is False
         assert rec.relevance_score is None
         assert rec.relevance_reasoning is None
+        # Issue #141: backwards-compat default for legacy V1-V4 audit rows
+        # whose schema column would have been backfilled to 'arxiv'.
+        assert rec.source is PaperSource.ARXIV
 
     def test_audit_full_construction(self) -> None:
         rec = MonitoringPaperAudit(
@@ -440,11 +484,19 @@ class TestMonitoringPaperAudit:
             registered=True,
             relevance_score=0.9,
             relevance_reasoning="strong match",
+            source=PaperSource.OPENALEX,
         )
         assert rec.paper_id == "2301.12345"
         assert rec.registered is True
         assert rec.relevance_score == 0.9
         assert rec.relevance_reasoning == "strong match"
+        assert rec.source is PaperSource.OPENALEX
+
+    def test_audit_accepts_each_paper_source(self) -> None:
+        """Issue #141: all PaperSource enum members are accepted."""
+        for src in PaperSource:
+            rec = MonitoringPaperAudit(paper_id="x", source=src)
+            assert rec.source is src
 
     def test_audit_paper_id_rejects_empty(self) -> None:
         with pytest.raises(ValidationError, match="at least 1 character"):
@@ -532,7 +584,10 @@ class TestMonitoringRunAudit:
         # values, but a record carries fields like ``title`` that the
         # audit type forbids -- so the coercion fails.
         record = MonitoringPaperRecord(
-            paper_id="2301.0001", title="Some Paper", is_new=True
+            paper_id="2301.0001",
+            title="Some Paper",
+            is_new=True,
+            source=PaperSource.ARXIV,
         )
         with pytest.raises(ValidationError):
             MonitoringRunAudit(

--- a/tests/unit/services/intelligence/monitoring/test_models.py
+++ b/tests/unit/services/intelligence/monitoring/test_models.py
@@ -93,7 +93,7 @@ class TestResearchSubscriptionConstruction:
         assert sub.status is SubscriptionStatus.PAUSED
 
     def test_extra_fields_forbidden(self) -> None:
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
             ResearchSubscription(
                 name="x", query="q", junk="bad"  # type: ignore[call-arg]
             )

--- a/tests/unit/services/intelligence/monitoring/test_multi_provider_monitor.py
+++ b/tests/unit/services/intelligence/monitoring/test_multi_provider_monitor.py
@@ -915,22 +915,112 @@ def test_build_tier1_extras_returns_none_when_no_llm() -> None:
     assert query_expander is None
 
 
-def test_build_tier1_extras_returns_none_on_construction_failure(
-    monkeypatch,
+def test_build_tier1_extras_returns_none_when_provider_construction_raises(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """H-C4: If provider construction fails, build_tier1_extras returns (None, None)."""
-    # Patch the factory to simulate a construction failure.
-    monkeypatch.setattr(
-        "src.services.intelligence.monitoring._tier1_factory.build_tier1_extras",
-        lambda llm: (None, None),
-    )
+    """C-2/H-C4: If a provider constructor raises, build_tier1_extras catches
+    the exception, logs monitor_tier1_init_failed, and returns (None, None).
 
+    Patches OpenAlexProvider (a *dependency* of build_tier1_extras, not the
+    function under test) so the production code path is actually executed.
+    """
+    import structlog
+    import structlog.testing
+
+    import src.services.intelligence.monitoring._tier1_factory as factory_module
     from src.services.intelligence.monitoring._tier1_factory import build_tier1_extras
 
-    extra_providers, query_expander = build_tier1_extras(MagicMock())
-    # When the factory is patched to always return (None, None), caller receives None.
+    monkeypatch.setattr(factory_module, "logger", structlog.get_logger())
+    monkeypatch.setattr(
+        "src.services.providers.openalex.OpenAlexProvider",
+        MagicMock(side_effect=RuntimeError("network unreachable")),
+    )
+
+    with structlog.testing.capture_logs() as logs:
+        extra_providers, query_expander = build_tier1_extras(MagicMock())
+
     assert extra_providers is None
     assert query_expander is None
+
+    failed_events = [e for e in logs if e.get("event") == "monitor_tier1_init_failed"]
+    assert len(failed_events) == 1
+    assert "network unreachable" in failed_events[0].get("error", "")
+
+
+def test_build_tier1_extras_happy_path_returns_providers_and_expander(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """C-2/H-C4: When all providers construct successfully, build_tier1_extras
+    returns a non-None providers dict and a QueryExpander.
+
+    Patches OpenAlexProvider, HuggingFaceProvider, and QueryExpander so
+    the real try-block (lines 60-79) is exercised without network I/O.
+    SEMANTIC_SCHOLAR_API_KEY is unset so the optional S2 branch is skipped.
+    """
+    from src.services.intelligence.monitoring._tier1_factory import build_tier1_extras
+    from src.services.intelligence.monitoring.models import PaperSource
+
+    fake_openalex = MagicMock()
+    fake_hf = MagicMock()
+    fake_expander = MagicMock()
+
+    monkeypatch.setattr(
+        "src.services.providers.openalex.OpenAlexProvider",
+        MagicMock(return_value=fake_openalex),
+    )
+    monkeypatch.setattr(
+        "src.services.providers.huggingface.HuggingFaceProvider",
+        MagicMock(return_value=fake_hf),
+    )
+    monkeypatch.setattr(
+        "src.utils.query_expander.QueryExpander",
+        MagicMock(return_value=fake_expander),
+    )
+    # Ensure no S2 key is present for this test.
+    monkeypatch.delenv("SEMANTIC_SCHOLAR_API_KEY", raising=False)
+
+    extra_providers, query_expander = build_tier1_extras(MagicMock())
+
+    assert extra_providers is not None
+    assert PaperSource.OPENALEX in extra_providers
+    assert PaperSource.HUGGINGFACE in extra_providers
+    assert PaperSource.SEMANTIC_SCHOLAR not in extra_providers
+    assert query_expander is fake_expander
+
+
+def test_build_tier1_extras_includes_semantic_scholar_when_api_key_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """C-2/H-C4: When SEMANTIC_SCHOLAR_API_KEY is set, SemanticScholarProvider
+    is included in the returned providers dict (line 73 branch).
+    """
+    from src.services.intelligence.monitoring._tier1_factory import build_tier1_extras
+    from src.services.intelligence.monitoring.models import PaperSource
+
+    fake_s2 = MagicMock()
+
+    monkeypatch.setattr(
+        "src.services.providers.openalex.OpenAlexProvider",
+        MagicMock(return_value=MagicMock()),
+    )
+    monkeypatch.setattr(
+        "src.services.providers.huggingface.HuggingFaceProvider",
+        MagicMock(return_value=MagicMock()),
+    )
+    monkeypatch.setattr(
+        "src.services.providers.semantic_scholar.SemanticScholarProvider",
+        MagicMock(return_value=fake_s2),
+    )
+    monkeypatch.setattr(
+        "src.utils.query_expander.QueryExpander",
+        MagicMock(return_value=MagicMock()),
+    )
+    monkeypatch.setenv("SEMANTIC_SCHOLAR_API_KEY", "test-key-123")
+
+    extra_providers, _ = build_tier1_extras(MagicMock())
+
+    assert extra_providers is not None
+    assert PaperSource.SEMANTIC_SCHOLAR in extra_providers
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/intelligence/monitoring/test_multi_provider_monitor.py
+++ b/tests/unit/services/intelligence/monitoring/test_multi_provider_monitor.py
@@ -623,6 +623,8 @@ async def test_check_identity_resolution_error_emits_log(monkeypatch) -> None:
     events = [e for e in logs if e.get("event") == "monitor_identity_resolution_error"]
     assert len(events) == 1
     assert events[0].get("paper_id") == "p1"
+    # H-4: source field must be present so a future drop of source= is caught.
+    assert events[0].get("source") == PaperSource.ARXIV.value
 
 
 @pytest.mark.asyncio
@@ -641,6 +643,8 @@ async def test_check_registry_write_error_emits_log(monkeypatch) -> None:
     events = [e for e in logs if e.get("event") == "monitor_registry_write_error"]
     assert len(events) == 1
     assert events[0].get("paper_id") == "p1"
+    # H-4: source field must be present so a future drop of source= is caught.
+    assert events[0].get("source") == PaperSource.ARXIV.value
 
 
 # ---------------------------------------------------------------------------
@@ -1069,20 +1073,23 @@ async def test_check_records_per_paper_source_for_each_provider() -> None:
     s2 = _make_provider(return_papers=[s2_paper])
     hf = _make_provider(return_papers=[hf_paper])
 
-    sub = _make_subscription()
+    sub_base = _make_subscription()
     # Bypass the model validator (which restricts MVP subscriptions to
     # ARXIV-only) so we can exercise the multi-provider paper-tracking
     # code path. This is exactly the path Tier 1 production builds will
     # hit once the subscription validator is widened in a follow-up.
-    object.__setattr__(
-        sub,
-        "sources",
-        [
-            PaperSource.ARXIV,
-            PaperSource.OPENALEX,
-            PaperSource.SEMANTIC_SCHOLAR,
-            PaperSource.HUGGINGFACE,
-        ],
+    # Use model_construct (the Pydantic API for validation-free construction)
+    # rather than object.__setattr__ to avoid coupling to Pydantic internals.
+    sub = ResearchSubscription.model_construct(
+        **{
+            **sub_base.model_dump(),
+            "sources": [
+                PaperSource.ARXIV,
+                PaperSource.OPENALEX,
+                PaperSource.SEMANTIC_SCHOLAR,
+                PaperSource.HUGGINGFACE,
+            ],
+        }
     )
 
     monitor = MultiProviderMonitor(
@@ -1117,8 +1124,15 @@ async def test_check_dedup_preserves_first_seen_source() -> None:
     arxiv = _make_provider(return_papers=[shared])
     openalex = _make_provider(return_papers=[shared])
 
-    sub = _make_subscription()
-    object.__setattr__(sub, "sources", [PaperSource.ARXIV, PaperSource.OPENALEX])
+    sub_base = _make_subscription()
+    # Use model_construct to bypass the ARXIV-only validator (Pydantic API
+    # rather than object.__setattr__ to avoid coupling to internals).
+    sub = ResearchSubscription.model_construct(
+        **{
+            **sub_base.model_dump(),
+            "sources": [PaperSource.ARXIV, PaperSource.OPENALEX],
+        }
+    )
 
     monitor = MultiProviderMonitor(
         providers={

--- a/tests/unit/services/intelligence/monitoring/test_multi_provider_monitor.py
+++ b/tests/unit/services/intelligence/monitoring/test_multi_provider_monitor.py
@@ -931,3 +931,132 @@ def test_build_tier1_extras_returns_none_on_construction_failure(
     # When the factory is patched to always return (None, None), caller receives None.
     assert extra_providers is None
     assert query_expander is None
+
+
+# ---------------------------------------------------------------------------
+# Issue #141: per-paper source provenance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_check_records_actual_source_per_paper() -> None:
+    """Issue #141: ``MonitoringRun.papers`` carries the actual provider per paper.
+
+    The MVP subscription only allows ARXIV in ``sources``, so all papers
+    in this single-provider scenario must come back stamped
+    ``source=PaperSource.ARXIV`` -- never the silent default the V5
+    column would have given them.
+    """
+    sub = _make_subscription()
+    arxiv = _make_provider(return_papers=[_make_paper("p1")])
+    monitor = MultiProviderMonitor(
+        providers={PaperSource.ARXIV: arxiv},
+        registry=_make_registry(),
+    )
+    result = await monitor.check(sub)
+    assert result.run.papers_seen == 1
+    assert result.run.papers[0].source is PaperSource.ARXIV
+
+
+@pytest.mark.asyncio
+async def test_check_records_per_paper_source_for_each_provider() -> None:
+    """Issue #141: when a subscription allows multiple providers, each
+    paper's source field reflects the provider it actually came from --
+    NOT a hardcoded ``PaperSource.ARXIV`` (the lie #141 is fixing).
+
+    Subscription is constructed with ``sources=[ARXIV, OPENALEX, ...]``
+    bypassing the model-level allowlist via ``object.__setattr__`` so
+    this test focuses on the monitor's per-paper source threading
+    rather than the (separately-tested) model validator.
+    """
+    arxiv_paper = _make_paper("arxiv-paper-1", title="ArXiv paper")
+    openalex_paper = _make_paper("oa-paper-1", title="OpenAlex paper")
+    s2_paper = _make_paper("s2-paper-1", title="S2 paper")
+    hf_paper = _make_paper("hf-paper-1", title="HF paper")
+
+    arxiv = _make_provider(return_papers=[arxiv_paper])
+    openalex = _make_provider(return_papers=[openalex_paper])
+    s2 = _make_provider(return_papers=[s2_paper])
+    hf = _make_provider(return_papers=[hf_paper])
+
+    sub = _make_subscription()
+    # Bypass the model validator (which restricts MVP subscriptions to
+    # ARXIV-only) so we can exercise the multi-provider paper-tracking
+    # code path. This is exactly the path Tier 1 production builds will
+    # hit once the subscription validator is widened in a follow-up.
+    object.__setattr__(
+        sub,
+        "sources",
+        [
+            PaperSource.ARXIV,
+            PaperSource.OPENALEX,
+            PaperSource.SEMANTIC_SCHOLAR,
+            PaperSource.HUGGINGFACE,
+        ],
+    )
+
+    monitor = MultiProviderMonitor(
+        providers={
+            PaperSource.ARXIV: arxiv,
+            PaperSource.OPENALEX: openalex,
+            PaperSource.SEMANTIC_SCHOLAR: s2,
+            PaperSource.HUGGINGFACE: hf,
+        },
+        registry=_make_registry(),
+    )
+    result = await monitor.check(sub)
+
+    # Index the audit rows by paper_id for an unambiguous mapping
+    # assertion.
+    by_id = {p.paper_id: p for p in result.run.papers}
+    assert by_id["arxiv-paper-1"].source is PaperSource.ARXIV
+    assert by_id["oa-paper-1"].source is PaperSource.OPENALEX
+    assert by_id["s2-paper-1"].source is PaperSource.SEMANTIC_SCHOLAR
+    assert by_id["hf-paper-1"].source is PaperSource.HUGGINGFACE
+
+
+@pytest.mark.asyncio
+async def test_check_dedup_preserves_first_seen_source() -> None:
+    """When two providers return the same paper, the first-seen source wins.
+
+    Iteration order over the providers dict is insertion order in
+    Python 3.7+, so ``ARXIV`` (inserted first) is the source of the
+    deduplicated row -- not OPENALEX which came second.
+    """
+    shared = _make_paper("shared-paper")
+    arxiv = _make_provider(return_papers=[shared])
+    openalex = _make_provider(return_papers=[shared])
+
+    sub = _make_subscription()
+    object.__setattr__(sub, "sources", [PaperSource.ARXIV, PaperSource.OPENALEX])
+
+    monitor = MultiProviderMonitor(
+        providers={
+            PaperSource.ARXIV: arxiv,
+            PaperSource.OPENALEX: openalex,
+        },
+        registry=_make_registry(),
+    )
+    result = await monitor.check(sub)
+
+    assert result.run.papers_seen == 1
+    # First-seen wins; arXiv was iterated first.
+    assert result.run.papers[0].source is PaperSource.ARXIV
+
+
+@pytest.mark.asyncio
+async def test_check_records_source_for_deduplicated_papers() -> None:
+    """Even papers known to the registry (deduplicated) must carry their
+    provider source on the audit row -- not just freshly-registered ones.
+    """
+    sub = _make_subscription()
+    known = _make_paper("known-paper")
+    arxiv = _make_provider(return_papers=[known])
+    monitor = MultiProviderMonitor(
+        providers={PaperSource.ARXIV: arxiv},
+        registry=_make_registry(matched_paper_ids={"known-paper"}),
+    )
+    result = await monitor.check(sub)
+    assert result.run.papers_deduplicated == 1
+    assert result.run.papers[0].source is PaperSource.ARXIV
+    assert result.run.papers[0].is_new is False

--- a/tests/unit/services/intelligence/monitoring/test_relevance_scorer.py
+++ b/tests/unit/services/intelligence/monitoring/test_relevance_scorer.py
@@ -440,9 +440,19 @@ class TestRelevanceScorerScore:
             await scorer.score(_make_subscription(), _make_paper())
 
     @pytest.mark.asyncio
-    async def test_structlog_relevance_scored_event_emitted(self) -> None:
+    async def test_structlog_relevance_scored_event_emitted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """H-T1: ``relevance_scored`` structlog event is emitted on success."""
+        import structlog
         import structlog.testing
+        from src.services.intelligence.monitoring import relevance_scorer as rs_mod
+
+        # Rebind the module-level logger before entering capture_logs() so
+        # the cached production logger is replaced and events are intercepted.
+        # Required because cache_logger_on_first_use=True freezes the bound
+        # logger at first call, bypassing the capture_logs() processor swap.
+        monkeypatch.setattr(rs_mod, "logger", structlog.get_logger())
 
         llm = _make_llm('{"score": 0.75, "reasoning": "Good match"}')
         scorer = RelevanceScorer(llm)

--- a/tests/unit/services/intelligence/monitoring/test_run_repository.py
+++ b/tests/unit/services/intelligence/monitoring/test_run_repository.py
@@ -776,3 +776,62 @@ class TestCascadeDelete:
                 (run.run_id,),
             ).fetchone()[0]
         assert paper_count == 0
+
+
+class TestUnknownSourceFailLoud:
+    """M-6: ``_fetch_papers`` re-raises on unrecognised source values.
+
+    A ``monitoring_papers`` row whose ``source`` column contains a
+    value not in the ``PaperSource`` enum must (a) emit a structured
+    ``monitoring_paper_unknown_source`` log event and (b) re-raise the
+    ``ValueError`` so the caller learns about schema drift rather than
+    silently swallowing it.
+    """
+
+    def test_fetch_papers_unknown_source_logs_and_reraises(
+        self, repo: MonitoringRunRepository, db_path: Path
+    ) -> None:
+        import sqlite3 as _sqlite3
+        import structlog
+        import structlog.testing
+
+        from src.services.intelligence.monitoring import run_repository as rr_mod
+
+        # Record a run with a valid paper so the FK constraint is satisfied.
+        run = _make_run(
+            run_id="run-unknown-src",
+            papers_seen=1,
+            papers_new=1,
+            papers=[_make_record(paper_id="paper:bad:001")],
+        )
+        repo.record_run(run)
+
+        # Corrupt the source column directly -- bypass the CHECK constraint
+        # to simulate future schema drift (e.g., a new PaperSource enum value
+        # was added to the DB but not yet to this Python version).
+        # We must disable CHECK constraints for this raw write because the
+        # schema guard from H-3 would otherwise prevent the corrupt value.
+        with _sqlite3.connect(str(db_path)) as conn:
+            conn.execute("PRAGMA ignore_check_constraints = ON")
+            conn.execute(
+                "UPDATE monitoring_papers SET source = ? WHERE paper_id = ?",
+                ("not_a_real_source", "paper:bad:001"),
+            )
+            conn.commit()
+
+        with structlog.testing.capture_logs() as logs:
+            # Rebind module-level logger so capture_logs() intercepts it.
+            original_logger = rr_mod.logger
+            rr_mod.logger = structlog.get_logger()
+            try:
+                with pytest.raises(ValueError):
+                    repo.get_run("run-unknown-src")
+            finally:
+                rr_mod.logger = original_logger
+
+        error_events = [
+            e for e in logs if e.get("event") == "monitoring_paper_unknown_source"
+        ]
+        assert len(error_events) == 1
+        assert error_events[0].get("paper_id") == "paper:bad:001"
+        assert error_events[0].get("raw_value") == "not_a_real_source"

--- a/tests/unit/services/intelligence/monitoring/test_run_repository.py
+++ b/tests/unit/services/intelligence/monitoring/test_run_repository.py
@@ -111,6 +111,7 @@ def _make_record(
     is_new: bool = True,
     relevance_score: float | None = None,
     relevance_reasoning: str | None = None,
+    source: PaperSource = PaperSource.ARXIV,
 ) -> MonitoringPaperRecord:
     return MonitoringPaperRecord(
         paper_id=paper_id,
@@ -118,11 +119,12 @@ def _make_record(
         # in-memory MonitoringPaperRecord round-trip only -- the
         # repository's read path returns MonitoringPaperAudit which
         # carries only the persisted columns (paper_id, registered,
-        # relevance_score, relevance_reasoning).
+        # relevance_score, relevance_reasoning, source).
         title=paper_id,
         is_new=is_new,
         relevance_score=relevance_score,
         relevance_reasoning=relevance_reasoning,
+        source=source,
     )
 
 
@@ -273,12 +275,13 @@ class TestRoundTrip:
 
     def test_record_and_get_with_papers(self, repo: MonitoringRunRepository) -> None:
         records = [
-            _make_record(paper_id="2301.0001", is_new=True),
+            _make_record(paper_id="2301.0001", is_new=True, source=PaperSource.ARXIV),
             _make_record(
                 paper_id="2301.0002",
                 is_new=False,
                 relevance_score=0.85,
                 relevance_reasoning="strong match",
+                source=PaperSource.OPENALEX,
             ),
         ]
         run = _make_run(papers_seen=2, papers_new=1, papers=records)
@@ -308,6 +311,9 @@ class TestRoundTrip:
         assert fetched.papers[0].relevance_reasoning is None
         assert fetched.papers[1].relevance_score == 0.85
         assert fetched.papers[1].relevance_reasoning == "strong match"
+        # Issue #141: per-paper source round-trips through the V5 column.
+        assert fetched.papers[0].source is PaperSource.ARXIV
+        assert fetched.papers[1].source is PaperSource.OPENALEX
 
     def test_record_persists_finished_at_and_error(
         self, repo: MonitoringRunRepository

--- a/tests/unit/services/intelligence/monitoring/test_runner.py
+++ b/tests/unit/services/intelligence/monitoring/test_runner.py
@@ -746,12 +746,14 @@ class TestScorerIntegration:
             title="Paper 1",
             is_new=True,
             url="https://arxiv.org/abs/p1",
+            source=PaperSource.ARXIV,
         )
         paper2 = MonitoringPaperRecord(
             paper_id="p2",
             title="Paper 2",
             is_new=True,
             url="https://arxiv.org/abs/p2",
+            source=PaperSource.ARXIV,
         )
         run_obj = _make_run(subscription_id="sub-scorer")
         run_obj = run_obj.model_copy(update={"papers": [paper1, paper2]})
@@ -808,12 +810,14 @@ class TestScorerIntegration:
             title="Paper 1",
             is_new=True,
             url="https://arxiv.org/abs/p1",
+            source=PaperSource.ARXIV,
         )
         paper2 = MonitoringPaperRecord(
             paper_id="p2",
             title="Paper 2",
             is_new=True,
             url="https://arxiv.org/abs/p2",
+            source=PaperSource.ARXIV,
         )
         run_obj = _make_run(subscription_id="sub-scorer2")
         run_obj = run_obj.model_copy(update={"papers": [paper1, paper2]})
@@ -862,7 +866,9 @@ class TestScorerIntegration:
         from src.services.intelligence.monitoring.runner import MonitoringRunner
 
         sub = _make_subscription(subscription_id="sub-no-scorer")
-        paper = MonitoringPaperRecord(paper_id="p1", title="Paper 1", is_new=True)
+        paper = MonitoringPaperRecord(
+            paper_id="p1", title="Paper 1", is_new=True, source=PaperSource.ARXIV
+        )
         run_obj = _make_run(subscription_id="sub-no-scorer")
         run_obj = run_obj.model_copy(update={"papers": [paper]})
         result = ArxivMonitorResult(run=run_obj, new_papers=[], deduplicated_papers=[])
@@ -902,13 +908,20 @@ class TestScorerIntegration:
 
         sub = _make_subscription(subscription_id="sub-nourl")
         paper_no_url = MonitoringPaperRecord(
-            paper_id="p-nourl", title="No URL Paper", is_new=True, url=None
+            paper_id="p-nourl",
+            title="No URL Paper",
+            is_new=True,
+            url=None,
+            # Issue #141: a non-arXiv paper missing its URL is the
+            # exact case the source-aware skip log was added to surface.
+            source=PaperSource.OPENALEX,
         )
         paper_with_url = MonitoringPaperRecord(
             paper_id="p-url",
             title="Has URL Paper",
             is_new=True,
             url="https://arxiv.org/abs/p-url",
+            source=PaperSource.ARXIV,
         )
         run_obj = _make_run(subscription_id="sub-nourl")
         run_obj = run_obj.model_copy(update={"papers": [paper_no_url, paper_with_url]})
@@ -959,6 +972,9 @@ class TestScorerIntegration:
         ]
         assert len(skip_events) == 1
         assert skip_events[0]["paper_id"] == "p-nourl"
+        # Issue #141: skip log carries the actual provider so ops can
+        # query "skipped papers from openalex" without joining audits.
+        assert skip_events[0]["source"] == PaperSource.OPENALEX.value
 
 
 # ---------------------------------------------------------------------------
@@ -1061,6 +1077,7 @@ class TestLLMBudgetCap:
                 title=f"Paper {i}",
                 is_new=True,
                 url=f"https://arxiv.org/abs/p{i}",
+                source=PaperSource.ARXIV,
             )
             for i in range(3)
         ]

--- a/tests/unit/services/intelligence/monitoring/test_runner.py
+++ b/tests/unit/services/intelligence/monitoring/test_runner.py
@@ -892,19 +892,26 @@ class TestScorerIntegration:
         assert runs[0].papers[0].relevance_score is None
 
     @pytest.mark.asyncio
-    async def test_scorer_skips_paper_with_no_url(self) -> None:
+    async def test_scorer_skips_paper_with_no_url(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         """C-2: Papers with url=None are skipped before scoring rather than
         fabricating an arXiv URL for non-arXiv papers.
         The ``monitoring_relevance_score_skipped_no_url`` event is emitted.
         """
+        import structlog
         import structlog.testing
         from unittest.mock import AsyncMock as _AsyncMock, MagicMock as _MagicMock
 
+        import src.services.intelligence.monitoring.runner as runner_module
         from src.services.intelligence.monitoring.models import MonitoringPaperRecord
         from src.services.intelligence.monitoring.relevance_scorer import (
             RelevanceScoreResult,
         )
         from src.services.intelligence.monitoring.runner import MonitoringRunner
+
+        monkeypatch.setattr(runner_module, "logger", structlog.get_logger())
 
         sub = _make_subscription(subscription_id="sub-nourl")
         paper_no_url = MonitoringPaperRecord(
@@ -950,11 +957,6 @@ class TestScorerIntegration:
             run_repo=repo,
             scorer=scorer,
         )
-
-        import structlog
-        import src.services.intelligence.monitoring.runner as runner_module2
-
-        runner_module2.logger = structlog.get_logger()
 
         with structlog.testing.capture_logs() as logs:
             runs = await runner.run_once()
@@ -1181,3 +1183,206 @@ class TestMultiProviderMonitorBudgetPassthrough:
         from src.services.intelligence.monitoring.runner import MAX_LLM_CALLS_PER_CYCLE
 
         assert received_kwargs.get("max_calls") == MAX_LLM_CALLS_PER_CYCLE
+
+
+# ---------------------------------------------------------------------------
+# C-1: Additional coverage for _score_paper branches (lines 364, 417-424,
+# 432-439, 499, 501)
+# ---------------------------------------------------------------------------
+
+
+class TestScorePaperBranches:
+    """Cover the remaining _score_paper / _run_one branches.
+
+    Uses monkeypatch.setattr(runner_module, "logger", ...) before
+    capture_logs() so the structlog processor swap reaches the module-
+    level cached logger (CLAUDE.md canonical pattern).
+    """
+
+    @pytest.mark.asyncio
+    async def test_score_paper_returns_early_when_scorer_is_none(self) -> None:
+        """Line 364: _score_paper early-returns when self._scorer is None.
+
+        Although _run_one gates on scorer is not None before spawning
+        scoring tasks, the defensive early-return in _score_paper itself
+        is valid code that must be reachable for coverage. Call
+        _score_paper directly on a runner with no scorer.
+        """
+        import asyncio
+        from unittest.mock import MagicMock as _MagicMock
+
+        from src.services.intelligence.monitoring.models import MonitoringPaperRecord
+        from src.services.intelligence.monitoring.runner import MonitoringRunner
+
+        runner = MonitoringRunner(
+            subscription_manager=_MagicMock(),
+            monitor=_MagicMock(),
+            run_repo=_MagicMock(),
+            scorer=None,  # no scorer
+        )
+        sub = _make_subscription(subscription_id="sub-early-return")
+        paper = MonitoringPaperRecord(
+            paper_id="p-er",
+            title="Paper",
+            is_new=True,
+            url="https://arxiv.org/abs/p1",
+            source=PaperSource.ARXIV,
+        )
+        sem = asyncio.Semaphore(10)
+        llm_calls_used: list[int] = [0]
+        # Must not raise; must return without touching scorer.
+        await runner._score_paper(sub, paper, sem, llm_calls_used)
+        assert paper.relevance_score is None
+        assert llm_calls_used[0] == 0
+
+    @pytest.mark.asyncio
+    async def test_score_paper_logs_unexpected_exception(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Lines 417-424: unexpected Exception in scorer is caught, logged,
+        and does not propagate — the paper is left unscored.
+        """
+        import asyncio
+        import structlog
+        import structlog.testing
+        from unittest.mock import AsyncMock as _AsyncMock, MagicMock as _MagicMock
+
+        import src.services.intelligence.monitoring.runner as runner_module
+        from src.services.intelligence.monitoring.models import MonitoringPaperRecord
+        from src.services.intelligence.monitoring.runner import MonitoringRunner
+
+        monkeypatch.setattr(runner_module, "logger", structlog.get_logger())
+
+        scorer = _MagicMock()
+        scorer.score = _AsyncMock(side_effect=RuntimeError("GPU exploded"))
+
+        runner = MonitoringRunner(
+            subscription_manager=_MagicMock(),
+            monitor=_MagicMock(),
+            run_repo=_MagicMock(),
+            scorer=scorer,
+        )
+        sub = _make_subscription(subscription_id="sub-unexpected")
+        paper = MonitoringPaperRecord(
+            paper_id="p-unexpected",
+            title="Unexpected Paper",
+            is_new=True,
+            url="https://arxiv.org/abs/p-unexpected",
+            source=PaperSource.ARXIV,
+        )
+        sem = asyncio.Semaphore(10)
+        llm_calls_used: list[int] = [0]
+
+        with structlog.testing.capture_logs() as logs:
+            await runner._score_paper(sub, paper, sem, llm_calls_used)
+
+        # Paper must be left unscored.
+        assert paper.relevance_score is None
+        # The unexpected-error event must be logged.
+        error_events = [
+            e
+            for e in logs
+            if e.get("event") == "monitoring_relevance_score_unexpected_error"
+        ]
+        assert len(error_events) == 1
+        assert error_events[0].get("paper_id") == "p-unexpected"
+        assert "GPU exploded" in error_events[0].get("error", "")
+
+    @pytest.mark.asyncio
+    async def test_score_paper_rejects_high_score_with_thin_reasoning(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Lines 432-439: high score (>=0.95) with reasoning < 30 chars is
+        rejected as a sanity-guard against prompt-injection. Paper is left
+        unscored and monitoring_relevance_score_sanity_rejected is logged.
+        """
+        import asyncio
+        import structlog
+        import structlog.testing
+        from unittest.mock import AsyncMock as _AsyncMock, MagicMock as _MagicMock
+
+        import src.services.intelligence.monitoring.runner as runner_module
+        from src.services.intelligence.monitoring.models import MonitoringPaperRecord
+        from src.services.intelligence.monitoring.relevance_scorer import (
+            RelevanceScoreResult,
+        )
+        from src.services.intelligence.monitoring.runner import MonitoringRunner
+
+        monkeypatch.setattr(runner_module, "logger", structlog.get_logger())
+
+        # Score at exactly the threshold with very short reasoning.
+        thin_result = RelevanceScoreResult(
+            score=0.95,
+            reasoning="short",  # len("short") == 5 < 30
+            model_used="gemini-1.5-flash",
+            cost_usd=0.0,
+        )
+        scorer = _MagicMock()
+        scorer.score = _AsyncMock(return_value=thin_result)
+
+        runner = MonitoringRunner(
+            subscription_manager=_MagicMock(),
+            monitor=_MagicMock(),
+            run_repo=_MagicMock(),
+            scorer=scorer,
+        )
+        sub = _make_subscription(subscription_id="sub-sanity")
+        paper = MonitoringPaperRecord(
+            paper_id="p-sanity",
+            title="Sanity Paper",
+            is_new=True,
+            url="https://arxiv.org/abs/p-sanity",
+            source=PaperSource.ARXIV,
+        )
+        sem = asyncio.Semaphore(10)
+        llm_calls_used: list[int] = [0]
+
+        with structlog.testing.capture_logs() as logs:
+            await runner._score_paper(sub, paper, sem, llm_calls_used)
+
+        # Paper must remain unscored after sanity rejection.
+        assert paper.relevance_score is None
+        sanity_events = [
+            e
+            for e in logs
+            if e.get("event") == "monitoring_relevance_score_sanity_rejected"
+        ]
+        assert len(sanity_events) == 1
+        assert sanity_events[0].get("paper_id") == "p-sanity"
+        assert sanity_events[0].get("score") == pytest.approx(0.95)
+
+    @pytest.mark.asyncio
+    async def test_run_one_creates_fallback_sem_and_counter_when_called_directly(
+        self,
+    ) -> None:
+        """Lines 499/501: _run_one creates its own Semaphore and llm_calls_used
+        list when called without sem/llm_calls_used (e.g., from tests that
+        bypass the run_once cycle context).
+        """
+        from unittest.mock import AsyncMock as _AsyncMock, MagicMock as _MagicMock
+
+        from src.services.intelligence.monitoring.runner import MonitoringRunner
+
+        sub = _make_subscription(subscription_id="sub-fallback")
+        run_obj = _make_run(subscription_id="sub-fallback")
+        result = ArxivMonitorResult(run=run_obj, new_papers=[], deduplicated_papers=[])
+
+        monitor = _MagicMock()
+        monitor.check = _AsyncMock(return_value=result)
+        repo = _MagicMock()
+        repo.record_run = _MagicMock()
+        sub_mgr = _MagicMock()
+        sub_mgr.mark_checked = _MagicMock()
+
+        runner = MonitoringRunner(
+            subscription_manager=sub_mgr,
+            monitor=monitor,
+            run_repo=repo,
+        )
+        # Call _run_one directly WITHOUT sem or llm_calls_used to exercise
+        # the fallback creation at lines 499/501.
+        returned_run = await runner._run_one(sub)
+        assert returned_run.subscription_id == "sub-fallback"
+        repo.record_run.assert_called_once()

--- a/tests/unit/storage/intelligence_graph/test_migrations.py
+++ b/tests/unit/storage/intelligence_graph/test_migrations.py
@@ -19,10 +19,12 @@ from src.storage.intelligence_graph.migrations import (
     MigrationManager,
     Migration,
     ALL_MIGRATIONS,
+    LATEST_MIGRATION_VERSION,
     MIGRATION_V1_INITIAL,
     MIGRATION_V2_MONITORING_RUNS,
     MIGRATION_V3_MONITORING_RUNS_FK,
     MIGRATION_V4_CITATION_INFLUENCE_METRICS,
+    MIGRATION_V5_PAPER_SOURCE_TRACKING,
 )
 from src.utils.security import SecurityError
 
@@ -1279,3 +1281,193 @@ class TestMigrationV4CitationInfluenceMetrics:
             assert run_row["status"] == "success"
             assert run_row["papers_found"] == 5
             assert run_row["papers_new"] == 2
+
+
+class TestMigrationV5PaperSourceTracking:
+    """Tests for ``MIGRATION_V5_PAPER_SOURCE_TRACKING`` (Issue #141).
+
+    Pinned scenarios (every test name follows
+    ``test_migrate_v5_<scenario>`` per the naming convention from V3):
+
+    - V5 adds a ``source`` column to ``monitoring_papers``.
+    - The new column is ``NOT NULL DEFAULT 'arxiv'``.
+    - Pre-V5 rows survive the migration with ``source='arxiv'`` so the
+      audit log treats legacy papers as arXiv (the only provider before
+      Tier 1).
+    - The migration is recorded in ``schema_migrations``.
+    - ``LATEST_MIGRATION_VERSION`` is bumped to 5.
+    - All other tables and rows survive untouched (V5 isolation).
+    """
+
+    def test_migrate_v5_adds_source_column(self, temp_db: Path) -> None:
+        """The ``monitoring_papers`` table must gain a ``source`` column."""
+        manager = MigrationManager(temp_db)
+        manager.migrate()
+        with open_connection(temp_db) as conn:
+            cursor = conn.execute("PRAGMA table_info(monitoring_papers)")
+            cols = {row["name"]: row for row in cursor.fetchall()}
+        assert "source" in cols, "V5 did not add the source column"
+        assert cols["source"]["notnull"] == 1, "source column must be NOT NULL"
+        # Default value reads back as the string literal 'arxiv'.
+        # SQLite stringifies the DEFAULT clause; PRAGMA returns it
+        # verbatim including the surrounding quotes.
+        assert "arxiv" in cols["source"]["dflt_value"]
+
+    def test_migrate_v5_backfills_existing_rows_to_arxiv(self, temp_db: Path) -> None:
+        """Pre-V5 monitoring_papers rows must end up with source='arxiv'.
+
+        Apply only V1-V4, insert a paper row under the V4 schema (no
+        source column), then apply V5. The backfilled column must be
+        'arxiv' for the legacy row -- this is the bounded "lie" the
+        V5 docstring documents.
+        """
+        manager = MigrationManager(temp_db)
+        # Apply only V1-V4 -- stop short of V5 so we can write a row
+        # under the legacy schema and verify the backfill.
+        conn = manager._get_connection()
+        try:
+            manager._ensure_migrations_table(conn)
+            manager.apply_migration(conn, MIGRATION_V1_INITIAL)
+            manager.apply_migration(conn, MIGRATION_V2_MONITORING_RUNS)
+            manager.apply_migration(conn, MIGRATION_V3_MONITORING_RUNS_FK)
+            manager.apply_migration(conn, MIGRATION_V4_CITATION_INFLUENCE_METRICS)
+        finally:
+            conn.close()
+
+        # Insert a parent run + a paper under the pre-V5 schema (no
+        # ``source`` column in the column list).
+        with open_connection(temp_db) as conn:
+            conn.execute(
+                """
+                INSERT INTO subscriptions (
+                    subscription_id, user_id, name, config
+                ) VALUES (?, ?, ?, ?)
+                """,
+                ("sub-v4-legacy", "alice", "Legacy", "{}"),
+            )
+            conn.execute(
+                """
+                INSERT INTO monitoring_runs (
+                    run_id, subscription_id, user_id,
+                    started_at, status
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    "run-v4-legacy",
+                    "sub-v4-legacy",
+                    "alice",
+                    "2024-06-01T00:00:00+00:00",
+                    "success",
+                ),
+            )
+            conn.execute(
+                """
+                INSERT INTO monitoring_papers (
+                    run_id, paper_id, registered,
+                    relevance_score, relevance_reasoning
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    "run-v4-legacy",
+                    "paper:legacy:001",
+                    1,
+                    0.8,
+                    "legacy reasoning",
+                ),
+            )
+            conn.commit()
+
+        # Now apply V5 in isolation -- must add the column AND backfill
+        # the legacy row to 'arxiv'.
+        conn = manager._get_connection()
+        try:
+            manager._ensure_migrations_table(conn)
+            manager.apply_migration(conn, MIGRATION_V5_PAPER_SOURCE_TRACKING)
+        finally:
+            conn.close()
+
+        with open_connection(temp_db) as conn:
+            row = conn.execute(
+                "SELECT source FROM monitoring_papers WHERE paper_id = ?",
+                ("paper:legacy:001",),
+            ).fetchone()
+        assert row is not None, "legacy row was destroyed by V5"
+        # Backfill must produce 'arxiv'.
+        assert row["source"] == "arxiv"
+
+    def test_migrate_v5_records_version(self, temp_db: Path) -> None:
+        """V5 must appear in ``schema_migrations`` after a full migrate()."""
+        manager = MigrationManager(temp_db)
+        manager.migrate()
+        applied_versions = {m["version"] for m in manager.get_applied_migrations()}
+        assert 5 in applied_versions
+
+    def test_migrate_v5_round_trips_each_paper_source(self, temp_db: Path) -> None:
+        """Pin that every PaperSource value can be stored + read back.
+
+        Defense against a future schema-level CHECK that forgets a
+        member of the enum (the same drift class V3 guards against
+        for ``MonitoringRunStatus``). This test stores one row per
+        enum value and asserts the column accepts it without raising.
+        """
+        from src.services.intelligence.models.monitoring import PaperSource
+
+        manager = MigrationManager(temp_db)
+        manager.migrate()
+        with open_connection(temp_db) as conn:
+            conn.execute(
+                """
+                INSERT INTO subscriptions (
+                    subscription_id, user_id, name, config
+                ) VALUES (?, ?, ?, ?)
+                """,
+                ("sub-v5-enum", "alice", "Enum", "{}"),
+            )
+            conn.execute(
+                """
+                INSERT INTO monitoring_runs (
+                    run_id, subscription_id, user_id, started_at, status
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    "run-v5-enum",
+                    "sub-v5-enum",
+                    "alice",
+                    "2024-06-01T00:00:00+00:00",
+                    "success",
+                ),
+            )
+            for src in PaperSource:
+                conn.execute(
+                    """
+                    INSERT INTO monitoring_papers (
+                        run_id, paper_id, source
+                    ) VALUES (?, ?, ?)
+                    """,
+                    ("run-v5-enum", f"paper:{src.value}:001", src.value),
+                )
+            conn.commit()
+
+            stored = {
+                row["source"]
+                for row in conn.execute(
+                    "SELECT source FROM monitoring_papers WHERE run_id = ?",
+                    ("run-v5-enum",),
+                ).fetchall()
+            }
+        assert stored == {src.value for src in PaperSource}
+
+
+class TestLatestMigrationVersion:
+    """``LATEST_MIGRATION_VERSION`` mirrors the highest entry in
+    ``ALL_MIGRATIONS`` so callers (or future cross-references) have
+    a single line to bump when a new migration is added.
+    """
+
+    def test_latest_version_constant_matches_all_migrations(self) -> None:
+        assert LATEST_MIGRATION_VERSION == max(m.version for m in ALL_MIGRATIONS)
+
+    def test_latest_version_is_5(self) -> None:
+        # Pinned literal so an accidental version bump shows up in
+        # review even if ``ALL_MIGRATIONS`` is also extended.
+        assert LATEST_MIGRATION_VERSION == 5

--- a/tests/unit/storage/intelligence_graph/test_migrations.py
+++ b/tests/unit/storage/intelligence_graph/test_migrations.py
@@ -211,7 +211,7 @@ class TestMigrationManager:
         conn.execute("PRAGMA foreign_keys = ON")
         try:
             # Try to insert edge without valid nodes - should fail
-            with pytest.raises(sqlite3.IntegrityError):
+            with pytest.raises(sqlite3.IntegrityError, match="FOREIGN KEY"):
                 conn.execute("""
                     INSERT INTO edges (edge_id, edge_type, source_id, target_id)
                     VALUES ('edge:1', 'cites', 'invalid:source', 'invalid:target')
@@ -556,7 +556,7 @@ class TestMigrationAdditionalEdgeCases:
         conn = manager._get_connection()
         try:
             manager._ensure_migrations_table(conn)
-            with pytest.raises(sqlite3.OperationalError):
+            with pytest.raises(sqlite3.OperationalError, match="syntax error"):
                 manager.apply_migration(conn, bad_migration)
         finally:
             conn.close()
@@ -630,7 +630,7 @@ class TestMigrationTransactionRollback:
 
         conn = manager._get_connection()
         try:
-            with pytest.raises(sqlite3.OperationalError):
+            with pytest.raises(sqlite3.OperationalError, match="no such table"):
                 manager.apply_migration(conn, bad_migration)
         finally:
             conn.close()
@@ -681,7 +681,7 @@ class TestMigrationTransactionRollback:
 
         conn = manager._get_connection()
         try:
-            with pytest.raises(sqlite3.OperationalError):
+            with pytest.raises(sqlite3.OperationalError, match="no such table"):
                 manager.apply_migration(conn, ddl_then_failure)
         finally:
             conn.close()
@@ -797,7 +797,7 @@ class TestMigrationV3MonitoringRunsFk:
             )
             conn.commit()
 
-            with pytest.raises(sqlite3.IntegrityError):
+            with pytest.raises(sqlite3.IntegrityError, match="CHECK"):
                 conn.execute(
                     """
                     INSERT INTO monitoring_runs (
@@ -837,7 +837,7 @@ class TestMigrationV3MonitoringRunsFk:
                 ("sub-empty", "alice", "Sub", "{}"),
             )
             conn.commit()
-            with pytest.raises(sqlite3.IntegrityError):
+            with pytest.raises(sqlite3.IntegrityError, match="CHECK"):
                 conn.execute(
                     """
                     INSERT INTO monitoring_runs (
@@ -877,7 +877,7 @@ class TestMigrationV3MonitoringRunsFk:
                 ("sub-null", "alice", "Sub", "{}"),
             )
             conn.commit()
-            with pytest.raises(sqlite3.IntegrityError):
+            with pytest.raises(sqlite3.IntegrityError, match="NOT NULL"):
                 conn.execute(
                     """
                     INSERT INTO monitoring_runs (
@@ -917,7 +917,7 @@ class TestMigrationV3MonitoringRunsFk:
                 ("sub-omit", "alice", "Sub", "{}"),
             )
             conn.commit()
-            with pytest.raises(sqlite3.IntegrityError):
+            with pytest.raises(sqlite3.IntegrityError, match="NOT NULL"):
                 # Note: status column is omitted from the column list.
                 conn.execute(
                     """
@@ -1391,9 +1391,24 @@ class TestMigrationV5PaperSourceTracking:
                 "SELECT source FROM monitoring_papers WHERE paper_id = ?",
                 ("paper:legacy:001",),
             ).fetchone()
-        assert row is not None, "legacy row was destroyed by V5"
-        # Backfill must produce 'arxiv'.
-        assert row["source"] == "arxiv"
+            assert row is not None, "legacy row was destroyed by V5"
+            # Backfill must produce 'arxiv'.
+            assert row["source"] == "arxiv"
+
+            # H-5: subscriptions and monitoring_runs rows must also survive V5.
+            sub_row = conn.execute(
+                "SELECT subscription_id FROM subscriptions "
+                "WHERE subscription_id = ?",
+                ("sub-v4-legacy",),
+            ).fetchone()
+            assert sub_row is not None, "subscription row was destroyed by V5"
+
+            run_row = conn.execute(
+                "SELECT run_id, status FROM monitoring_runs WHERE run_id = ?",
+                ("run-v4-legacy",),
+            ).fetchone()
+            assert run_row is not None, "monitoring_run row was destroyed by V5"
+            assert run_row["status"] == "success"
 
     def test_migrate_v5_records_version(self, temp_db: Path) -> None:
         """V5 must appear in ``schema_migrations`` after a full migrate()."""
@@ -1456,6 +1471,190 @@ class TestMigrationV5PaperSourceTracking:
                 ).fetchall()
             }
         assert stored == {src.value for src in PaperSource}
+
+    def test_migrate_v5_rejects_unknown_source_via_check(self, temp_db: Path) -> None:
+        """H-3: V5 CHECK constraint must reject unknown source strings.
+
+        Any value not in PaperSource must cause an IntegrityError at
+        insert time, not silently corrupt the audit trail.
+        """
+        manager = MigrationManager(temp_db)
+        manager.migrate()
+        with open_connection(temp_db) as conn:
+            conn.execute(
+                """
+                INSERT INTO subscriptions (
+                    subscription_id, user_id, name, config
+                ) VALUES (?, ?, ?, ?)
+                """,
+                ("sub-v5-check", "alice", "Check", "{}"),
+            )
+            conn.execute(
+                """
+                INSERT INTO monitoring_runs (
+                    run_id, subscription_id, user_id, started_at, status
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    "run-v5-check",
+                    "sub-v5-check",
+                    "alice",
+                    "2024-06-01T00:00:00+00:00",
+                    "success",
+                ),
+            )
+            conn.commit()
+            with pytest.raises(sqlite3.IntegrityError, match="CHECK"):
+                conn.execute(
+                    """
+                    INSERT INTO monitoring_papers (
+                        run_id, paper_id, source
+                    ) VALUES (?, ?, ?)
+                    """,
+                    ("run-v5-check", "paper:bogus:001", "BOGUS_SOURCE"),
+                )
+
+    def test_migrate_v5_check_constraint_matches_paper_source_enum(self) -> None:
+        """H-3: Enum-vs-CHECK exhaustive drift guard.
+
+        If PaperSource gains a new member, the V5 CHECK constraint must
+        also widen — otherwise ``record_run`` would produce an
+        IntegrityError on the new value at runtime. This test catches
+        the drift at import-time so the missing migration (V6 widening
+        the CHECK) is obvious before any live insert fails. Pure
+        SQL-string scan, no DB needed.
+
+        Mirrors ``test_migrate_v3_check_constraint_matches_monitoring_run_status_enum``.
+        """
+        from src.services.intelligence.models.monitoring import PaperSource
+
+        sql = MIGRATION_V5_PAPER_SOURCE_TRACKING.up
+        assert isinstance(sql, str)
+        for member in PaperSource:
+            assert f"'{member.value}'" in sql, (
+                f"PaperSource.{member.name} = {member.value!r} "
+                "is not present in MIGRATION_V5 CHECK constraint. "
+                "Add MIGRATION_V6 widening the CHECK list."
+            )
+
+    def test_migrate_v5_preserves_data_inserted_under_v4_schema(
+        self, temp_db: Path
+    ) -> None:
+        """H-1: V5 isolation upgrade test.
+
+        Apply V1+V2+V3+V4 only, insert known rows into ``nodes``,
+        ``monitoring_runs``, ``monitoring_papers``, and
+        ``subscriptions``, then apply V5 in isolation. V5 must (a)
+        add the ``source`` column to ``monitoring_papers`` and (b) not
+        disturb any pre-existing rows in any table. Mirrors the V4
+        regression guard at
+        ``test_migrate_v4_preserves_data_inserted_under_v3_schema``.
+        """
+        manager = MigrationManager(temp_db)
+        # Apply only V1-V4 -- stop short of V5.
+        conn = manager._get_connection()
+        try:
+            manager._ensure_migrations_table(conn)
+            manager.apply_migration(conn, MIGRATION_V1_INITIAL)
+            manager.apply_migration(conn, MIGRATION_V2_MONITORING_RUNS)
+            manager.apply_migration(conn, MIGRATION_V3_MONITORING_RUNS_FK)
+            manager.apply_migration(conn, MIGRATION_V4_CITATION_INFLUENCE_METRICS)
+        finally:
+            conn.close()
+
+        # Insert rows into all four tables under the V4 schema.
+        with open_connection(temp_db) as conn:
+            conn.execute(
+                """
+                INSERT INTO nodes (
+                    node_id, node_type, properties, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    "paper:s2:v4node",
+                    "paper",
+                    "{}",
+                    "2024-07-01T00:00:00+00:00",
+                    "2024-07-01T00:00:00+00:00",
+                ),
+            )
+            conn.execute(
+                """
+                INSERT INTO subscriptions (
+                    subscription_id, user_id, name, config
+                ) VALUES (?, ?, ?, ?)
+                """,
+                ("sub-v4-iso", "alice", "V4 Iso Sub", "{}"),
+            )
+            conn.execute(
+                """
+                INSERT INTO monitoring_runs (
+                    run_id, subscription_id, user_id,
+                    started_at, status
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    "run-v4-iso",
+                    "sub-v4-iso",
+                    "alice",
+                    "2024-07-01T00:00:00+00:00",
+                    "success",
+                ),
+            )
+            conn.execute(
+                """
+                INSERT INTO monitoring_papers (
+                    run_id, paper_id, registered,
+                    relevance_score, relevance_reasoning
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                ("run-v4-iso", "paper:v4:iso001", 1, 0.75, "V4 reasoning"),
+            )
+            conn.commit()
+
+        # Now apply V5 in isolation -- must (a) add the source column
+        # and (b) not destroy anything that was already there.
+        conn = manager._get_connection()
+        try:
+            manager._ensure_migrations_table(conn)
+            manager.apply_migration(conn, MIGRATION_V5_PAPER_SOURCE_TRACKING)
+        finally:
+            conn.close()
+
+        with open_connection(temp_db) as conn:
+            # (a) source column now present on monitoring_papers
+            cursor = conn.execute("PRAGMA table_info(monitoring_papers)")
+            cols = {row["name"] for row in cursor.fetchall()}
+            assert "source" in cols
+
+            # (b) All V4 rows survive intact
+            node_row = conn.execute(
+                "SELECT node_id, node_type FROM nodes WHERE node_id = ?",
+                ("paper:s2:v4node",),
+            ).fetchone()
+            assert node_row is not None
+            assert node_row["node_type"] == "paper"
+
+            sub_row = conn.execute(
+                "SELECT subscription_id FROM subscriptions WHERE subscription_id = ?",
+                ("sub-v4-iso",),
+            ).fetchone()
+            assert sub_row is not None
+
+            run_row = conn.execute(
+                "SELECT run_id, status FROM monitoring_runs WHERE run_id = ?",
+                ("run-v4-iso",),
+            ).fetchone()
+            assert run_row is not None
+            assert run_row["status"] == "success"
+
+            paper_row = conn.execute(
+                "SELECT paper_id, source FROM monitoring_papers WHERE paper_id = ?",
+                ("paper:v4:iso001",),
+            ).fetchone()
+            assert paper_row is not None
+            # V5 backfill must have set source to 'arxiv'.
+            assert paper_row["source"] == "arxiv"
 
 
 class TestLatestMigrationVersion:


### PR DESCRIPTION
## Summary

Resolves the \"`MonitoringRun.source` hardcoded to `ARXIV`\" lie in PR #140's audit log. Each `MonitoringPaperRecord` now carries the actual discovery provider, persisted via a new V5 SQLite migration.

- **V5 migration:** adds `monitoring_papers.source TEXT NOT NULL DEFAULT 'arxiv'`, with deterministic backfill of legacy rows. Introduces `LATEST_MIGRATION_VERSION = 5` so future cross-checks update in one place.
- **Models:** `MonitoringPaperRecord.source` is **required** (no default — a silent fallback would re-create the bug we're fixing). `MonitoringPaperAudit.source` defaults to `ARXIV` to round-trip cleanly with backfilled legacy rows.
- **Multi-provider monitor:** the `(paper, source)` tuple flows through fan-out → dedup → resolve_and_register; each `MonitoringPaperRecord` is stamped with the actual provider it came from. First-seen-wins on cross-provider duplicates. Removed the resolved `TODO(issue #141)` block; cycle-level `MonitoringRun.source` stays `ARXIV` for V1-V4 schema compat (semantics widened in code: it now means \"primary source\").
- **ArxivMonitor:** every record stamped with `source=ARXIV` by construction.
- **Run repository:** INSERT writes the V5 column; SELECT round-trips it into `MonitoringPaperAudit.source`.
- **Digest generator:** Top Papers entries now render `Source: \`<provider>\`` so a digest reader sees provenance without DB lookups.
- **Runner:** `monitoring_relevance_score_skipped_no_url` log event now includes `source=paper.source.value` so ops can pivot \"why was this paper skipped?\" by provider.

## Tests

- **5109 tests pass** (12 new tests added across V5 migration, model required-field/enum guards, multi-provider per-paper attribution, dedup precedence, digest source rendering)
- **Project coverage: 99.13%** (over the 99% gate)
- `./verify.sh` clean (Black / Flake8 / Mypy / pytest)

## Test plan

- [x] V5 migration: column added, backfill, version recording, enum round-trip, isolation upgrade
- [x] Models: `source` required on `MonitoringPaperRecord`; default-to-ARXIV on `MonitoringPaperAudit`; per-enum acceptance on both
- [x] `MultiProviderMonitor.check`: each paper stamped with its provider; multi-provider attribution; first-seen-wins on dedup; deduplicated path also carries source
- [x] `MonitoringRunRepository`: source round-trips in `record_run` → `get_run`
- [x] `DigestGenerator`: source line present per paper, omitted when no papers
- [x] `MonitoringRunner._score_paper`: skip log carries the actual source

## Compatibility

- Cycle-level `MonitoringRun.source` kept as a single `PaperSource` (not widened to a list) — preserves V1-V4 schema without breaking any reader. Per-paper provenance lives on `MonitoringPaperRecord.source` which is now the source of truth.
- Pre-V5 audit rows backfill cleanly to `'arxiv'` (correct for pre-Tier-1; the only gap is the small handful of cycles between PR #140 merge and this migration where non-arXiv papers may be silently attributed to arXiv — bounded and documented in the V5 docstring).

Closes #141.

🤖 Generated with [Claude Code](https://claude.com/claude-code)