### PR TITLE
feat(phase-9.2): citation-based recommender (closes #130)

### DIFF
--- a/src/services/intelligence/citation/__init__.py
+++ b/src/services/intelligence/citation/__init__.py
@@ -1,10 +1,10 @@
-"""Milestone 9.2: Citation Graph Intelligence (Week 1 + 1.5 surface).
+"""Milestone 9.2: Citation Graph Intelligence (Week 1 + 1.5 + 2.5 surface).
 
 This package builds and persists citation graphs from external APIs
 (Semantic Scholar primary, OpenAlex fallback) using the Phase 9
 ``GraphStore`` for storage. Week 1 + 1.5 deliver depth=1 graph
 construction; BFS crawler, coupling analyzer, influence scorer, and
-recommender are deferred to follow-up PRs (Weeks 2-3).
+recommender complete the full citation intelligence stack.
 
 Public surface:
 
@@ -17,6 +17,12 @@ Public surface:
 - :class:`CitationGraphBuilder` / :class:`GraphBuildResult` — composes
   the two clients and persists via ``GraphStore.add_nodes_batch`` /
   ``add_edges_batch`` (depth=1 only; BFS crawl is Week 2).
+- :class:`CitationRecommender` — four citation-based recommendation
+  strategies (similar, influential predecessors, active successors,
+  bridge papers). Use :meth:`CitationRecommender.connect` for
+  production wiring; inject collaborators for testing.
+- :class:`Recommendation` / :class:`RecommendationStrategy` — result
+  models produced by :class:`CitationRecommender`.
 
 Architecture choice (recorded for downstream milestones):
 We deliberately built **dedicated citation clients alongside** the
@@ -62,6 +68,13 @@ from src.services.intelligence.citation.models import (
 from src.services.intelligence.citation.openalex_client import (
     OpenAlexCitationClient,
 )
+from src.services.intelligence.citation.recommender import (
+    CitationRecommender,
+)
+from src.services.intelligence.citation.models import (
+    Recommendation,
+    RecommendationStrategy,
+)
 from src.services.intelligence.citation.semantic_scholar_client import (
     SemanticScholarCitationClient,
 )
@@ -96,4 +109,8 @@ __all__ = [
     "DEFAULT_CACHE_TTL",
     "MAX_GRAPH_NODES_FOR_HITS",
     "MAX_GRAPH_NODES_FOR_PAGERANK",
+    # Recommender (Issue #130)
+    "CitationRecommender",
+    "Recommendation",
+    "RecommendationStrategy",
 ]

--- a/src/services/intelligence/citation/coupling_protocol.py
+++ b/src/services/intelligence/citation/coupling_protocol.py
@@ -1,0 +1,152 @@
+"""Coupling protocol shim for parallel development with issue #128.
+
+# TO BE REPLACED by #128's models — interface-locked for parallel development.
+
+Issue #128 (CouplingAnalyzer — Bibliographic Coupling) is being developed
+concurrently. This module defines a minimal ``CouplingAnalyzerProtocol``
+and a stub ``CouplingResult`` model so the recommender (issue #130) can
+code against a well-typed interface without waiting for #128 to land.
+
+When #128 lands and this branch rebases onto main, the real
+``CouplingAnalyzer`` will already satisfy the Protocol implicitly (duck
+typing). No production code change will be needed in the recommender.
+
+Interface-lock contract:
+- ``CouplingResult.paper_a_id`` / ``paper_b_id`` — canonical node-id format
+- ``CouplingResult.coupling_strength`` — float in [0.0, 1.0]
+- ``CouplingResult.shared_reference_count`` — non-negative int
+- ``CouplingAnalyzerProtocol.analyze_pair(a_id, b_id) -> CouplingResult``
+- ``CouplingAnalyzerProtocol.analyze_for_paper(seed_id, candidates, top_k)
+  -> list[CouplingResult]``
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from src.services.intelligence.citation._id_validation import (
+    CANONICAL_NODE_ID_PATTERN,
+    PAPER_ID_MAX_LENGTH,
+)
+
+
+def _validate_paper_id_str(v: str, field_name: str) -> str:
+    """Validate a paper id string against the canonical node-id pattern."""
+    if not isinstance(v, str) or not v.strip():
+        raise ValueError(f"{field_name} must be a non-empty string")
+    if len(v) > PAPER_ID_MAX_LENGTH:
+        raise ValueError(
+            f"{field_name} length {len(v)} exceeds max {PAPER_ID_MAX_LENGTH}"
+        )
+    if not CANONICAL_NODE_ID_PATTERN.match(v):
+        raise ValueError(
+            f"Invalid {field_name} format: {v!r}. "
+            "Allowed: alphanumeric, colons, periods, hyphens, underscores."
+        )
+    return v
+
+
+class CouplingResult(BaseModel):
+    """Result of a bibliographic coupling computation between two papers.
+
+    # TO BE REPLACED by #128's models — interface-locked for parallel development.
+
+    Mirrors the spec contract from issue #128 so the recommender can
+    consume coupling results without importing the (not-yet-landed)
+    ``CouplingAnalyzer``.
+
+    Validators:
+    - ``paper_a_id`` and ``paper_b_id`` must match the canonical node-id
+      pattern (alphanumeric, colons, periods, hyphens, underscores).
+    - ``coupling_strength`` is clamped to [0.0, 1.0].
+    """
+
+    model_config = ConfigDict(extra="forbid", strict=False)
+
+    paper_a_id: str = Field(
+        ...,
+        min_length=1,
+        max_length=PAPER_ID_MAX_LENGTH,
+        description="Canonical node id of the first paper.",
+    )
+    paper_b_id: str = Field(
+        ...,
+        min_length=1,
+        max_length=PAPER_ID_MAX_LENGTH,
+        description="Canonical node id of the second paper.",
+    )
+    coupling_strength: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="Bibliographic coupling strength in [0.0, 1.0].",
+    )
+    shared_reference_count: int = Field(
+        default=0,
+        ge=0,
+        description="Number of references shared by both papers.",
+    )
+    jaccard_index: float = Field(
+        default=0.0,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Jaccard index of reference sets: |A ∩ B| / |A ∪ B|. "
+            "Zero when either paper has no references."
+        ),
+    )
+
+    def model_post_init(self, __context: object) -> None:
+        """Validate paper ids after field construction."""
+        _validate_paper_id_str(self.paper_a_id, "paper_a_id")
+        _validate_paper_id_str(self.paper_b_id, "paper_b_id")
+
+
+@runtime_checkable
+class CouplingAnalyzerProtocol(Protocol):
+    """Protocol for bibliographic coupling analysis.
+
+    # TO BE REPLACED by #128's models — interface-locked for parallel development.
+
+    The recommender depends on this protocol, not on the concrete
+    ``CouplingAnalyzer`` class from issue #128. When #128 lands, the real
+    ``CouplingAnalyzer`` will satisfy this protocol implicitly. Tests inject
+    mock objects implementing this protocol.
+
+    Methods:
+        analyze_pair: Compute coupling between two papers.
+        analyze_for_paper: Find the top-k most coupled papers for a seed.
+    """
+
+    async def analyze_pair(self, paper_a_id: str, paper_b_id: str) -> "CouplingResult":
+        """Compute bibliographic coupling between two papers.
+
+        Args:
+            paper_a_id: Canonical node id of the first paper.
+            paper_b_id: Canonical node id of the second paper.
+
+        Returns:
+            A ``CouplingResult`` with the coupling metrics.
+        """
+        raise NotImplementedError  # pragma: abstract
+
+    async def analyze_for_paper(
+        self,
+        seed_id: str,
+        candidates: list[str],
+        top_k: int = 10,
+    ) -> list["CouplingResult"]:
+        """Find the top-k most coupled papers for a seed.
+
+        Args:
+            seed_id: Canonical node id of the seed paper.
+            candidates: Node ids of candidate papers to rank.
+            top_k: Maximum number of results to return.
+
+        Returns:
+            Coupling results sorted by ``coupling_strength`` descending,
+            at most ``top_k`` entries.
+        """
+        raise NotImplementedError  # pragma: abstract

--- a/src/services/intelligence/citation/coupling_protocol.py
+++ b/src/services/intelligence/citation/coupling_protocol.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 from typing import Protocol, runtime_checkable
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from src.services.intelligence.citation._id_validation import (
     CANONICAL_NODE_ID_PATTERN,
@@ -60,10 +60,12 @@ class CouplingResult(BaseModel):
     Validators:
     - ``paper_a_id`` and ``paper_b_id`` must match the canonical node-id
       pattern (alphanumeric, colons, periods, hyphens, underscores).
+    - ``paper_a_id`` must differ from ``paper_b_id`` (self-coupling is
+      semantically invalid).
     - ``coupling_strength`` is clamped to [0.0, 1.0].
     """
 
-    model_config = ConfigDict(extra="forbid", strict=False)
+    model_config = ConfigDict(extra="forbid", strict=True)
 
     paper_a_id: str = Field(
         ...,
@@ -98,10 +100,22 @@ class CouplingResult(BaseModel):
         ),
     )
 
-    def model_post_init(self, __context: object) -> None:
-        """Validate paper ids after field construction."""
-        _validate_paper_id_str(self.paper_a_id, "paper_a_id")
-        _validate_paper_id_str(self.paper_b_id, "paper_b_id")
+    @field_validator("paper_a_id", "paper_b_id")
+    @classmethod
+    def _validate_paper_ids(cls, v: str, info: object) -> str:
+        """Validate paper ids against the canonical node-id pattern."""
+        field_name = getattr(info, "field_name", "paper_id")
+        return _validate_paper_id_str(v, field_name)
+
+    @model_validator(mode="after")
+    def _reject_self_coupling(self) -> "CouplingResult":
+        """Ensure paper_a_id differs from paper_b_id (self-coupling is invalid)."""
+        if self.paper_a_id == self.paper_b_id:
+            raise ValueError(
+                f"paper_a_id and paper_b_id must differ; "
+                f"both are {self.paper_a_id!r}"
+            )
+        return self
 
 
 @runtime_checkable
@@ -130,7 +144,7 @@ class CouplingAnalyzerProtocol(Protocol):
         Returns:
             A ``CouplingResult`` with the coupling metrics.
         """
-        raise NotImplementedError  # pragma: abstract
+        ...
 
     async def analyze_for_paper(
         self,
@@ -149,4 +163,4 @@ class CouplingAnalyzerProtocol(Protocol):
             Coupling results sorted by ``coupling_strength`` descending,
             at most ``top_k`` entries.
         """
-        raise NotImplementedError  # pragma: abstract
+        ...

--- a/src/services/intelligence/citation/influence_scorer.py
+++ b/src/services/intelligence/citation/influence_scorer.py
@@ -261,11 +261,16 @@ class InfluenceScorer:
         return metrics
 
     async def compute_for_graph(self, node_ids: list[str]) -> list[InfluenceMetrics]:
-        """Bulk compute metrics for a set of papers.
+        """Bulk compute metrics for a set of papers with cache awareness.
 
-        One PageRank invocation; one HITS invocation; one
-        ``record_metrics`` call per row (each in
-        ``asyncio.to_thread`` so the event loop is never blocked).
+        Checks the cache for each requested id first. Only ids that
+        are not cached (or whose cached row is stale) are included in
+        the PageRank / HITS computation. Cached hits are returned
+        directly without triggering a new graph-global computation.
+
+        One PageRank invocation covers all cache-miss ids; one HITS
+        invocation likewise. Each new row is written via
+        ``asyncio.to_thread`` so the event loop is never blocked.
         Returns metrics in the same order as ``node_ids``.
 
         Raises:
@@ -276,20 +281,41 @@ class InfluenceScorer:
         if not node_ids:
             return []
 
-        target_set = set(node_ids)
-        computed = await self._compute_metrics_for_graph(target_ids=target_set)
-        # Ensure every requested id has a row; missing ones get a
-        # baseline-zero metric so callers don't have to special-case
-        # "node not in graph yet".
+        # Phase 1: consult cache for all requested ids.
+        max_age = self._max_age_days()
+        cache_hits: dict[str, InfluenceMetrics] = {}
+        cache_miss_ids: list[str] = []
+        for nid in node_ids:
+            cached = await asyncio.to_thread(
+                self._repo.get_metrics,
+                nid,
+                max_age,
+            )
+            if cached is not None:
+                cache_hits[nid] = cached
+            else:
+                cache_miss_ids.append(nid)
+
+        # Phase 2: compute PageRank + HITS only for cache misses.
+        newly_computed: dict[str, InfluenceMetrics] = {}
+        if cache_miss_ids:
+            newly_computed = await self._compute_metrics_for_graph(
+                target_ids=set(cache_miss_ids)
+            )
+            for metrics in newly_computed.values():
+                await asyncio.to_thread(self._repo.record_metrics, metrics)
+
+        # Phase 3: assemble results in original order.
         out: list[InfluenceMetrics] = []
         for nid in node_ids:
-            metrics = computed.get(
-                nid,
-                InfluenceMetrics(paper_id=nid, computed_at=self._now()),
-            )
-            out.append(metrics)
-        for metrics in out:
-            await asyncio.to_thread(self._repo.record_metrics, metrics)
+            if nid in cache_hits:
+                out.append(cache_hits[nid])
+            else:
+                metrics = newly_computed.get(
+                    nid,
+                    InfluenceMetrics(paper_id=nid, computed_at=self._now()),
+                )
+                out.append(metrics)
         return out
 
     def _max_age_days(self) -> int:

--- a/src/services/intelligence/citation/models.py
+++ b/src/services/intelligence/citation/models.py
@@ -413,18 +413,27 @@ class RecommendationStrategy(str, Enum):
 class Recommendation(BaseModel):
     """A single paper recommendation produced by ``CitationRecommender``.
 
-    Pydantic V2 strict model (``extra="forbid"``) per project standards.
+    Pydantic V2 strict model (``extra="forbid", strict=True``) per project
+    standards.
 
     Constraints:
     - ``paper_id`` must match the canonical node-id pattern.
-    - ``score`` is in [0.0, 1.0]; strategy-specific normalization ensures
-      every strategy emits comparable scores.
+    - ``score`` is in [0.0, 1.0] — strategy-specific normalization applies
+      independently per strategy.
     - ``seed_paper_id`` must differ from ``paper_id`` — a paper cannot
       recommend itself.
     - ``reasoning`` is a short human-readable explanation (1–512 chars).
+
+    .. warning:: Score asymmetry — do NOT cross-rank between strategies.
+        Each strategy normalizes scores independently (each divides by its
+        own maximum). A score of 0.8 from SIMILAR does **not** mean the
+        same as a score of 0.8 from BRIDGE. Rankings produced by mixing
+        scores from different strategies are semantically meaningless and
+        will produce misleading results. Always compare recommendations
+        within a single strategy.
     """
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", strict=True)
 
     paper_id: str = Field(
         ...,

--- a/src/services/intelligence/citation/models.py
+++ b/src/services/intelligence/citation/models.py
@@ -31,7 +31,7 @@ from datetime import date, datetime, timezone
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from src.services.intelligence.citation._id_validation import (
     CANONICAL_NODE_ID_PATTERN,
@@ -394,3 +394,86 @@ class CitationEdge(BaseModel):
             target_id=self.cited_paper_id,
             properties=properties,
         )
+
+
+# ---------------------------------------------------------------------------
+# Recommendation models (REQ-9.2.5 / Issue #130)
+# ---------------------------------------------------------------------------
+
+
+class RecommendationStrategy(str, Enum):
+    """Strategy used to produce a paper recommendation (REQ-9.2.5)."""
+
+    SIMILAR = "similar"
+    INFLUENTIAL_PREDECESSOR = "influential_predecessor"
+    ACTIVE_SUCCESSOR = "active_successor"
+    BRIDGE = "bridge"
+
+
+class Recommendation(BaseModel):
+    """A single paper recommendation produced by ``CitationRecommender``.
+
+    Pydantic V2 strict model (``extra="forbid"``) per project standards.
+
+    Constraints:
+    - ``paper_id`` must match the canonical node-id pattern.
+    - ``score`` is in [0.0, 1.0]; strategy-specific normalization ensures
+      every strategy emits comparable scores.
+    - ``seed_paper_id`` must differ from ``paper_id`` — a paper cannot
+      recommend itself.
+    - ``reasoning`` is a short human-readable explanation (1–512 chars).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    paper_id: str = Field(
+        ...,
+        min_length=1,
+        max_length=512,
+        description="Canonical node id of the recommended paper.",
+    )
+    score: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="Strategy-specific score in [0.0, 1.0].",
+    )
+    strategy: RecommendationStrategy = Field(
+        ...,
+        description="Which strategy produced this recommendation.",
+    )
+    reasoning: str = Field(
+        ...,
+        min_length=1,
+        max_length=512,
+        description="Human-readable explanation of why this paper was recommended.",
+    )
+    seed_paper_id: str = Field(
+        ...,
+        min_length=1,
+        max_length=512,
+        description="Canonical node id of the seed paper this was recommended for.",
+    )
+
+    @field_validator("paper_id", "seed_paper_id")
+    @classmethod
+    def _validate_id_format(cls, v: str) -> str:
+        """Enforce canonical node-id format on both paper ids."""
+        v = v.strip()
+        if not v:
+            raise ValueError("paper id cannot be empty")
+        if not CANONICAL_NODE_ID_PATTERN.match(v):
+            raise ValueError(
+                f"Invalid paper id format: {v!r}. "
+                "Allowed: alphanumeric, colons, periods, hyphens, underscores."
+            )
+        return v
+
+    @model_validator(mode="after")
+    def _reject_self_recommendation(self) -> "Recommendation":
+        """Ensure the recommended paper differs from the seed."""
+        if self.paper_id == self.seed_paper_id:
+            raise ValueError(
+                f"paper_id and seed_paper_id must differ; both are {self.paper_id!r}"
+            )
+        return self

--- a/src/services/intelligence/citation/recommender.py
+++ b/src/services/intelligence/citation/recommender.py
@@ -21,27 +21,40 @@ Design notes
 - All four strategies are injected via DI constructor so callers can
   substitute mocks in tests.
 - ``recommend_all`` runs all four in ``asyncio.gather`` for concurrency.
+  ``return_exceptions=True`` is used so one strategy failure returns a
+  partial result and emits ``recommender_strategy_failed_in_recommend_all``
+  rather than aborting all strategies.
 - Scores are normalized to [0.0, 1.0] per strategy before being wrapped
   in :class:`Recommendation` objects.
-- Every public method validates ``seed_id`` using
-  :meth:`InfluenceScorer._validate_paper_id` (the project's single
-  source of truth for paper-id validation in this package).
+
+  .. warning::
+      Scores are **not** cross-comparable between strategies — each
+      strategy normalizes independently. Do NOT rank recommendations from
+      different strategies against each other by score.
+
+- Every public method validates ``seed_id`` via the canonical
+  :func:`_validate_paper_id` (single source of truth in this package).
+  ``k`` is validated to be in [1, 100].
 - Structured log events emitted: ``recommender_strategy_complete``,
   ``recommender_seed_isolated_returns_empty``,
-  ``recommender_strategy_failed``.
+  ``recommender_strategy_failed``,
+  ``recommender_strategy_failed_in_recommend_all``,
+  ``recommender_bridge_frontier_truncated``.
 
 Failure semantics
 -----------------
-If a strategy raises an unexpected exception, ``recommender_strategy_failed``
-is logged and the exception propagates (not swallowed). This preserves the
-"Checked Success" pattern from CLAUDE.md: silent swallowing would hide
-bugs and leave the caller unaware that recommendations are incomplete.
+Individual strategies propagate exceptions to the caller (fail-hard by
+default). In ``recommend_all``, ``asyncio.gather(return_exceptions=True)``
+is used so a single strategy failure returns a partial result for the
+other strategies, and emits ``recommender_strategy_failed_in_recommend_all``
+for each failed strategy.
 """
 
 from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timezone
+from pathlib import Path
 
 import structlog
 
@@ -55,6 +68,7 @@ from src.services.intelligence.citation.coupling_protocol import (
 from src.services.intelligence.citation.crawler import CitationCrawler
 from src.services.intelligence.citation.influence_scorer import InfluenceScorer
 from src.services.intelligence.citation.models import (
+    EdgeType,
     Recommendation,
     RecommendationStrategy,
 )
@@ -66,8 +80,13 @@ logger = structlog.get_logger(__name__)
 # Year cutoff for "active successors": papers published in the last N years.
 _ACTIVE_SUCCESSOR_YEARS = 2
 
-# BFS radius used to gather seed candidates for similar / bridge strategies.
+# BFS radius used to gather seed candidates for similar strategy.
 _BFS_RADIUS_SIMILAR = 2
+
+# BFS radius used to gather backward candidates for influential predecessors.
+# Kept separate from _BFS_RADIUS_SIMILAR so each strategy can be tuned
+# independently without inadvertently changing the other.
+_BFS_RADIUS_PREDECESSOR = 2
 
 # Minimum number of "distant papers" (frontier) that must co-cite a bridge
 # candidate for it to count as a bridge.
@@ -76,12 +95,24 @@ _BRIDGE_MIN_DISTANT_CO_CITERS = 2
 # BFS depth for gathering the distant frontier used in bridge detection.
 _BRIDGE_FRONTIER_RADIUS = 3
 
+# Hard cap on the distant-frontier size in bridge detection. Large corpora
+# can produce thousands of radius-3 nodes which would trigger one
+# _get_bfs_neighbors call per node. Capping at 500 prevents pathological
+# runtimes while still covering realistic citation graphs.
+_BRIDGE_MAX_DISTANT = 500
+
+# Hard cap on the candidate list passed to analyze_for_paper (M-7).
+# Large BFS expansions can produce thousands of candidates; capping here
+# prevents unbounded work in the coupling analyzer.
+_MAX_CANDIDATES = 500
+
+# Valid range for k (applies to all public methods).
+_K_MIN = 1
+_K_MAX = 100
+
 
 def _validate_paper_id(paper_id: str) -> None:
-    """Validate a paper id using the project canonical pattern.
-
-    Delegates to :func:`InfluenceScorer._validate_paper_id` so that the
-    validation logic has a single source of truth.
+    """Validate a paper id against the project's canonical node-id pattern.
 
     Raises:
         ValueError: If ``paper_id`` is malformed.
@@ -97,6 +128,16 @@ def _validate_paper_id(paper_id: str) -> None:
             f"Invalid paper_id format: {paper_id!r}. "
             "Allowed: alphanumeric, colons, periods, hyphens, underscores."
         )
+
+
+def _validate_k(k: int) -> None:
+    """Validate that k is in [_K_MIN, _K_MAX].
+
+    Raises:
+        ValueError: If ``k`` is outside [1, 100].
+    """
+    if not _K_MIN <= k <= _K_MAX:
+        raise ValueError(f"k must be in [{_K_MIN}, {_K_MAX}]; got {k}")
 
 
 def _normalize_scores(scores: dict[str, float]) -> dict[str, float]:
@@ -144,6 +185,65 @@ class CitationRecommender:
         self._store = store
 
     # ------------------------------------------------------------------
+    # Factory
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def connect(
+        cls,
+        *,
+        db_path: Path | str,
+        coupling: CouplingAnalyzerProtocol | None = None,
+    ) -> "CitationRecommender":
+        """Create a fully-wired ``CitationRecommender`` from a database path.
+
+        Wires together ``SQLiteGraphStore``, ``CitationCrawler``,
+        ``InfluenceScorer``, and (optionally) a ``CouplingAnalyzerProtocol``
+        so callers do not need to know about the internal collaborators.
+
+        Args:
+            db_path: Path to the SQLite database backing the graph store.
+            coupling: Optional coupling analyzer. When ``None``, no
+                similarity analysis is available; the ``recommend_similar``
+                strategy will return empty results or raise on any call
+                that reaches the analyzer. In production, PR #128's
+                ``CouplingAnalyzer`` should be passed here once it lands.
+
+        Returns:
+            A ready-to-use ``CitationRecommender``.
+        """
+        from src.services.intelligence.citation.crawler import CitationCrawler
+        from src.services.intelligence.citation.openalex_client import (
+            OpenAlexCitationClient,
+        )
+        from src.services.intelligence.citation.semantic_scholar_client import (
+            SemanticScholarCitationClient,
+        )
+
+        store = SQLiteGraphStore(db_path)
+        s2_client = SemanticScholarCitationClient()
+        openalex_client = OpenAlexCitationClient()
+        crawler = CitationCrawler(
+            store=store,
+            s2_client=s2_client,
+            openalex_client=openalex_client,
+        )
+        scorer = InfluenceScorer(store=store)
+
+        if coupling is None:
+            # Use a no-op coupling adapter that always returns empty results.
+            # External code (PR #128 / CouplingAnalyzer) should be injected
+            # once it lands.
+            coupling = _NullCouplingAdapter()  # type: ignore[assignment]
+
+        return cls(
+            coupling=coupling,  # type: ignore[arg-type]
+            crawler=crawler,
+            scorer=scorer,
+            store=store,
+        )
+
+    # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
 
@@ -158,16 +258,17 @@ class CitationRecommender:
 
         Args:
             seed_id: Canonical node id of the seed paper.
-            k: Maximum number of recommendations to return.
+            k: Maximum number of recommendations to return (1–100).
 
         Returns:
             Up to ``k`` :class:`Recommendation` objects, sorted by score
             descending.
 
         Raises:
-            ValueError: If ``seed_id`` is malformed.
+            ValueError: If ``seed_id`` is malformed or ``k`` is out of range.
         """
         _validate_paper_id(seed_id)
+        _validate_k(k)
         strategy = RecommendationStrategy.SIMILAR
         try:
             candidates = self._get_bfs_neighbors(seed_id, radius=_BFS_RADIUS_SIMILAR)
@@ -180,6 +281,10 @@ class CitationRecommender:
                     strategy=strategy.value,
                 )
                 return []
+
+            # Cap candidate list to prevent unbounded coupling work.
+            if len(candidates) > _MAX_CANDIDATES:
+                candidates = candidates[:_MAX_CANDIDATES]
 
             coupling_results = await self._coupling.analyze_for_paper(
                 seed_id, candidates, top_k=k
@@ -235,21 +340,22 @@ class CitationRecommender:
 
         Args:
             seed_id: Canonical node id of the seed paper.
-            k: Maximum number of recommendations to return.
+            k: Maximum number of recommendations to return (1–100).
 
         Returns:
             Up to ``k`` :class:`Recommendation` objects sorted by score
             descending.
 
         Raises:
-            ValueError: If ``seed_id`` is malformed.
+            ValueError: If ``seed_id`` is malformed or ``k`` is out of range.
         """
         _validate_paper_id(seed_id)
+        _validate_k(k)
         strategy = RecommendationStrategy.INFLUENTIAL_PREDECESSOR
         try:
             backward_nodes = self._get_bfs_neighbors(
                 seed_id,
-                radius=_BFS_RADIUS_SIMILAR,
+                radius=_BFS_RADIUS_PREDECESSOR,
                 direction="outgoing",
             )
             backward_nodes = [n for n in backward_nodes if n != seed_id]
@@ -281,10 +387,8 @@ class CitationRecommender:
             for nid in ranked:
                 m = metrics_by_id.get(nid)
                 pr = m.pagerank_score if m else 0.0
-                hop_count = self._hop_count(seed_id, nid, direction="outgoing")
                 reasoning = (
-                    f"PageRank={pr:.4f}, cited by seed via "
-                    f"{hop_count}-hop backward crawl"
+                    f"PageRank={pr:.4f}, " "cited by seed via backward citation chain"
                 )
                 recommendations.append(
                     Recommendation(
@@ -326,16 +430,17 @@ class CitationRecommender:
 
         Args:
             seed_id: Canonical node id of the seed paper.
-            k: Maximum number of recommendations to return.
+            k: Maximum number of recommendations to return (1–100).
 
         Returns:
             Up to ``k`` :class:`Recommendation` objects sorted by score
             descending.
 
         Raises:
-            ValueError: If ``seed_id`` is malformed.
+            ValueError: If ``seed_id`` is malformed or ``k`` is out of range.
         """
         _validate_paper_id(seed_id)
+        _validate_k(k)
         strategy = RecommendationStrategy.ACTIVE_SUCCESSOR
         try:
             forward_nodes = self._get_bfs_neighbors(
@@ -427,6 +532,8 @@ class CitationRecommender:
         Heuristic (no NetworkX / community-detection libs required):
         1. Collect all papers cited by the seed (radius-2 backward BFS).
         2. Collect a "distant frontier" at radius-3 backward BFS.
+           The distant frontier is capped at :data:`_BRIDGE_MAX_DISTANT`
+           nodes to prevent pathological runtimes on large corpora.
         3. A candidate is a "bridge" if it appears in the seed's radius-2
            neighborhood AND is also cited by ≥
            :data:`_BRIDGE_MIN_DISTANT_CO_CITERS` distinct papers in the
@@ -437,20 +544,25 @@ class CitationRecommender:
 
         Args:
             seed_id: Canonical node id of the seed paper.
-            k: Maximum number of recommendations to return.
+            k: Maximum number of recommendations to return (1–100).
 
         Returns:
             Up to ``k`` :class:`Recommendation` objects sorted by score
             descending.
 
         Raises:
-            ValueError: If ``seed_id`` is malformed.
+            ValueError: If ``seed_id`` is malformed or ``k`` is out of range.
         """
         _validate_paper_id(seed_id)
+        _validate_k(k)
         strategy = RecommendationStrategy.BRIDGE
         try:
             # Radius-2 neighbors of seed (candidates).
-            r2_nodes = self._get_bfs_neighbors(seed_id, radius=2, direction="outgoing")
+            r2_nodes = self._get_bfs_neighbors(
+                seed_id,
+                radius=2,
+                direction="outgoing",
+            )
             r2_nodes = [n for n in r2_nodes if n != seed_id]
 
             if not r2_nodes:
@@ -465,10 +577,21 @@ class CitationRecommender:
 
             # Radius-3 "distant" neighbors.
             r3_nodes = self._get_bfs_neighbors(
-                seed_id, radius=_BRIDGE_FRONTIER_RADIUS, direction="outgoing"
+                seed_id,
+                radius=_BRIDGE_FRONTIER_RADIUS,
+                direction="outgoing",
             )
             # Distant = in r3 but NOT in r2 (radius > 2 from seed).
             distant_nodes = [n for n in r3_nodes if n not in r2_set and n != seed_id]
+
+            # Cap the frontier to bound per-node BFS calls (H-3).
+            if len(distant_nodes) > _BRIDGE_MAX_DISTANT:
+                distant_nodes = distant_nodes[:_BRIDGE_MAX_DISTANT]
+                logger.info(
+                    "recommender_bridge_frontier_truncated",
+                    seed_id=seed_id,
+                    cap=_BRIDGE_MAX_DISTANT,
+                )
 
             # Count how many distinct distant nodes cite each r2 candidate.
             # "Cite" in the backward direction means: the distant node
@@ -477,7 +600,9 @@ class CitationRecommender:
             for distant in distant_nodes:
                 # What does this distant node reference?
                 cited_by_distant = self._get_bfs_neighbors(
-                    distant, radius=1, direction="outgoing"
+                    distant,
+                    radius=1,
+                    direction="outgoing",
                 )
                 for cited in cited_by_distant:
                     if cited in r2_set:
@@ -550,35 +675,57 @@ class CitationRecommender:
     ) -> dict[RecommendationStrategy, list[Recommendation]]:
         """Run all four strategies concurrently and return a combined dict.
 
-        Uses ``asyncio.gather`` so the four strategies overlap their I/O
-        instead of running sequentially.
+        Uses ``asyncio.gather(return_exceptions=True)`` so a single strategy
+        failure returns a partial result for the remaining strategies rather
+        than aborting all of them. Each failing strategy is logged with
+        ``recommender_strategy_failed_in_recommend_all`` and contributes an
+        empty list in the returned dict.
 
         Args:
             seed_id: Canonical node id of the seed paper.
-            k_per_strategy: ``k`` passed to each individual strategy.
+            k_per_strategy: ``k`` passed to each individual strategy (1–100).
 
         Returns:
             A dict mapping each :class:`RecommendationStrategy` to its
-            list of :class:`Recommendation` objects.
+            list of :class:`Recommendation` objects. Strategies that raised
+            an exception map to an empty list.
 
         Raises:
-            ValueError: If ``seed_id`` is malformed.
-            Exception: Re-raises any exception from a failing strategy
-                (first exception wins; see asyncio.gather semantics).
+            ValueError: If ``seed_id`` is malformed or ``k_per_strategy``
+                is out of range.
         """
         _validate_paper_id(seed_id)
-        results = await asyncio.gather(
+        _validate_k(k_per_strategy)
+
+        strategies = [
+            RecommendationStrategy.SIMILAR,
+            RecommendationStrategy.INFLUENTIAL_PREDECESSOR,
+            RecommendationStrategy.ACTIVE_SUCCESSOR,
+            RecommendationStrategy.BRIDGE,
+        ]
+        coroutines = [
             self.recommend_similar(seed_id, k=k_per_strategy),
             self.recommend_influential_predecessors(seed_id, k=k_per_strategy),
             self.recommend_active_successors(seed_id, k=k_per_strategy),
             self.recommend_bridge_papers(seed_id, k=k_per_strategy),
-        )
-        return {
-            RecommendationStrategy.SIMILAR: results[0],
-            RecommendationStrategy.INFLUENTIAL_PREDECESSOR: results[1],
-            RecommendationStrategy.ACTIVE_SUCCESSOR: results[2],
-            RecommendationStrategy.BRIDGE: results[3],
-        }
+        ]
+
+        # return_exceptions=True: partial results on strategy failure.
+        raw_results = await asyncio.gather(*coroutines, return_exceptions=True)
+
+        output: dict[RecommendationStrategy, list[Recommendation]] = {}
+        for strategy, result in zip(strategies, raw_results):
+            if isinstance(result, BaseException):
+                logger.error(
+                    "recommender_strategy_failed_in_recommend_all",
+                    seed_id=seed_id,
+                    strategy=strategy.value,
+                    error=_trunc(result),
+                )
+                output[strategy] = []
+            else:
+                output[strategy] = result
+        return output
 
     # ------------------------------------------------------------------
     # Internals
@@ -603,8 +750,6 @@ class CitationRecommender:
         Returns:
             List of neighbor node ids (order not guaranteed).
         """
-        from src.services.intelligence.models import EdgeType
-
         nodes = self._store.traverse(
             node_id,
             edge_types=[EdgeType.CITES],
@@ -650,27 +795,24 @@ class CitationRecommender:
                     kept.append(nid)
         return kept
 
-    def _hop_count(
-        self, source_id: str, target_id: str, direction: str = "outgoing"
-    ) -> int:
-        """Return the BFS hop distance from ``source_id`` to ``target_id``.
 
-        Uses progressive BFS (depth 1, 2, 3) to find the first depth at
-        which ``target_id`` appears. Returns 1 if not found (safe fallback
-        — the caller uses this only for reasoning string generation).
+class _NullCouplingAdapter:
+    """No-op coupling adapter used when no real CouplingAnalyzer is available.
 
-        Args:
-            source_id: BFS origin.
-            target_id: Target node to search for.
-            direction: ``"outgoing"``, ``"incoming"``, or ``"both"``.
+    This satisfies :class:`CouplingAnalyzerProtocol` and is the default
+    wired by :meth:`CitationRecommender.connect` until PR #128 lands and
+    provides a real implementation.
+    """
 
-        Returns:
-            Hop count, or 1 if not reachable within 3 hops.
-        """
-        for depth in range(1, 4):
-            neighbors = self._get_bfs_neighbors(
-                source_id, radius=depth, direction=direction
-            )
-            if target_id in neighbors:
-                return depth
-        return 1
+    async def analyze_pair(self, paper_a_id: str, paper_b_id: str) -> object:
+        """Always returns an empty result (no coupling data available)."""
+        return None
+
+    async def analyze_for_paper(
+        self,
+        seed_id: str,
+        candidates: list[str],
+        top_k: int = 10,
+    ) -> list[object]:
+        """Always returns an empty list (no coupling data available)."""
+        return []

--- a/src/services/intelligence/citation/recommender.py
+++ b/src/services/intelligence/citation/recommender.py
@@ -58,6 +58,7 @@ from src.services.intelligence.citation.models import (
     Recommendation,
     RecommendationStrategy,
 )
+from src.storage.intelligence_graph.connection import _trunc
 from src.storage.intelligence_graph.unified_graph import SQLiteGraphStore
 
 logger = structlog.get_logger(__name__)
@@ -219,7 +220,7 @@ class CitationRecommender:
                 "recommender_strategy_failed",
                 seed_id=seed_id,
                 strategy=strategy.value,
-                error=repr(str(exc)[:512]),
+                error=_trunc(exc),
             )
             raise
 
@@ -308,7 +309,7 @@ class CitationRecommender:
                 "recommender_strategy_failed",
                 seed_id=seed_id,
                 strategy=strategy.value,
-                error=repr(str(exc)[:512]),
+                error=_trunc(exc),
             )
             raise
 
@@ -414,7 +415,7 @@ class CitationRecommender:
                 "recommender_strategy_failed",
                 seed_id=seed_id,
                 strategy=strategy.value,
-                error=repr(str(exc)[:512]),
+                error=_trunc(exc),
             )
             raise
 
@@ -540,7 +541,7 @@ class CitationRecommender:
                 "recommender_strategy_failed",
                 seed_id=seed_id,
                 strategy=strategy.value,
-                error=repr(str(exc)[:512]),
+                error=_trunc(exc),
             )
             raise
 

--- a/src/services/intelligence/citation/recommender.py
+++ b/src/services/intelligence/citation/recommender.py
@@ -596,15 +596,14 @@ class CitationRecommender:
             # Count how many distinct distant nodes cite each r2 candidate.
             # "Cite" in the backward direction means: the distant node
             # references the candidate (outgoing edge from distant → candidate).
+            # Use a single bulk SQL query instead of one traverse per node.
+            distant_to_targets = self._store._list_outgoing_edges_for_nodes(
+                distant_nodes,
+                edge_type_values=[EdgeType.CITES.value],
+            )
             bridge_counts: dict[str, int] = {}
-            for distant in distant_nodes:
-                # What does this distant node reference?
-                cited_by_distant = self._get_bfs_neighbors(
-                    distant,
-                    radius=1,
-                    direction="outgoing",
-                )
-                for cited in cited_by_distant:
+            for cited_list in distant_to_targets.values():
+                for cited in cited_list:
                     if cited in r2_set:
                         bridge_counts[cited] = bridge_counts.get(cited, 0) + 1
 

--- a/src/services/intelligence/citation/recommender.py
+++ b/src/services/intelligence/citation/recommender.py
@@ -1,0 +1,675 @@
+"""Citation-based paper recommender (Milestone 9.2 — REQ-9.2.5 / Issue #130).
+
+Implements four recommendation strategies built on top of the crawler,
+coupling, and influence layers:
+
+1. **Similar** — papers with high bibliographic coupling to the seed
+   (uses :class:`CouplingAnalyzerProtocol`).
+2. **Influential Predecessors** — high-PageRank papers in the backward
+   citation chain (uses :class:`CitationCrawler` BACKWARD +
+   :class:`InfluenceScorer`).
+3. **Active Successors** — recent papers (last 2 years) that cite the
+   seed with high ``citation_velocity`` (uses :class:`CitationCrawler`
+   FORWARD + :class:`InfluenceScorer`).
+4. **Bridge Papers** — papers connecting different citation clusters via
+   a simple heuristic: papers cited by the seed *and* also cited by ≥2
+   papers in the seed's BFS frontier beyond radius 2 (no NetworkX /
+   community-detection libs required).
+
+Design notes
+------------
+- All four strategies are injected via DI constructor so callers can
+  substitute mocks in tests.
+- ``recommend_all`` runs all four in ``asyncio.gather`` for concurrency.
+- Scores are normalized to [0.0, 1.0] per strategy before being wrapped
+  in :class:`Recommendation` objects.
+- Every public method validates ``seed_id`` using
+  :meth:`InfluenceScorer._validate_paper_id` (the project's single
+  source of truth for paper-id validation in this package).
+- Structured log events emitted: ``recommender_strategy_complete``,
+  ``recommender_seed_isolated_returns_empty``,
+  ``recommender_strategy_failed``.
+
+Failure semantics
+-----------------
+If a strategy raises an unexpected exception, ``recommender_strategy_failed``
+is logged and the exception propagates (not swallowed). This preserves the
+"Checked Success" pattern from CLAUDE.md: silent swallowing would hide
+bugs and leave the caller unaware that recommendations are incomplete.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+import structlog
+
+from src.services.intelligence.citation._id_validation import (
+    CANONICAL_NODE_ID_PATTERN,
+    PAPER_ID_MAX_LENGTH,
+)
+from src.services.intelligence.citation.coupling_protocol import (
+    CouplingAnalyzerProtocol,
+)
+from src.services.intelligence.citation.crawler import CitationCrawler
+from src.services.intelligence.citation.influence_scorer import InfluenceScorer
+from src.services.intelligence.citation.models import (
+    Recommendation,
+    RecommendationStrategy,
+)
+from src.storage.intelligence_graph.unified_graph import SQLiteGraphStore
+
+logger = structlog.get_logger(__name__)
+
+# Year cutoff for "active successors": papers published in the last N years.
+_ACTIVE_SUCCESSOR_YEARS = 2
+
+# BFS radius used to gather seed candidates for similar / bridge strategies.
+_BFS_RADIUS_SIMILAR = 2
+
+# Minimum number of "distant papers" (frontier) that must co-cite a bridge
+# candidate for it to count as a bridge.
+_BRIDGE_MIN_DISTANT_CO_CITERS = 2
+
+# BFS depth for gathering the distant frontier used in bridge detection.
+_BRIDGE_FRONTIER_RADIUS = 3
+
+
+def _validate_paper_id(paper_id: str) -> None:
+    """Validate a paper id using the project canonical pattern.
+
+    Delegates to :func:`InfluenceScorer._validate_paper_id` so that the
+    validation logic has a single source of truth.
+
+    Raises:
+        ValueError: If ``paper_id`` is malformed.
+    """
+    if not isinstance(paper_id, str) or not paper_id.strip():
+        raise ValueError("paper_id must be a non-empty string")
+    if len(paper_id) > PAPER_ID_MAX_LENGTH:
+        raise ValueError(
+            f"paper_id length {len(paper_id)} exceeds max {PAPER_ID_MAX_LENGTH}"
+        )
+    if not CANONICAL_NODE_ID_PATTERN.match(paper_id):
+        raise ValueError(
+            f"Invalid paper_id format: {paper_id!r}. "
+            "Allowed: alphanumeric, colons, periods, hyphens, underscores."
+        )
+
+
+def _normalize_scores(scores: dict[str, float]) -> dict[str, float]:
+    """Linearly normalize scores to [0.0, 1.0] by dividing by max.
+
+    When all scores are 0.0 (or the dict is empty), all results remain 0.0.
+    """
+    if not scores:
+        return scores
+    max_score = max(scores.values())
+    if max_score <= 0.0:
+        return {k: 0.0 for k in scores}
+    return {k: v / max_score for k, v in scores.items()}
+
+
+def _current_year() -> int:
+    """Return the current UTC year. Extracted for testability."""
+    return datetime.now(timezone.utc).year
+
+
+class CitationRecommender:
+    """Recommend papers via four citation-based strategies (REQ-9.2.5).
+
+    Constructor requires all collaborators so tests can inject mocks at the
+    module boundary (PR #143 H-5 lesson: patch public dependencies, not
+    private methods).
+
+    Args:
+        coupling: A :class:`CouplingAnalyzerProtocol` for similarity.
+        crawler: A :class:`CitationCrawler` for BFS expansion.
+        scorer: An :class:`InfluenceScorer` for PageRank + velocity.
+        store: A :class:`SQLiteGraphStore` for raw graph reads.
+    """
+
+    def __init__(
+        self,
+        coupling: CouplingAnalyzerProtocol,
+        crawler: CitationCrawler,
+        scorer: InfluenceScorer,
+        store: SQLiteGraphStore,
+    ) -> None:
+        self._coupling = coupling
+        self._crawler = crawler
+        self._scorer = scorer
+        self._store = store
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def recommend_similar(
+        self, seed_id: str, k: int = 10
+    ) -> list[Recommendation]:
+        """Recommend papers similar to ``seed_id`` by coupling strength.
+
+        Candidate set: all nodes discovered via BFS expansion of the seed
+        at radius 1–2 (using the stored graph; no new provider calls).
+        Coupling is computed via ``CouplingAnalyzerProtocol.analyze_for_paper``.
+
+        Args:
+            seed_id: Canonical node id of the seed paper.
+            k: Maximum number of recommendations to return.
+
+        Returns:
+            Up to ``k`` :class:`Recommendation` objects, sorted by score
+            descending.
+
+        Raises:
+            ValueError: If ``seed_id`` is malformed.
+        """
+        _validate_paper_id(seed_id)
+        strategy = RecommendationStrategy.SIMILAR
+        try:
+            candidates = self._get_bfs_neighbors(seed_id, radius=_BFS_RADIUS_SIMILAR)
+            candidates = [c for c in candidates if c != seed_id]
+
+            if not candidates:
+                logger.info(
+                    "recommender_seed_isolated_returns_empty",
+                    seed_id=seed_id,
+                    strategy=strategy.value,
+                )
+                return []
+
+            coupling_results = await self._coupling.analyze_for_paper(
+                seed_id, candidates, top_k=k
+            )
+
+            recommendations: list[Recommendation] = []
+            for cr in coupling_results:
+                other_id = cr.paper_b_id if cr.paper_a_id == seed_id else cr.paper_a_id
+                if other_id == seed_id:
+                    continue
+                reasoning = (
+                    f"Top coupling (Jaccard={cr.jaccard_index:.2f}, "
+                    f"{cr.shared_reference_count} shared references)"
+                )
+                recommendations.append(
+                    Recommendation(
+                        paper_id=other_id,
+                        score=cr.coupling_strength,
+                        strategy=strategy,
+                        reasoning=reasoning,
+                        seed_paper_id=seed_id,
+                    )
+                )
+
+            recommendations.sort(key=lambda r: r.score, reverse=True)
+            recommendations = recommendations[:k]
+
+            logger.info(
+                "recommender_strategy_complete",
+                seed_id=seed_id,
+                strategy=strategy.value,
+                count=len(recommendations),
+            )
+            return recommendations
+
+        except Exception as exc:
+            logger.error(
+                "recommender_strategy_failed",
+                seed_id=seed_id,
+                strategy=strategy.value,
+                error=repr(str(exc)[:512]),
+            )
+            raise
+
+    async def recommend_influential_predecessors(
+        self, seed_id: str, k: int = 10
+    ) -> list[Recommendation]:
+        """Recommend high-influence papers in the backward citation chain.
+
+        Performs a BACKWARD BFS crawl (papers that ``seed_id`` cites,
+        transitively), then ranks by ``pagerank_score`` from
+        :class:`InfluenceScorer`.
+
+        Args:
+            seed_id: Canonical node id of the seed paper.
+            k: Maximum number of recommendations to return.
+
+        Returns:
+            Up to ``k`` :class:`Recommendation` objects sorted by score
+            descending.
+
+        Raises:
+            ValueError: If ``seed_id`` is malformed.
+        """
+        _validate_paper_id(seed_id)
+        strategy = RecommendationStrategy.INFLUENTIAL_PREDECESSOR
+        try:
+            backward_nodes = self._get_bfs_neighbors(
+                seed_id,
+                radius=_BFS_RADIUS_SIMILAR,
+                direction="outgoing",
+            )
+            backward_nodes = [n for n in backward_nodes if n != seed_id]
+
+            if not backward_nodes:
+                logger.info(
+                    "recommender_seed_isolated_returns_empty",
+                    seed_id=seed_id,
+                    strategy=strategy.value,
+                )
+                return []
+
+            metrics_list = await self._scorer.compute_for_graph(backward_nodes)
+            metrics_by_id = {m.paper_id: m for m in metrics_list}
+
+            # pagerank_score is already in [0.0, 1.0] from InfluenceScorer.
+            ranked = sorted(
+                backward_nodes,
+                key=lambda nid: (
+                    metrics_by_id.get(nid).pagerank_score  # type: ignore[union-attr]
+                    if metrics_by_id.get(nid)
+                    else 0.0
+                ),
+                reverse=True,
+            )
+            ranked = ranked[:k]
+
+            recommendations: list[Recommendation] = []
+            for nid in ranked:
+                m = metrics_by_id.get(nid)
+                pr = m.pagerank_score if m else 0.0
+                hop_count = self._hop_count(seed_id, nid, direction="outgoing")
+                reasoning = (
+                    f"PageRank={pr:.4f}, cited by seed via "
+                    f"{hop_count}-hop backward crawl"
+                )
+                recommendations.append(
+                    Recommendation(
+                        paper_id=nid,
+                        score=pr,
+                        strategy=strategy,
+                        reasoning=reasoning,
+                        seed_paper_id=seed_id,
+                    )
+                )
+
+            logger.info(
+                "recommender_strategy_complete",
+                seed_id=seed_id,
+                strategy=strategy.value,
+                count=len(recommendations),
+            )
+            return recommendations
+
+        except Exception as exc:
+            logger.error(
+                "recommender_strategy_failed",
+                seed_id=seed_id,
+                strategy=strategy.value,
+                error=repr(str(exc)[:512]),
+            )
+            raise
+
+    async def recommend_active_successors(
+        self, seed_id: str, k: int = 10
+    ) -> list[Recommendation]:
+        """Recommend recent papers that cite the seed with high velocity.
+
+        Performs a FORWARD BFS crawl (papers that cite ``seed_id``), then
+        filters to papers published within the last
+        :data:`_ACTIVE_SUCCESSOR_YEARS` years (from the current UTC year).
+        Results are ranked by ``citation_velocity`` (normalized by the
+        max velocity in the result set).
+
+        Args:
+            seed_id: Canonical node id of the seed paper.
+            k: Maximum number of recommendations to return.
+
+        Returns:
+            Up to ``k`` :class:`Recommendation` objects sorted by score
+            descending.
+
+        Raises:
+            ValueError: If ``seed_id`` is malformed.
+        """
+        _validate_paper_id(seed_id)
+        strategy = RecommendationStrategy.ACTIVE_SUCCESSOR
+        try:
+            forward_nodes = self._get_bfs_neighbors(
+                seed_id,
+                radius=_BFS_RADIUS_SIMILAR,
+                direction="incoming",
+            )
+            forward_nodes = [n for n in forward_nodes if n != seed_id]
+
+            if not forward_nodes:
+                logger.info(
+                    "recommender_seed_isolated_returns_empty",
+                    seed_id=seed_id,
+                    strategy=strategy.value,
+                )
+                return []
+
+            # Filter by publication year.
+            cutoff_year = _current_year() - _ACTIVE_SUCCESSOR_YEARS
+            recent_nodes = self._filter_by_year(forward_nodes, cutoff_year)
+
+            if not recent_nodes:
+                logger.info(
+                    "recommender_seed_isolated_returns_empty",
+                    seed_id=seed_id,
+                    strategy=strategy.value,
+                )
+                return []
+
+            metrics_list = await self._scorer.compute_for_graph(recent_nodes)
+            metrics_by_id = {m.paper_id: m for m in metrics_list}
+
+            # Normalize velocity by the max in the result set.
+            velocity_map = {
+                nid: (
+                    metrics_by_id[nid].citation_velocity
+                    if nid in metrics_by_id
+                    else 0.0
+                )
+                for nid in recent_nodes
+            }
+            normalized = _normalize_scores(velocity_map)
+
+            ranked = sorted(
+                recent_nodes, key=lambda nid: normalized.get(nid, 0.0), reverse=True
+            )
+            ranked = ranked[:k]
+
+            recommendations: list[Recommendation] = []
+            for nid in ranked:
+                m = metrics_by_id.get(nid)
+                vel = m.citation_velocity if m else 0.0
+                norm_score = normalized.get(nid, 0.0)
+                reasoning = (
+                    f"velocity={vel:.2f} citations/year, " f"published ≥{cutoff_year}"
+                )
+                recommendations.append(
+                    Recommendation(
+                        paper_id=nid,
+                        score=norm_score,
+                        strategy=strategy,
+                        reasoning=reasoning,
+                        seed_paper_id=seed_id,
+                    )
+                )
+
+            logger.info(
+                "recommender_strategy_complete",
+                seed_id=seed_id,
+                strategy=strategy.value,
+                count=len(recommendations),
+            )
+            return recommendations
+
+        except Exception as exc:
+            logger.error(
+                "recommender_strategy_failed",
+                seed_id=seed_id,
+                strategy=strategy.value,
+                error=repr(str(exc)[:512]),
+            )
+            raise
+
+    async def recommend_bridge_papers(
+        self, seed_id: str, k: int = 10
+    ) -> list[Recommendation]:
+        """Recommend papers that bridge different citation clusters.
+
+        Heuristic (no NetworkX / community-detection libs required):
+        1. Collect all papers cited by the seed (radius-2 backward BFS).
+        2. Collect a "distant frontier" at radius-3 backward BFS.
+        3. A candidate is a "bridge" if it appears in the seed's radius-2
+           neighborhood AND is also cited by ≥
+           :data:`_BRIDGE_MIN_DISTANT_CO_CITERS` distinct papers in the
+           distant frontier (i.e., it connects the seed's cluster to
+           distant clusters).
+        4. Score = bridge_count (number of distinct distant co-citers),
+           normalized by max bridge_count.
+
+        Args:
+            seed_id: Canonical node id of the seed paper.
+            k: Maximum number of recommendations to return.
+
+        Returns:
+            Up to ``k`` :class:`Recommendation` objects sorted by score
+            descending.
+
+        Raises:
+            ValueError: If ``seed_id`` is malformed.
+        """
+        _validate_paper_id(seed_id)
+        strategy = RecommendationStrategy.BRIDGE
+        try:
+            # Radius-2 neighbors of seed (candidates).
+            r2_nodes = self._get_bfs_neighbors(seed_id, radius=2, direction="outgoing")
+            r2_nodes = [n for n in r2_nodes if n != seed_id]
+
+            if not r2_nodes:
+                logger.info(
+                    "recommender_seed_isolated_returns_empty",
+                    seed_id=seed_id,
+                    strategy=strategy.value,
+                )
+                return []
+
+            r2_set = set(r2_nodes)
+
+            # Radius-3 "distant" neighbors.
+            r3_nodes = self._get_bfs_neighbors(
+                seed_id, radius=_BRIDGE_FRONTIER_RADIUS, direction="outgoing"
+            )
+            # Distant = in r3 but NOT in r2 (radius > 2 from seed).
+            distant_nodes = [n for n in r3_nodes if n not in r2_set and n != seed_id]
+
+            # Count how many distinct distant nodes cite each r2 candidate.
+            # "Cite" in the backward direction means: the distant node
+            # references the candidate (outgoing edge from distant → candidate).
+            bridge_counts: dict[str, int] = {}
+            for distant in distant_nodes:
+                # What does this distant node reference?
+                cited_by_distant = self._get_bfs_neighbors(
+                    distant, radius=1, direction="outgoing"
+                )
+                for cited in cited_by_distant:
+                    if cited in r2_set:
+                        bridge_counts[cited] = bridge_counts.get(cited, 0) + 1
+
+            # Keep only candidates with sufficient co-citation bridge count.
+            bridge_candidates = {
+                nid: count
+                for nid, count in bridge_counts.items()
+                if count >= _BRIDGE_MIN_DISTANT_CO_CITERS
+            }
+
+            if not bridge_candidates:
+                logger.info(
+                    "recommender_seed_isolated_returns_empty",
+                    seed_id=seed_id,
+                    strategy=strategy.value,
+                )
+                return []
+
+            # Normalize bridge counts.
+            normalized = _normalize_scores(
+                {k: float(v) for k, v in bridge_candidates.items()}
+            )
+
+            ranked = sorted(
+                bridge_candidates.keys(),
+                key=lambda nid: normalized.get(nid, 0.0),
+                reverse=True,
+            )
+            ranked = ranked[:k]
+
+            recommendations: list[Recommendation] = []
+            for nid in ranked:
+                raw_count = bridge_candidates[nid]
+                norm_score = normalized.get(nid, 0.0)
+                reasoning = (
+                    f"Bridge paper: co-cited by {raw_count} distant papers "
+                    f"(radius >{_BFS_RADIUS_SIMILAR}) in the citation frontier"
+                )
+                recommendations.append(
+                    Recommendation(
+                        paper_id=nid,
+                        score=norm_score,
+                        strategy=strategy,
+                        reasoning=reasoning,
+                        seed_paper_id=seed_id,
+                    )
+                )
+
+            logger.info(
+                "recommender_strategy_complete",
+                seed_id=seed_id,
+                strategy=strategy.value,
+                count=len(recommendations),
+            )
+            return recommendations
+
+        except Exception as exc:
+            logger.error(
+                "recommender_strategy_failed",
+                seed_id=seed_id,
+                strategy=strategy.value,
+                error=repr(str(exc)[:512]),
+            )
+            raise
+
+    async def recommend_all(
+        self, seed_id: str, k_per_strategy: int = 5
+    ) -> dict[RecommendationStrategy, list[Recommendation]]:
+        """Run all four strategies concurrently and return a combined dict.
+
+        Uses ``asyncio.gather`` so the four strategies overlap their I/O
+        instead of running sequentially.
+
+        Args:
+            seed_id: Canonical node id of the seed paper.
+            k_per_strategy: ``k`` passed to each individual strategy.
+
+        Returns:
+            A dict mapping each :class:`RecommendationStrategy` to its
+            list of :class:`Recommendation` objects.
+
+        Raises:
+            ValueError: If ``seed_id`` is malformed.
+            Exception: Re-raises any exception from a failing strategy
+                (first exception wins; see asyncio.gather semantics).
+        """
+        _validate_paper_id(seed_id)
+        results = await asyncio.gather(
+            self.recommend_similar(seed_id, k=k_per_strategy),
+            self.recommend_influential_predecessors(seed_id, k=k_per_strategy),
+            self.recommend_active_successors(seed_id, k=k_per_strategy),
+            self.recommend_bridge_papers(seed_id, k=k_per_strategy),
+        )
+        return {
+            RecommendationStrategy.SIMILAR: results[0],
+            RecommendationStrategy.INFLUENTIAL_PREDECESSOR: results[1],
+            RecommendationStrategy.ACTIVE_SUCCESSOR: results[2],
+            RecommendationStrategy.BRIDGE: results[3],
+        }
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _get_bfs_neighbors(
+        self,
+        node_id: str,
+        radius: int,
+        direction: str = "both",
+    ) -> list[str]:
+        """Return all node ids reachable from ``node_id`` within ``radius`` hops.
+
+        Uses :meth:`SQLiteGraphStore.traverse` with the CITES edge type.
+        The returned list excludes the start node itself.
+
+        Args:
+            node_id: Starting node id.
+            radius: Maximum BFS depth.
+            direction: ``"outgoing"``, ``"incoming"``, or ``"both"``.
+
+        Returns:
+            List of neighbor node ids (order not guaranteed).
+        """
+        from src.services.intelligence.models import EdgeType
+
+        nodes = self._store.traverse(
+            node_id,
+            edge_types=[EdgeType.CITES],
+            max_depth=radius,
+            direction=direction,
+        )
+        return [n.node_id for n in nodes]
+
+    def _filter_by_year(self, node_ids: list[str], cutoff_year: int) -> list[str]:
+        """Return only node ids whose stored year is >= ``cutoff_year``.
+
+        Nodes without a year property (or whose property is missing from
+        the graph) are excluded.
+
+        Args:
+            node_ids: Candidate node ids to check.
+            cutoff_year: Minimum publication year (inclusive).
+
+        Returns:
+            Filtered list of node ids.
+        """
+        kept: list[str] = []
+        for nid in node_ids:
+            node = self._store.get_node(nid)
+            if node is None:
+                continue
+            props = node.properties or {}
+            year = props.get("year")
+            if year is None:
+                # Try publication_date as fallback.
+                pub_date_str = props.get("publication_date")
+                if pub_date_str:
+                    try:
+                        year = int(pub_date_str[:4])
+                    except (ValueError, TypeError):
+                        year = None
+            if year is not None:
+                try:
+                    year_int = int(year)
+                except (ValueError, TypeError):
+                    continue
+                if year_int >= cutoff_year:
+                    kept.append(nid)
+        return kept
+
+    def _hop_count(
+        self, source_id: str, target_id: str, direction: str = "outgoing"
+    ) -> int:
+        """Return the BFS hop distance from ``source_id`` to ``target_id``.
+
+        Uses progressive BFS (depth 1, 2, 3) to find the first depth at
+        which ``target_id`` appears. Returns 1 if not found (safe fallback
+        — the caller uses this only for reasoning string generation).
+
+        Args:
+            source_id: BFS origin.
+            target_id: Target node to search for.
+            direction: ``"outgoing"``, ``"incoming"``, or ``"both"``.
+
+        Returns:
+            Hop count, or 1 if not reachable within 3 hops.
+        """
+        for depth in range(1, 4):
+            neighbors = self._get_bfs_neighbors(
+                source_id, radius=depth, direction=direction
+            )
+            if target_id in neighbors:
+                return depth
+        return 1

--- a/src/storage/intelligence_graph/unified_graph.py
+++ b/src/storage/intelligence_graph/unified_graph.py
@@ -1145,6 +1145,47 @@ class SQLiteGraphStore:
         finally:
             conn.close()
 
+    def _list_outgoing_edges_for_nodes(
+        self,
+        source_ids: list[str],
+        edge_type_values: list[str],
+    ) -> dict[str, list[str]]:
+        """Return outgoing edge targets grouped by source, for the given nodes.
+
+        Issues a single SQL query instead of one traverse call per node,
+        making it suitable for bulk bridge-paper detection.  Only direct
+        (depth-1) outgoing edges are returned.
+
+        Args:
+            source_ids: Node ids whose outgoing edges should be fetched.
+            edge_type_values: Edge-type string values to filter by.
+
+        Returns:
+            A dict mapping each source id to its list of target node ids.
+            Source ids with no outgoing edges are absent from the dict.
+        """
+        if not source_ids or not edge_type_values:
+            return {}
+        conn = self._get_connection()
+        try:
+            src_placeholders = ",".join("?" * len(source_ids))
+            type_placeholders = ",".join("?" * len(edge_type_values))
+            cursor = conn.execute(
+                f"""
+                SELECT source_id, target_id FROM edges
+                WHERE source_id IN ({src_placeholders})
+                  AND edge_type IN ({type_placeholders})
+                """,
+                tuple(source_ids) + tuple(edge_type_values),
+            )
+            result: dict[str, list[str]] = {}
+            for row in cursor.fetchall():
+                src = row["source_id"]
+                result.setdefault(src, []).append(row["target_id"])
+            return result
+        finally:
+            conn.close()
+
     # Metrics
 
     def get_node_count(self, node_type: Optional[NodeType] = None) -> int:

--- a/tests/unit/services/intelligence/citation/test_recommender.py
+++ b/tests/unit/services/intelligence/citation/test_recommender.py
@@ -501,11 +501,11 @@ async def test_recommend_bridge_papers_identifies_connectors(monkeypatch) -> Non
     r2_nodes = [_make_graph_node(_P1), _make_graph_node(_P2), _make_graph_node(_P3)]
     r3_nodes = r2_nodes + [_make_graph_node(_P4), _make_graph_node(_P5)]
 
-    # Store.traverse is called multiple times:
+    # Store.traverse is called twice:
     # 1st call: radius=2 outgoing → r2_nodes (candidates)
     # 2nd call: radius=3 outgoing → r3_nodes (frontier)
-    # 3rd call: radius=1 outgoing from P4 → [P1, P2] (P4 → P1, P4 → P2)
-    # 4th call: radius=1 outgoing from P5 → [P1] (P5 → P1)
+    # Then _list_outgoing_edges_for_nodes is called once with [P4, P5]:
+    #   P4 → [P1, P2], P5 → [P1]
 
     call_count = [0]
 
@@ -513,20 +513,18 @@ async def test_recommend_bridge_papers_identifies_connectors(monkeypatch) -> Non
         call_count[0] += 1
         c = call_count[0]
         if c == 1:
-            # radius-2 backward: candidates
             return r2_nodes
         elif c == 2:
-            # radius-3 backward: full frontier
             return r3_nodes
-        elif c == 3 and node_id == _P4:
-            return [_make_graph_node(_P1), _make_graph_node(_P2)]
-        elif c == 4 and node_id == _P5:
-            return [_make_graph_node(_P1)]
         return []
 
     mock_store = MagicMock()
     mock_store.traverse = MagicMock(side_effect=_traverse_side_effect)
     mock_store.get_node = MagicMock(return_value=None)
+    # Bulk query: P4 cites P1+P2, P5 cites P1
+    mock_store._list_outgoing_edges_for_nodes = MagicMock(
+        return_value={_P4: [_P1, _P2], _P5: [_P1]}
+    )
 
     rec = CitationRecommender(
         coupling=AsyncMock(),
@@ -581,14 +579,13 @@ async def test_recommend_bridge_papers_no_bridges_below_threshold(
             return r2_nodes
         elif c == 2:
             return r3_nodes
-        elif c == 3:
-            # P4 only references P1 once (count=1 < threshold of 2)
-            return [_make_graph_node(_P1)]
         return []
 
     mock_store = MagicMock()
     mock_store.traverse = MagicMock(side_effect=_traverse_se)
     mock_store.get_node = MagicMock(return_value=None)
+    # P4 only references P1 once (count=1 < threshold of 2)
+    mock_store._list_outgoing_edges_for_nodes = MagicMock(return_value={_P4: [_P1]})
 
     rec = CitationRecommender(
         coupling=AsyncMock(),
@@ -777,7 +774,7 @@ def test_score_normalization_preserves_ordering() -> None:
 async def test_recommend_bridge_no_distant_nodes(monkeypatch) -> None:
     """When radius-3 frontier equals radius-2 (no distant nodes), return empty."""
     r2_nodes = [_make_graph_node(_P1), _make_graph_node(_P2)]
-    # r3 == r2 → no distant nodes → no bridges
+    # r3 == r2 → no distant nodes → _list_outgoing_edges_for_nodes called with []
     call_count = [0]
 
     def _traverse_se(node_id, edge_types, max_depth, direction="both"):
@@ -789,6 +786,7 @@ async def test_recommend_bridge_no_distant_nodes(monkeypatch) -> None:
     mock_store = MagicMock()
     mock_store.traverse = MagicMock(side_effect=_traverse_se)
     mock_store.get_node = MagicMock(return_value=None)
+    mock_store._list_outgoing_edges_for_nodes = MagicMock(return_value={})
 
     rec = CitationRecommender(
         coupling=AsyncMock(),
@@ -1182,14 +1180,13 @@ async def test_recommend_bridge_distant_cites_outside_r2_ignored(
             return r2_nodes
         elif c == 2:
             return r3_nodes
-        elif c == 3 and node_id == _P4:
-            # P4 cites P5 only (not in r2) → the false branch at 488->487
-            return [_make_graph_node(_P5)]
         return []
 
     mock_store = MagicMock()
     mock_store.traverse = MagicMock(side_effect=_traverse_se)
     mock_store.get_node = MagicMock(return_value=None)
+    # P4 cites P5 only (not in r2) → count stays 0
+    mock_store._list_outgoing_edges_for_nodes = MagicMock(return_value={_P4: [_P5]})
 
     rec = CitationRecommender(
         coupling=AsyncMock(),

--- a/tests/unit/services/intelligence/citation/test_recommender.py
+++ b/tests/unit/services/intelligence/citation/test_recommender.py
@@ -1,0 +1,1256 @@
+"""Tests for CitationRecommender (Issue #130, REQ-9.2.5).
+
+Conventions (from CLAUDE.md and PR #143 lessons):
+- Use ``monkeypatch.setattr(target_module, "logger", structlog.get_logger())``
+  *before* entering ``capture_logs()`` to rebind the cached logger.
+- All ``pytest.raises`` calls include ``match=``.
+- Mock ``CouplingAnalyzerProtocol``, ``CitationCrawler``, and ``InfluenceScorer``
+  at the module's *namespace* boundary (NOT patch internal methods).
+- ``pytest.mark.asyncio`` on every async test (asyncio_mode = "strict").
+- Use ``assert_called_once_with(...)`` — never bare ``assert_called_once()``.
+- No bare ``assert_called_once()``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import random
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import structlog
+import structlog.testing
+
+from src.services.intelligence.citation import recommender as recommender_module
+from src.services.intelligence.citation.coupling_protocol import CouplingResult
+from src.services.intelligence.citation.influence_scorer import InfluenceMetrics
+from src.services.intelligence.citation.models import (
+    Recommendation,
+    RecommendationStrategy,
+)
+from src.services.intelligence.citation.recommender import (
+    CitationRecommender,
+    _normalize_scores,
+    _validate_paper_id,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SEED = "paper:s2:seed001"
+_P1 = "paper:s2:cand001"
+_P2 = "paper:s2:cand002"
+_P3 = "paper:s2:cand003"
+_P4 = "paper:s2:cand004"
+_P5 = "paper:s2:cand005"
+
+
+def _make_metrics(
+    paper_id: str,
+    *,
+    pagerank: float = 0.1,
+    velocity: float = 5.0,
+    citation_count: int = 10,
+) -> InfluenceMetrics:
+    return InfluenceMetrics(
+        paper_id=paper_id,
+        pagerank_score=pagerank,
+        citation_velocity=velocity,
+        citation_count=citation_count,
+        computed_at=datetime.now(timezone.utc),
+    )
+
+
+def _coupling_result(
+    seed: str,
+    other: str,
+    strength: float = 0.5,
+    shared: int = 5,
+    jaccard: float = 0.3,
+) -> CouplingResult:
+    return CouplingResult(
+        paper_a_id=seed,
+        paper_b_id=other,
+        coupling_strength=strength,
+        shared_reference_count=shared,
+        jaccard_index=jaccard,
+    )
+
+
+def _make_graph_node(node_id: str, year: int | None = None) -> MagicMock:
+    node = MagicMock()
+    node.node_id = node_id
+    props: dict[str, Any] = {}
+    if year is not None:
+        props["year"] = year
+    node.properties = props
+    return node
+
+
+def _build_recommender(
+    *,
+    traverse_returns: list[Any] | None = None,
+    coupling_results: list[CouplingResult] | None = None,
+    metrics_map: dict[str, InfluenceMetrics] | None = None,
+    get_node_returns: dict[str, Any] | None = None,
+) -> tuple[CitationRecommender, MagicMock, MagicMock, MagicMock, MagicMock]:
+    """Build a CitationRecommender with mocked collaborators.
+
+    Returns:
+        (recommender, mock_coupling, mock_crawler, mock_scorer, mock_store)
+    """
+    mock_coupling = AsyncMock()
+    mock_coupling.analyze_for_paper = AsyncMock(return_value=coupling_results or [])
+
+    mock_crawler = MagicMock()
+
+    mock_scorer = AsyncMock()
+
+    # Build metrics list from map
+    m_map = metrics_map or {}
+
+    async def _compute_for_graph(node_ids: list[str]) -> list[InfluenceMetrics]:
+        return [m_map.get(nid, _make_metrics(nid)) for nid in node_ids]
+
+    mock_scorer.compute_for_graph = _compute_for_graph
+
+    mock_store = MagicMock()
+    mock_store.traverse = MagicMock(return_value=traverse_returns or [])
+
+    g_n = get_node_returns or {}
+    mock_store.get_node = MagicMock(side_effect=lambda nid: g_n.get(nid))
+
+    rec = CitationRecommender(
+        coupling=mock_coupling,
+        crawler=mock_crawler,
+        scorer=mock_scorer,
+        store=mock_store,
+    )
+    return rec, mock_coupling, mock_crawler, mock_scorer, mock_store
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for helpers
+# ---------------------------------------------------------------------------
+
+
+def test_validate_paper_id_accepts_valid() -> None:
+    """Valid canonical paper ids should not raise."""
+    _validate_paper_id("paper:s2:abc123")
+    _validate_paper_id("paper:s2:abc-def_ghi.jkl")
+
+
+def test_validate_paper_id_rejects_empty() -> None:
+    with pytest.raises(ValueError, match="non-empty string"):
+        _validate_paper_id("")
+
+
+def test_validate_paper_id_rejects_too_long() -> None:
+    with pytest.raises(ValueError, match="exceeds max"):
+        _validate_paper_id("a" * 513)
+
+
+def test_validate_paper_id_rejects_slash() -> None:
+    with pytest.raises(ValueError, match="Invalid paper_id format"):
+        _validate_paper_id("paper/slash")
+
+
+def test_normalize_scores_empty() -> None:
+    assert _normalize_scores({}) == {}
+
+
+def test_normalize_scores_all_zero() -> None:
+    assert _normalize_scores({"a": 0.0, "b": 0.0}) == {"a": 0.0, "b": 0.0}
+
+
+def test_normalize_scores_scales_to_one() -> None:
+    result = _normalize_scores({"a": 2.0, "b": 4.0, "c": 1.0})
+    assert result["b"] == pytest.approx(1.0)
+    assert result["a"] == pytest.approx(0.5)
+    assert result["c"] == pytest.approx(0.25)
+
+
+# ---------------------------------------------------------------------------
+# Recommendation model tests
+# ---------------------------------------------------------------------------
+
+
+def test_recommendation_score_bounded_zero_to_one() -> None:
+    """All recommendations must have score in [0.0, 1.0] (fuzz test)."""
+    rng = random.Random(42)
+    for _ in range(50):
+        score = rng.uniform(0.0, 1.0)
+        rec = Recommendation(
+            paper_id=_P1,
+            score=score,
+            strategy=RecommendationStrategy.SIMILAR,
+            reasoning="test",
+            seed_paper_id=_SEED,
+        )
+        assert 0.0 <= rec.score <= 1.0
+
+
+def test_recommendation_rejects_self_recommendation() -> None:
+    """seed_paper_id == paper_id must raise a validation error."""
+    with pytest.raises(Exception, match="must differ"):
+        Recommendation(
+            paper_id=_SEED,
+            score=0.5,
+            strategy=RecommendationStrategy.SIMILAR,
+            reasoning="bad",
+            seed_paper_id=_SEED,
+        )
+
+
+def test_recommendation_rejects_empty_reasoning() -> None:
+    with pytest.raises(Exception, match="at least 1 character"):
+        Recommendation(
+            paper_id=_P1,
+            score=0.5,
+            strategy=RecommendationStrategy.SIMILAR,
+            reasoning="",
+            seed_paper_id=_SEED,
+        )
+
+
+def test_recommendation_rejects_invalid_paper_id() -> None:
+    with pytest.raises(Exception, match="Invalid paper id format"):
+        Recommendation(
+            paper_id="bad/id",
+            score=0.5,
+            strategy=RecommendationStrategy.SIMILAR,
+            reasoning="ok",
+            seed_paper_id=_SEED,
+        )
+
+
+def test_recommendation_rejects_whitespace_only_paper_id() -> None:
+    """Empty (whitespace) paper_id should raise 'paper id cannot be empty'."""
+    with pytest.raises(Exception, match="paper id cannot be empty"):
+        Recommendation(
+            paper_id="   ",
+            score=0.5,
+            strategy=RecommendationStrategy.SIMILAR,
+            reasoning="ok",
+            seed_paper_id=_SEED,
+        )
+
+
+# ---------------------------------------------------------------------------
+# CouplingResult model tests
+# ---------------------------------------------------------------------------
+
+
+def test_coupling_result_rejects_invalid_id() -> None:
+    with pytest.raises(Exception, match="Invalid paper_a_id format"):
+        CouplingResult(
+            paper_a_id="bad/id",
+            paper_b_id=_P1,
+            coupling_strength=0.5,
+        )
+
+
+def test_coupling_result_rejects_out_of_range_strength() -> None:
+    with pytest.raises(Exception, match="less than or equal to 1"):
+        CouplingResult(
+            paper_a_id=_SEED,
+            paper_b_id=_P1,
+            coupling_strength=1.5,
+        )
+
+
+# ---------------------------------------------------------------------------
+# recommend_similar
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recommend_similar_returns_top_k_by_coupling(monkeypatch) -> None:
+    """recommend_similar returns recommendations ordered by coupling_strength."""
+    coupling_results = [
+        _coupling_result(_SEED, _P1, strength=0.9, shared=10, jaccard=0.5),
+        _coupling_result(_SEED, _P2, strength=0.6, shared=6, jaccard=0.3),
+        _coupling_result(_SEED, _P3, strength=0.3, shared=3, jaccard=0.15),
+    ]
+    traverse_nodes = [
+        _make_graph_node(_P1),
+        _make_graph_node(_P2),
+        _make_graph_node(_P3),
+    ]
+    rec, mock_coupling, _, _, _ = _build_recommender(
+        traverse_returns=traverse_nodes,
+        coupling_results=coupling_results,
+    )
+
+    monkeypatch.setattr(recommender_module, "logger", structlog.get_logger())
+    with structlog.testing.capture_logs() as cap_logs:
+        results = await rec.recommend_similar(_SEED, k=2)
+
+    assert len(results) == 2
+    assert results[0].paper_id == _P1
+    assert results[0].score == pytest.approx(0.9)
+    assert results[0].strategy == RecommendationStrategy.SIMILAR
+    assert "Jaccard=0.50" in results[0].reasoning
+    assert results[1].paper_id == _P2
+
+    events = [e["event"] for e in cap_logs]
+    assert "recommender_strategy_complete" in events
+
+    mock_coupling.analyze_for_paper.assert_called_once_with(
+        _SEED, [_P1, _P2, _P3], top_k=2
+    )
+
+
+@pytest.mark.asyncio
+async def test_recommend_similar_with_isolated_seed_returns_empty(monkeypatch) -> None:
+    """When the BFS finds no neighbors, return [] and log seed_isolated."""
+    rec, _, _, _, _ = _build_recommender(traverse_returns=[])
+
+    monkeypatch.setattr(recommender_module, "logger", structlog.get_logger())
+    with structlog.testing.capture_logs() as cap_logs:
+        results = await rec.recommend_similar(_SEED, k=10)
+
+    assert results == []
+    events = [e["event"] for e in cap_logs]
+    assert "recommender_seed_isolated_returns_empty" in events
+
+
+@pytest.mark.asyncio
+async def test_recommend_similar_invalid_seed_raises() -> None:
+    """Malformed seed id raises ValueError before any I/O."""
+    rec, _, _, _, _ = _build_recommender()
+    with pytest.raises(ValueError, match="Invalid paper_id format"):
+        await rec.recommend_similar("bad/seed", k=5)
+
+
+# ---------------------------------------------------------------------------
+# recommend_influential_predecessors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recommend_influential_predecessors_uses_backward_crawl(
+    monkeypatch,
+) -> None:
+    """Influential predecessors are ranked by pagerank_score descending."""
+    metrics_map = {
+        _P1: _make_metrics(_P1, pagerank=0.8),
+        _P2: _make_metrics(_P2, pagerank=0.4),
+        _P3: _make_metrics(_P3, pagerank=0.1),
+    }
+    traverse_nodes = [
+        _make_graph_node(_P1),
+        _make_graph_node(_P2),
+        _make_graph_node(_P3),
+    ]
+    rec, _, _, _, mock_store = _build_recommender(
+        traverse_returns=traverse_nodes,
+        metrics_map=metrics_map,
+    )
+
+    monkeypatch.setattr(recommender_module, "logger", structlog.get_logger())
+    with structlog.testing.capture_logs() as cap_logs:
+        results = await rec.recommend_influential_predecessors(_SEED, k=3)
+
+    assert len(results) == 3
+    assert results[0].paper_id == _P1
+    assert results[0].score == pytest.approx(0.8)
+    assert results[0].strategy == RecommendationStrategy.INFLUENTIAL_PREDECESSOR
+    assert "PageRank=0.8000" in results[0].reasoning
+    assert results[1].paper_id == _P2
+
+    events = [e["event"] for e in cap_logs]
+    assert "recommender_strategy_complete" in events
+
+    # Store must have been called with the CITES edge type via traverse
+    assert mock_store.traverse.called
+
+
+@pytest.mark.asyncio
+async def test_recommend_influential_predecessors_isolated_returns_empty(
+    monkeypatch,
+) -> None:
+    rec, _, _, _, _ = _build_recommender(traverse_returns=[])
+
+    monkeypatch.setattr(recommender_module, "logger", structlog.get_logger())
+    with structlog.testing.capture_logs() as cap_logs:
+        results = await rec.recommend_influential_predecessors(_SEED, k=5)
+
+    assert results == []
+    events = [e["event"] for e in cap_logs]
+    assert "recommender_seed_isolated_returns_empty" in events
+
+
+# ---------------------------------------------------------------------------
+# recommend_active_successors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recommend_active_successors_filters_by_year(monkeypatch) -> None:
+    """Only papers published within the last 2 years are returned."""
+    from src.services.intelligence.citation import recommender as rm
+
+    current_year = rm._current_year()
+    cutoff = current_year - 2
+
+    old_node = _make_graph_node(_P1, year=cutoff - 1)  # too old
+    new_node = _make_graph_node(_P2, year=current_year)  # recent
+
+    metrics_map = {
+        _P2: _make_metrics(_P2, velocity=10.0),
+    }
+    traverse_nodes = [old_node, new_node]
+    get_node_returns = {
+        _P1: old_node,
+        _P2: new_node,
+    }
+    rec, _, _, _, _ = _build_recommender(
+        traverse_returns=traverse_nodes,
+        metrics_map=metrics_map,
+        get_node_returns=get_node_returns,
+    )
+
+    monkeypatch.setattr(recommender_module, "logger", structlog.get_logger())
+    with structlog.testing.capture_logs() as cap_logs:
+        results = await rec.recommend_active_successors(_SEED, k=10)
+
+    # Only the recent paper makes it through.
+    paper_ids = [r.paper_id for r in results]
+    assert _P2 in paper_ids
+    assert _P1 not in paper_ids
+
+    events = [e["event"] for e in cap_logs]
+    assert "recommender_strategy_complete" in events
+
+
+@pytest.mark.asyncio
+async def test_recommend_active_successors_ranks_by_velocity(monkeypatch) -> None:
+    """Active successors are sorted by normalized citation_velocity."""
+    from src.services.intelligence.citation import recommender as rm
+
+    current_year = rm._current_year()
+
+    n1 = _make_graph_node(_P1, year=current_year)
+    n2 = _make_graph_node(_P2, year=current_year)
+    n3 = _make_graph_node(_P3, year=current_year)
+
+    metrics_map = {
+        _P1: _make_metrics(_P1, velocity=5.0),
+        _P2: _make_metrics(_P2, velocity=20.0),  # highest
+        _P3: _make_metrics(_P3, velocity=10.0),
+    }
+    get_node_returns = {_P1: n1, _P2: n2, _P3: n3}
+    traverse_nodes = [n1, n2, n3]
+
+    rec, _, _, _, _ = _build_recommender(
+        traverse_returns=traverse_nodes,
+        metrics_map=metrics_map,
+        get_node_returns=get_node_returns,
+    )
+
+    monkeypatch.setattr(recommender_module, "logger", structlog.get_logger())
+    results = await rec.recommend_active_successors(_SEED, k=3)
+
+    assert len(results) == 3
+    assert results[0].paper_id == _P2  # highest velocity
+    assert results[0].score == pytest.approx(1.0)  # normalized
+    assert results[1].paper_id == _P3
+    assert results[2].paper_id == _P1
+
+
+@pytest.mark.asyncio
+async def test_recommend_active_successors_no_recent_papers(monkeypatch) -> None:
+    """All papers older than cutoff → empty result, log seed_isolated."""
+    from src.services.intelligence.citation import recommender as rm
+
+    current_year = rm._current_year()
+    old_node = _make_graph_node(_P1, year=current_year - 10)
+    get_node_returns = {_P1: old_node}
+
+    rec, _, _, _, _ = _build_recommender(
+        traverse_returns=[old_node],
+        get_node_returns=get_node_returns,
+    )
+
+    monkeypatch.setattr(recommender_module, "logger", structlog.get_logger())
+    with structlog.testing.capture_logs() as cap_logs:
+        results = await rec.recommend_active_successors(_SEED, k=10)
+
+    assert results == []
+    events = [e["event"] for e in cap_logs]
+    assert "recommender_seed_isolated_returns_empty" in events
+
+
+# ---------------------------------------------------------------------------
+# recommend_bridge_papers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recommend_bridge_papers_identifies_connectors(monkeypatch) -> None:
+    """Papers co-cited by ≥2 distant papers are identified as bridges."""
+    # BFS radius-2 neighbors of seed: [P1, P2, P3]
+    # BFS radius-3 additional distant nodes: [P4, P5] (not in r2)
+    # P4 and P5 both reference P1 → P1 is a bridge with count=2.
+    # P4 references P2 → P2 has count=1 (below threshold).
+
+    r2_nodes = [_make_graph_node(_P1), _make_graph_node(_P2), _make_graph_node(_P3)]
+    r3_nodes = r2_nodes + [_make_graph_node(_P4), _make_graph_node(_P5)]
+
+    # Store.traverse is called multiple times:
+    # 1st call: radius=2 outgoing → r2_nodes (candidates)
+    # 2nd call: radius=3 outgoing → r3_nodes (frontier)
+    # 3rd call: radius=1 outgoing from P4 → [P1, P2] (P4 → P1, P4 → P2)
+    # 4th call: radius=1 outgoing from P5 → [P1] (P5 → P1)
+
+    call_count = [0]
+
+    def _traverse_side_effect(node_id, edge_types, max_depth, direction="both"):
+        call_count[0] += 1
+        c = call_count[0]
+        if c == 1:
+            # radius-2 backward: candidates
+            return r2_nodes
+        elif c == 2:
+            # radius-3 backward: full frontier
+            return r3_nodes
+        elif c == 3 and node_id == _P4:
+            return [_make_graph_node(_P1), _make_graph_node(_P2)]
+        elif c == 4 and node_id == _P5:
+            return [_make_graph_node(_P1)]
+        return []
+
+    mock_store = MagicMock()
+    mock_store.traverse = MagicMock(side_effect=_traverse_side_effect)
+    mock_store.get_node = MagicMock(return_value=None)
+
+    rec = CitationRecommender(
+        coupling=AsyncMock(),
+        crawler=MagicMock(),
+        scorer=AsyncMock(),
+        store=mock_store,
+    )
+
+    monkeypatch.setattr(recommender_module, "logger", structlog.get_logger())
+    with structlog.testing.capture_logs() as cap_logs:
+        results = await rec.recommend_bridge_papers(_SEED, k=5)
+
+    paper_ids = [r.paper_id for r in results]
+    assert _P1 in paper_ids  # co-cited by P4 and P5 (count=2 ≥ threshold)
+    assert _P2 not in paper_ids  # only co-cited by P4 (count=1 < threshold)
+
+    assert results[0].strategy == RecommendationStrategy.BRIDGE
+    assert results[0].score == pytest.approx(1.0)  # P1 is the only bridge → max
+
+    events = [e["event"] for e in cap_logs]
+    assert "recommender_strategy_complete" in events
+
+
+@pytest.mark.asyncio
+async def test_recommend_bridge_papers_isolated_seed(monkeypatch) -> None:
+    """Seed with no neighbors returns empty."""
+    rec, _, _, _, _ = _build_recommender(traverse_returns=[])
+
+    monkeypatch.setattr(recommender_module, "logger", structlog.get_logger())
+    with structlog.testing.capture_logs() as cap_logs:
+        results = await rec.recommend_bridge_papers(_SEED, k=5)
+
+    assert results == []
+    events = [e["event"] for e in cap_logs]
+    assert "recommender_seed_isolated_returns_empty" in events
+
+
+@pytest.mark.asyncio
+async def test_recommend_bridge_papers_no_bridges_below_threshold(
+    monkeypatch,
+) -> None:
+    """No candidate meets the min-distant-co-citers threshold → empty + log."""
+    r2_nodes = [_make_graph_node(_P1), _make_graph_node(_P2)]
+    r3_nodes = r2_nodes + [_make_graph_node(_P4)]
+
+    call_count = [0]
+
+    def _traverse_se(node_id, edge_types, max_depth, direction="both"):
+        call_count[0] += 1
+        c = call_count[0]
+        if c == 1:
+            return r2_nodes
+        elif c == 2:
+            return r3_nodes
+        elif c == 3:
+            # P4 only references P1 once (count=1 < threshold of 2)
+            return [_make_graph_node(_P1)]
+        return []
+
+    mock_store = MagicMock()
+    mock_store.traverse = MagicMock(side_effect=_traverse_se)
+    mock_store.get_node = MagicMock(return_value=None)
+
+    rec = CitationRecommender(
+        coupling=AsyncMock(),
+        crawler=MagicMock(),
+        scorer=AsyncMock(),
+        store=mock_store,
+    )
+
+    monkeypatch.setattr(recommender_module, "logger", structlog.get_logger())
+    with structlog.testing.capture_logs() as cap_logs:
+        results = await rec.recommend_bridge_papers(_SEED, k=5)
+
+    assert results == []
+    events = [e["event"] for e in cap_logs]
+    assert "recommender_seed_isolated_returns_empty" in events
+
+
+# ---------------------------------------------------------------------------
+# recommend_all
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recommend_all_returns_per_strategy(monkeypatch) -> None:
+    """recommend_all returns a dict with all four strategy keys."""
+    traverse_nodes = [_make_graph_node(_P1)]
+    coupling_results = [_coupling_result(_SEED, _P1)]
+    current_year = recommender_module._current_year()
+    get_node_returns = {_P1: _make_graph_node(_P1, year=current_year)}
+
+    rec, _, _, _, _ = _build_recommender(
+        traverse_returns=traverse_nodes,
+        coupling_results=coupling_results,
+        get_node_returns=get_node_returns,
+    )
+
+    monkeypatch.setattr(recommender_module, "logger", structlog.get_logger())
+    result = await rec.recommend_all(_SEED, k_per_strategy=1)
+
+    assert set(result.keys()) == set(RecommendationStrategy)
+    for strategy in RecommendationStrategy:
+        assert isinstance(result[strategy], list)
+
+
+@pytest.mark.asyncio
+async def test_recommend_all_runs_strategies_concurrently(monkeypatch) -> None:
+    """recommend_all invokes asyncio.gather (concurrent execution)."""
+    rec, _, _, _, _ = _build_recommender(traverse_returns=[])
+
+    gather_calls: list[Any] = []
+    original_gather = asyncio.gather
+
+    async def _mock_gather(*coros, **kwargs):
+        gather_calls.append(coros)
+        return await original_gather(*coros, **kwargs)
+
+    monkeypatch.setattr(recommender_module.asyncio, "gather", _mock_gather)
+    monkeypatch.setattr(recommender_module, "logger", structlog.get_logger())
+
+    await rec.recommend_all(_SEED, k_per_strategy=3)
+
+    # gather must have been called exactly once (the recommend_all call)
+    assert len(gather_calls) == 1
+    # It must have received exactly 4 coroutines (one per strategy)
+    assert len(gather_calls[0]) == 4
+
+
+@pytest.mark.asyncio
+async def test_recommend_all_invalid_seed_raises() -> None:
+    rec, _, _, _, _ = _build_recommender()
+    with pytest.raises(ValueError, match="Invalid paper_id format"):
+        await rec.recommend_all("bad/seed", k_per_strategy=5)
+
+
+# ---------------------------------------------------------------------------
+# invalid seed id tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invalid_seed_id_raises_similar() -> None:
+    rec, _, _, _, _ = _build_recommender()
+    with pytest.raises(ValueError, match="Invalid paper_id format"):
+        await rec.recommend_similar("bad/seed")
+
+
+@pytest.mark.asyncio
+async def test_invalid_seed_id_raises_predecessors() -> None:
+    rec, _, _, _, _ = _build_recommender()
+    with pytest.raises(ValueError, match="Invalid paper_id format"):
+        await rec.recommend_influential_predecessors("bad/seed")
+
+
+@pytest.mark.asyncio
+async def test_invalid_seed_id_raises_successors() -> None:
+    rec, _, _, _, _ = _build_recommender()
+    with pytest.raises(ValueError, match="Invalid paper_id format"):
+        await rec.recommend_active_successors("bad/seed")
+
+
+@pytest.mark.asyncio
+async def test_invalid_seed_id_raises_bridge() -> None:
+    rec, _, _, _, _ = _build_recommender()
+    with pytest.raises(ValueError, match="Invalid paper_id format"):
+        await rec.recommend_bridge_papers("bad/seed")
+
+
+# ---------------------------------------------------------------------------
+# Log event tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recommend_strategy_logs_failure_and_propagates(monkeypatch) -> None:
+    """When a strategy raises, ``recommender_strategy_failed`` is logged and
+    the exception propagates to the caller."""
+    mock_store = MagicMock()
+    mock_store.traverse = MagicMock(side_effect=RuntimeError("graph DB down"))
+
+    rec = CitationRecommender(
+        coupling=AsyncMock(),
+        crawler=MagicMock(),
+        scorer=AsyncMock(),
+        store=mock_store,
+    )
+
+    monkeypatch.setattr(recommender_module, "logger", structlog.get_logger())
+    with structlog.testing.capture_logs() as cap_logs:
+        with pytest.raises(RuntimeError, match="graph DB down"):
+            await rec.recommend_similar(_SEED, k=5)
+
+    events = [e["event"] for e in cap_logs]
+    assert "recommender_strategy_failed" in events
+
+
+@pytest.mark.asyncio
+async def test_recommend_strategy_complete_logged_on_success(monkeypatch) -> None:
+    """``recommender_strategy_complete`` is emitted on a successful strategy run."""
+    traverse_nodes = [_make_graph_node(_P1)]
+    coupling_results = [_coupling_result(_SEED, _P1)]
+
+    rec, _, _, _, _ = _build_recommender(
+        traverse_returns=traverse_nodes,
+        coupling_results=coupling_results,
+    )
+
+    monkeypatch.setattr(recommender_module, "logger", structlog.get_logger())
+    with structlog.testing.capture_logs() as cap_logs:
+        await rec.recommend_similar(_SEED, k=5)
+
+    events = [e["event"] for e in cap_logs]
+    assert "recommender_strategy_complete" in events
+
+
+# ---------------------------------------------------------------------------
+# Score normalization fuzz test
+# ---------------------------------------------------------------------------
+
+
+def test_score_normalization_within_zero_one() -> None:
+    """Fuzz test: _normalize_scores always produces values in [0.0, 1.0]."""
+    rng = random.Random(1234)
+    for _ in range(100):
+        n = rng.randint(1, 20)
+        raw = {f"paper:s2:p{i}": rng.uniform(0.0, 100.0) for i in range(n)}
+        normalized = _normalize_scores(raw)
+        for k, v in normalized.items():
+            assert 0.0 <= v <= 1.0, f"Score for {k} is {v}, expected in [0.0, 1.0]"
+
+
+def test_score_normalization_preserves_ordering() -> None:
+    """Normalization must not reorder scores."""
+    scores = {"a": 3.0, "b": 1.5, "c": 0.5}
+    normalized = _normalize_scores(scores)
+    ranked_before = sorted(scores, key=lambda k: scores[k], reverse=True)
+    ranked_after = sorted(normalized, key=lambda k: normalized[k], reverse=True)
+    assert ranked_before == ranked_after
+
+
+# ---------------------------------------------------------------------------
+# Integration-style: bridge heuristic with no distant nodes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recommend_bridge_no_distant_nodes(monkeypatch) -> None:
+    """When radius-3 frontier equals radius-2 (no distant nodes), return empty."""
+    r2_nodes = [_make_graph_node(_P1), _make_graph_node(_P2)]
+    # r3 == r2 → no distant nodes → no bridges
+    call_count = [0]
+
+    def _traverse_se(node_id, edge_types, max_depth, direction="both"):
+        call_count[0] += 1
+        if call_count[0] <= 2:
+            return r2_nodes
+        return []
+
+    mock_store = MagicMock()
+    mock_store.traverse = MagicMock(side_effect=_traverse_se)
+    mock_store.get_node = MagicMock(return_value=None)
+
+    rec = CitationRecommender(
+        coupling=AsyncMock(),
+        crawler=MagicMock(),
+        scorer=AsyncMock(),
+        store=mock_store,
+    )
+
+    monkeypatch.setattr(recommender_module, "logger", structlog.get_logger())
+    with structlog.testing.capture_logs() as cap_logs:
+        results = await rec.recommend_bridge_papers(_SEED, k=5)
+
+    assert results == []
+    events = [e["event"] for e in cap_logs]
+    assert "recommender_seed_isolated_returns_empty" in events
+
+
+# ---------------------------------------------------------------------------
+# Coverage gap: recommend_similar — seed appears as paper_b_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recommend_similar_skips_when_other_id_equals_seed(monkeypatch) -> None:
+    """When other_id resolves to seed_id, the coupling entry is skipped.
+
+    The skip branch (other_id == seed_id) is triggered via mock objects:
+    paper_a_id == seed → other = paper_b_id = seed → skip.
+    """
+    # Valid coupling result (other_id = P1, not seed)
+    mock_cr = MagicMock()
+    mock_cr.paper_a_id = _P1
+    mock_cr.paper_b_id = _SEED
+    mock_cr.coupling_strength = 0.8
+    mock_cr.jaccard_index = 0.4
+    mock_cr.shared_reference_count = 6
+
+    # This coupling result has paper_a_id == seed → other = paper_b_id = seed → SKIP
+    mock_cr_skip = MagicMock()
+    mock_cr_skip.paper_a_id = _SEED  # == seed → other = paper_b_id
+    mock_cr_skip.paper_b_id = _SEED  # other == seed → skipped
+    mock_cr_skip.coupling_strength = 0.9
+    mock_cr_skip.jaccard_index = 0.5
+    mock_cr_skip.shared_reference_count = 8
+
+    traverse_nodes = [_make_graph_node(_P1)]
+
+    mock_coupling = AsyncMock()
+    mock_coupling.analyze_for_paper = AsyncMock(return_value=[mock_cr_skip, mock_cr])
+    mock_store = MagicMock()
+    mock_store.traverse = MagicMock(return_value=traverse_nodes)
+    mock_store.get_node = MagicMock(return_value=None)
+
+    rec = CitationRecommender(
+        coupling=mock_coupling,
+        crawler=MagicMock(),
+        scorer=AsyncMock(),
+        store=mock_store,
+    )
+
+    monkeypatch.setattr(recommender_module, "logger", structlog.get_logger())
+    results = await rec.recommend_similar(_SEED, k=5)
+
+    # mock_cr_skip should be skipped; mock_cr other_id = P1 (not seed)
+    paper_ids = [r.paper_id for r in results]
+    assert _SEED not in paper_ids
+
+
+# ---------------------------------------------------------------------------
+# Coverage gap: exception propagation in other strategies
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recommend_influential_predecessors_logs_failure(monkeypatch) -> None:
+    """Failures in influential_predecessors log and propagate."""
+    mock_store = MagicMock()
+    mock_store.traverse = MagicMock(side_effect=RuntimeError("store error"))
+
+    rec = CitationRecommender(
+        coupling=AsyncMock(),
+        crawler=MagicMock(),
+        scorer=AsyncMock(),
+        store=mock_store,
+    )
+
+    monkeypatch.setattr(recommender_module, "logger", structlog.get_logger())
+    with structlog.testing.capture_logs() as cap_logs:
+        with pytest.raises(RuntimeError, match="store error"):
+            await rec.recommend_influential_predecessors(_SEED, k=5)
+
+    events = [e["event"] for e in cap_logs]
+    assert "recommender_strategy_failed" in events
+
+
+@pytest.mark.asyncio
+async def test_recommend_active_successors_logs_failure(monkeypatch) -> None:
+    """Failures in active_successors log and propagate."""
+    mock_store = MagicMock()
+    mock_store.traverse = MagicMock(side_effect=RuntimeError("db error"))
+
+    rec = CitationRecommender(
+        coupling=AsyncMock(),
+        crawler=MagicMock(),
+        scorer=AsyncMock(),
+        store=mock_store,
+    )
+
+    monkeypatch.setattr(recommender_module, "logger", structlog.get_logger())
+    with structlog.testing.capture_logs() as cap_logs:
+        with pytest.raises(RuntimeError, match="db error"):
+            await rec.recommend_active_successors(_SEED, k=5)
+
+    events = [e["event"] for e in cap_logs]
+    assert "recommender_strategy_failed" in events
+
+
+@pytest.mark.asyncio
+async def test_recommend_bridge_papers_logs_failure(monkeypatch) -> None:
+    """Failures in bridge_papers log and propagate."""
+    mock_store = MagicMock()
+    mock_store.traverse = MagicMock(side_effect=RuntimeError("bridge error"))
+
+    rec = CitationRecommender(
+        coupling=AsyncMock(),
+        crawler=MagicMock(),
+        scorer=AsyncMock(),
+        store=mock_store,
+    )
+
+    monkeypatch.setattr(recommender_module, "logger", structlog.get_logger())
+    with structlog.testing.capture_logs() as cap_logs:
+        with pytest.raises(RuntimeError, match="bridge error"):
+            await rec.recommend_bridge_papers(_SEED, k=5)
+
+    events = [e["event"] for e in cap_logs]
+    assert "recommender_strategy_failed" in events
+
+
+# ---------------------------------------------------------------------------
+# Coverage gap: _filter_by_year — publication_date fallback path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recommend_active_successors_uses_publication_date_fallback(
+    monkeypatch,
+) -> None:
+    """_filter_by_year falls back to publication_date when year is missing."""
+    from src.services.intelligence.citation import recommender as rm
+
+    current_year = rm._current_year()
+
+    # A node with no 'year' but a 'publication_date' string
+    node_with_pub_date = MagicMock()
+    node_with_pub_date.node_id = _P1
+    node_with_pub_date.properties = {"publication_date": f"{current_year}-06-01"}
+
+    # A node with no year and no publication_date → excluded
+    node_no_date = MagicMock()
+    node_no_date.node_id = _P2
+    node_no_date.properties = {}
+
+    metrics_map = {
+        _P1: _make_metrics(_P1, velocity=8.0),
+    }
+
+    mock_store = MagicMock()
+    mock_store.traverse = MagicMock(return_value=[node_with_pub_date, node_no_date])
+    mock_store.get_node = MagicMock(
+        side_effect=lambda nid: {
+            _P1: node_with_pub_date,
+            _P2: node_no_date,
+        }.get(nid)
+    )
+
+    async def _compute_for_graph(node_ids):
+        return [metrics_map.get(nid, _make_metrics(nid)) for nid in node_ids]
+
+    mock_scorer = AsyncMock()
+    mock_scorer.compute_for_graph = _compute_for_graph
+
+    rec = CitationRecommender(
+        coupling=AsyncMock(),
+        crawler=MagicMock(),
+        scorer=mock_scorer,
+        store=mock_store,
+    )
+
+    monkeypatch.setattr(recommender_module, "logger", structlog.get_logger())
+    results = await rec.recommend_active_successors(_SEED, k=5)
+
+    paper_ids = [r.paper_id for r in results]
+    assert _P1 in paper_ids
+    assert _P2 not in paper_ids
+
+
+@pytest.mark.asyncio
+async def test_recommend_active_successors_bad_publication_date_excluded(
+    monkeypatch,
+) -> None:
+    """Nodes with unparseable publication_date are excluded from active successors."""
+    node_bad_date = MagicMock()
+    node_bad_date.node_id = _P1
+    node_bad_date.properties = {"publication_date": "not-a-date"}
+
+    mock_store = MagicMock()
+    mock_store.traverse = MagicMock(return_value=[node_bad_date])
+    mock_store.get_node = MagicMock(return_value=node_bad_date)
+
+    rec = CitationRecommender(
+        coupling=AsyncMock(),
+        crawler=MagicMock(),
+        scorer=AsyncMock(),
+        store=mock_store,
+    )
+
+    monkeypatch.setattr(recommender_module, "logger", structlog.get_logger())
+    with structlog.testing.capture_logs() as cap_logs:
+        results = await rec.recommend_active_successors(_SEED, k=5)
+
+    assert results == []
+    events = [e["event"] for e in cap_logs]
+    assert "recommender_seed_isolated_returns_empty" in events
+
+
+@pytest.mark.asyncio
+async def test_recommend_active_successors_bad_year_value_excluded(
+    monkeypatch,
+) -> None:
+    """Nodes with non-integer year values are excluded from active successors."""
+    node_bad_year = MagicMock()
+    node_bad_year.node_id = _P1
+    node_bad_year.properties = {"year": "not-a-year"}
+
+    mock_store = MagicMock()
+    mock_store.traverse = MagicMock(return_value=[node_bad_year])
+    mock_store.get_node = MagicMock(return_value=node_bad_year)
+
+    rec = CitationRecommender(
+        coupling=AsyncMock(),
+        crawler=MagicMock(),
+        scorer=AsyncMock(),
+        store=mock_store,
+    )
+
+    monkeypatch.setattr(recommender_module, "logger", structlog.get_logger())
+    with structlog.testing.capture_logs() as cap_logs:
+        results = await rec.recommend_active_successors(_SEED, k=5)
+
+    assert results == []
+    events = [e["event"] for e in cap_logs]
+    assert "recommender_seed_isolated_returns_empty" in events
+
+
+# ---------------------------------------------------------------------------
+# Coverage gap: _hop_count fallback when node not reachable within 3 hops
+# ---------------------------------------------------------------------------
+
+
+def test_hop_count_returns_1_when_not_found() -> None:
+    """_hop_count returns 1 as fallback when target not in any BFS radius."""
+    mock_store = MagicMock()
+    # traverse never returns the target
+    mock_store.traverse = MagicMock(return_value=[])
+
+    rec = CitationRecommender(
+        coupling=AsyncMock(),
+        crawler=MagicMock(),
+        scorer=AsyncMock(),
+        store=mock_store,
+    )
+
+    result = rec._hop_count(_SEED, _P1, direction="outgoing")
+    assert result == 1
+
+
+def test_hop_count_returns_correct_depth() -> None:
+    """_hop_count returns the correct depth when target is found."""
+    mock_store = MagicMock()
+    target_node = _make_graph_node(_P1)
+
+    call_count = [0]
+
+    def _traverse_se(node_id, edge_types, max_depth, direction="both"):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return []  # depth 1: not found
+        return [target_node]  # depth 2: found
+
+    mock_store.traverse = MagicMock(side_effect=_traverse_se)
+
+    rec = CitationRecommender(
+        coupling=AsyncMock(),
+        crawler=MagicMock(),
+        scorer=AsyncMock(),
+        store=mock_store,
+    )
+
+    result = rec._hop_count(_SEED, _P1, direction="outgoing")
+    assert result == 2
+
+
+# ---------------------------------------------------------------------------
+# Coverage gap: coupling_protocol._validate_paper_id_str branches
+# ---------------------------------------------------------------------------
+
+
+def test_coupling_protocol_validate_empty_string() -> None:
+    """_validate_paper_id_str rejects empty strings."""
+    from src.services.intelligence.citation.coupling_protocol import (
+        _validate_paper_id_str,
+    )
+
+    with pytest.raises(ValueError, match="must be a non-empty string"):
+        _validate_paper_id_str("", "paper_a_id")
+
+
+def test_coupling_protocol_validate_too_long() -> None:
+    """_validate_paper_id_str rejects strings exceeding PAPER_ID_MAX_LENGTH."""
+    from src.services.intelligence.citation.coupling_protocol import (
+        _validate_paper_id_str,
+    )
+
+    with pytest.raises(ValueError, match="exceeds max"):
+        _validate_paper_id_str("a" * 513, "paper_a_id")
+
+
+def test_coupling_protocol_validate_invalid_format() -> None:
+    """_validate_paper_id_str rejects invalid format."""
+    from src.services.intelligence.citation.coupling_protocol import (
+        _validate_paper_id_str,
+    )
+
+    with pytest.raises(ValueError, match="Invalid paper_a_id format"):
+        _validate_paper_id_str("bad/id", "paper_a_id")
+
+
+def test_coupling_result_model_post_init_rejects_bad_a_id() -> None:
+    """CouplingResult.model_post_init rejects bad paper_a_id via field validator."""
+    with pytest.raises(Exception, match="Invalid paper_a_id format"):
+        CouplingResult(
+            paper_a_id="bad/id",
+            paper_b_id=_P1,
+            coupling_strength=0.5,
+        )
+
+
+def test_coupling_result_model_post_init_rejects_bad_b_id() -> None:
+    """CouplingResult.model_post_init rejects bad paper_b_id."""
+    with pytest.raises(Exception, match="Invalid paper_b_id format"):
+        CouplingResult(
+            paper_a_id=_P1,
+            paper_b_id="bad/id",
+            coupling_strength=0.5,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Coverage gap: Recommendation model — score out of range
+# ---------------------------------------------------------------------------
+
+
+def test_recommendation_rejects_score_above_one() -> None:
+    """score > 1.0 must fail validation."""
+    with pytest.raises(Exception, match="less than or equal to 1"):
+        Recommendation(
+            paper_id=_P1,
+            score=1.1,
+            strategy=RecommendationStrategy.SIMILAR,
+            reasoning="test",
+            seed_paper_id=_SEED,
+        )
+
+
+def test_recommendation_rejects_score_below_zero() -> None:
+    """score < 0.0 must fail validation."""
+    with pytest.raises(Exception, match="greater than or equal to 0"):
+        Recommendation(
+            paper_id=_P1,
+            score=-0.1,
+            strategy=RecommendationStrategy.SIMILAR,
+            reasoning="test",
+            seed_paper_id=_SEED,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Coverage gap: _filter_by_year — node is None in store
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recommend_active_successors_node_not_in_store(monkeypatch) -> None:
+    """Nodes whose get_node returns None are excluded from active successors."""
+    traverse_node = _make_graph_node(_P1)
+
+    mock_store = MagicMock()
+    mock_store.traverse = MagicMock(return_value=[traverse_node])
+    # get_node returns None for any id → the `continue` at line 638 fires
+    mock_store.get_node = MagicMock(return_value=None)
+
+    rec = CitationRecommender(
+        coupling=AsyncMock(),
+        crawler=MagicMock(),
+        scorer=AsyncMock(),
+        store=mock_store,
+    )
+
+    monkeypatch.setattr(recommender_module, "logger", structlog.get_logger())
+    with structlog.testing.capture_logs() as cap_logs:
+        results = await rec.recommend_active_successors(_SEED, k=5)
+
+    assert results == []
+    events = [e["event"] for e in cap_logs]
+    assert "recommender_seed_isolated_returns_empty" in events
+
+
+# ---------------------------------------------------------------------------
+# Coverage gap: bridge — cited node NOT in r2_set (the false branch)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recommend_bridge_distant_cites_outside_r2_ignored(
+    monkeypatch,
+) -> None:
+    """When distant nodes cite papers NOT in r2_set, those are not counted."""
+    # r2 = [P1]; distant = [P4]; P4 references P5 (NOT in r2) → count stays 0
+    r2_nodes = [_make_graph_node(_P1)]
+    r3_nodes = r2_nodes + [_make_graph_node(_P4)]
+
+    call_count = [0]
+
+    def _traverse_se(node_id, edge_types, max_depth, direction="both"):
+        call_count[0] += 1
+        c = call_count[0]
+        if c == 1:
+            return r2_nodes
+        elif c == 2:
+            return r3_nodes
+        elif c == 3 and node_id == _P4:
+            # P4 cites P5 only (not in r2) → the false branch at 488->487
+            return [_make_graph_node(_P5)]
+        return []
+
+    mock_store = MagicMock()
+    mock_store.traverse = MagicMock(side_effect=_traverse_se)
+    mock_store.get_node = MagicMock(return_value=None)
+
+    rec = CitationRecommender(
+        coupling=AsyncMock(),
+        crawler=MagicMock(),
+        scorer=AsyncMock(),
+        store=mock_store,
+    )
+
+    monkeypatch.setattr(recommender_module, "logger", structlog.get_logger())
+    with structlog.testing.capture_logs() as cap_logs:
+        results = await rec.recommend_bridge_papers(_SEED, k=5)
+
+    # No bridges found because P5 not in r2 and count < threshold
+    assert results == []
+    events = [e["event"] for e in cap_logs]
+    assert "recommender_seed_isolated_returns_empty" in events

--- a/tests/unit/services/intelligence/citation/test_recommender.py
+++ b/tests/unit/services/intelligence/citation/test_recommender.py
@@ -1089,7 +1089,7 @@ async def test_recommend_active_successors_uses_publication_date_fallback(
 async def test_recommend_active_successors_bad_publication_date_excluded(
     monkeypatch,
 ) -> None:
-    """Nodes with unparseable publication_date are excluded from active successors."""
+    """Nodes with unparsable publication_date are excluded from active successors."""
     node_bad_date = MagicMock()
     node_bad_date.node_id = _P1
     node_bad_date.properties = {"publication_date": "not-a-date"}

--- a/tests/unit/services/intelligence/citation/test_recommender.py
+++ b/tests/unit/services/intelligence/citation/test_recommender.py
@@ -1045,54 +1045,6 @@ async def test_recommend_active_successors_bad_year_value_excluded(
 
 
 # ---------------------------------------------------------------------------
-# Coverage gap: _hop_count fallback when node not reachable within 3 hops
-# ---------------------------------------------------------------------------
-
-
-def test_hop_count_returns_1_when_not_found() -> None:
-    """_hop_count returns 1 as fallback when target not in any BFS radius."""
-    mock_store = MagicMock()
-    # traverse never returns the target
-    mock_store.traverse = MagicMock(return_value=[])
-
-    rec = CitationRecommender(
-        coupling=AsyncMock(),
-        crawler=MagicMock(),
-        scorer=AsyncMock(),
-        store=mock_store,
-    )
-
-    result = rec._hop_count(_SEED, _P1, direction="outgoing")
-    assert result == 1
-
-
-def test_hop_count_returns_correct_depth() -> None:
-    """_hop_count returns the correct depth when target is found."""
-    mock_store = MagicMock()
-    target_node = _make_graph_node(_P1)
-
-    call_count = [0]
-
-    def _traverse_se(node_id, edge_types, max_depth, direction="both"):
-        call_count[0] += 1
-        if call_count[0] == 1:
-            return []  # depth 1: not found
-        return [target_node]  # depth 2: found
-
-    mock_store.traverse = MagicMock(side_effect=_traverse_se)
-
-    rec = CitationRecommender(
-        coupling=AsyncMock(),
-        crawler=MagicMock(),
-        scorer=AsyncMock(),
-        store=mock_store,
-    )
-
-    result = rec._hop_count(_SEED, _P1, direction="outgoing")
-    assert result == 2
-
-
-# ---------------------------------------------------------------------------
 # Coverage gap: coupling_protocol._validate_paper_id_str branches
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/services/intelligence/citation/test_recommender.py
+++ b/tests/unit/services/intelligence/citation/test_recommender.py
@@ -27,6 +27,7 @@ from src.services.intelligence.citation import recommender as recommender_module
 from src.services.intelligence.citation.coupling_protocol import CouplingResult
 from src.services.intelligence.citation.influence_scorer import InfluenceMetrics
 from src.services.intelligence.citation.models import (
+    EdgeType,
     Recommendation,
     RecommendationStrategy,
 )
@@ -326,6 +327,90 @@ async def test_recommend_similar_invalid_seed_raises() -> None:
         await rec.recommend_similar("bad/seed", k=5)
 
 
+@pytest.mark.asyncio
+async def test_recommend_similar_k_zero_raises() -> None:
+    """M-3: k=0 must raise (after H-2 cap requiring k in [1, 100])."""
+    rec, _, _, _, _ = _build_recommender()
+    with pytest.raises(ValueError, match=r"k must be in \[1, 100\]"):
+        await rec.recommend_similar(_SEED, k=0)
+
+
+@pytest.mark.asyncio
+async def test_recommend_similar_k_above_cap_raises() -> None:
+    """M-3 / H-2: k > 100 must raise."""
+    rec, _, _, _, _ = _build_recommender()
+    with pytest.raises(ValueError, match=r"k must be in \[1, 100\]"):
+        await rec.recommend_similar(_SEED, k=101)
+
+
+@pytest.mark.asyncio
+async def test_recommend_similar_k_exceeds_candidates_returns_all() -> None:
+    """M-3: k larger than available candidates returns all available, not k entries."""
+    coupling_results = [
+        _coupling_result(_SEED, _P1, strength=0.9, shared=10, jaccard=0.5),
+        _coupling_result(_SEED, _P2, strength=0.6, shared=6, jaccard=0.3),
+    ]
+    traverse_nodes = [_make_graph_node(_P1), _make_graph_node(_P2)]
+    rec, _, _, _, _ = _build_recommender(
+        traverse_returns=traverse_nodes,
+        coupling_results=coupling_results,
+    )
+
+    results = await rec.recommend_similar(_SEED, k=10)
+
+    assert len(results) == 2
+    assert results[0].paper_id == _P1
+    assert results[1].paper_id == _P2
+
+
+@pytest.mark.asyncio
+async def test_recommend_similar_ties_broken_deterministically() -> None:
+    """M-3: Tied coupling_strength → results are consistently ordered.
+
+    Tie-break stability matters because recommend_all and downstream UI
+    must produce stable output across cache-cold and cache-warm calls.
+    """
+    coupling_results = [
+        _coupling_result(_SEED, _P3, strength=0.5, shared=5, jaccard=0.25),
+        _coupling_result(_SEED, _P1, strength=0.5, shared=5, jaccard=0.25),
+        _coupling_result(_SEED, _P2, strength=0.5, shared=5, jaccard=0.25),
+    ]
+    traverse_nodes = [
+        _make_graph_node(_P1),
+        _make_graph_node(_P2),
+        _make_graph_node(_P3),
+    ]
+    rec, _, _, _, _ = _build_recommender(
+        traverse_returns=traverse_nodes,
+        coupling_results=coupling_results,
+    )
+
+    # Two consecutive calls produce the same order (deterministic).
+    results_a = await rec.recommend_similar(_SEED, k=3)
+    results_b = await rec.recommend_similar(_SEED, k=3)
+
+    assert [r.paper_id for r in results_a] == [r.paper_id for r in results_b]
+
+
+def test_recommendation_rejects_extra_fields() -> None:
+    """M-1: Recommendation model_config has extra='forbid'.
+
+    Future refactor that drops the strict config would silently accept
+    spurious fields and not be caught without this pin.
+    """
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        Recommendation(
+            paper_id=_P1,
+            score=0.5,
+            strategy=RecommendationStrategy.SIMILAR,
+            reasoning="test",
+            seed_paper_id=_SEED,
+            spurious_field="should be rejected",  # type: ignore[call-arg]
+        )
+
+
 # ---------------------------------------------------------------------------
 # recommend_influential_predecessors
 # ---------------------------------------------------------------------------
@@ -365,8 +450,13 @@ async def test_recommend_influential_predecessors_uses_backward_crawl(
     events = [e["event"] for e in cap_logs]
     assert "recommender_strategy_complete" in events
 
-    # Store must have been called with the CITES edge type via traverse
-    assert mock_store.traverse.called
+    # Store called with correct args (H-5: assert_called_with not bare .called)
+    mock_store.traverse.assert_called_with(
+        _SEED,
+        edge_types=[EdgeType.CITES],
+        max_depth=2,
+        direction="outgoing",
+    )
 
 
 @pytest.mark.asyncio
@@ -651,6 +741,17 @@ async def test_recommend_all_runs_strategies_concurrently(monkeypatch) -> None:
     assert len(gather_calls) == 1
     # It must have received exactly 4 coroutines (one per strategy)
     assert len(gather_calls[0]) == 4
+
+    # L-7: verify the result dict contains all four strategies in the
+    # canonical order (SIMILAR, INFLUENTIAL_PREDECESSOR, ACTIVE_SUCCESSOR, BRIDGE).
+    # recommend_all(...) with empty traverse returns empty lists for all.
+    all_result = await rec.recommend_all(_SEED, k_per_strategy=3)
+    assert list(all_result.keys()) == [
+        RecommendationStrategy.SIMILAR,
+        RecommendationStrategy.INFLUENTIAL_PREDECESSOR,
+        RecommendationStrategy.ACTIVE_SUCCESSOR,
+        RecommendationStrategy.BRIDGE,
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/storage/intelligence_graph/test_unified_graph.py
+++ b/tests/unit/storage/intelligence_graph/test_unified_graph.py
@@ -1688,3 +1688,81 @@ class TestTraverseInternalBranches:
             f"expected {expected_chunks} IN-clause queries for n={n}, "
             f"got {len(in_clause_queries)}"
         )
+
+
+class TestListOutgoingEdgesForNodes:
+    """Coverage for ``_list_outgoing_edges_for_nodes`` — bulk fan-out
+    helper added in PR #146 to replace per-node ``traverse`` calls in
+    the recommender's bridge-paper strategy."""
+
+    def test_returns_empty_dict_for_empty_source_ids(
+        self, graph_store: SQLiteGraphStore
+    ) -> None:
+        """Empty source_ids short-circuits to {}."""
+        result = graph_store._list_outgoing_edges_for_nodes(
+            source_ids=[],
+            edge_type_values=[EdgeType.CITES.value],
+        )
+        assert result == {}
+
+    def test_returns_empty_dict_for_empty_edge_types(
+        self, graph_store: SQLiteGraphStore
+    ) -> None:
+        """Empty edge_type_values short-circuits to {}."""
+        graph_store.add_node("paper:a", NodeType.PAPER, {})
+        result = graph_store._list_outgoing_edges_for_nodes(
+            source_ids=["paper:a"],
+            edge_type_values=[],
+        )
+        assert result == {}
+
+    def test_returns_targets_grouped_by_source(
+        self, graph_store: SQLiteGraphStore
+    ) -> None:
+        """Targets are grouped under their source id."""
+        for nid in ("paper:a", "paper:b", "paper:c", "paper:d"):
+            graph_store.add_node(nid, NodeType.PAPER, {})
+        graph_store.add_edge("edge:1", "paper:a", "paper:c", EdgeType.CITES, {})
+        graph_store.add_edge("edge:2", "paper:a", "paper:d", EdgeType.CITES, {})
+        graph_store.add_edge("edge:3", "paper:b", "paper:c", EdgeType.CITES, {})
+
+        result = graph_store._list_outgoing_edges_for_nodes(
+            source_ids=["paper:a", "paper:b"],
+            edge_type_values=[EdgeType.CITES.value],
+        )
+        assert set(result.keys()) == {"paper:a", "paper:b"}
+        assert sorted(result["paper:a"]) == ["paper:c", "paper:d"]
+        assert result["paper:b"] == ["paper:c"]
+
+    def test_filters_by_edge_type(self, graph_store: SQLiteGraphStore) -> None:
+        """Only requested edge types appear in the result."""
+        graph_store.add_node("paper:a", NodeType.PAPER, {})
+        graph_store.add_node("paper:b", NodeType.PAPER, {})
+        graph_store.add_node("paper:c", NodeType.PAPER, {})
+        graph_store.add_edge("edge:cites", "paper:a", "paper:b", EdgeType.CITES, {})
+        graph_store.add_edge(
+            "edge:cited_by",
+            "paper:a",
+            "paper:c",
+            EdgeType.CITED_BY,
+            {},
+        )
+
+        result = graph_store._list_outgoing_edges_for_nodes(
+            source_ids=["paper:a"],
+            edge_type_values=[EdgeType.CITES.value],
+        )
+        assert result == {"paper:a": ["paper:b"]}
+
+    def test_omits_sources_with_no_outgoing_edges(
+        self, graph_store: SQLiteGraphStore
+    ) -> None:
+        """Source ids with no matching outgoing edges are absent (not empty list)."""
+        graph_store.add_node("paper:a", NodeType.PAPER, {})
+        graph_store.add_node("paper:b", NodeType.PAPER, {})
+
+        result = graph_store._list_outgoing_edges_for_nodes(
+            source_ids=["paper:a", "paper:b"],
+            edge_type_values=[EdgeType.CITES.value],
+        )
+        assert result == {}


### PR DESCRIPTION
## Summary

Implements `CitationRecommender` (REQ-9.2.5 / Issue #130) with four
paper recommendation strategies and a parallel-development coupling
Protocol shim for concurrent work with Issue #128.

### Changes

- **`src/services/intelligence/citation/coupling_protocol.py`** (NEW — SHIM):
  Defines `CouplingAnalyzerProtocol` (runtime-checkable Protocol) and a
  stub `CouplingResult` Pydantic V2 model. This is the parallel-dev shim
  that lets the recommender code against a typed interface without waiting
  for Issue #128's `CouplingAnalyzer` to land on `main`. When #128 lands
  and this branch rebases, the real `CouplingAnalyzer` already satisfies
  the Protocol implicitly — no production code change needed. This module
  will be replaced in a follow-up commit once #128 merges.

- **`src/services/intelligence/citation/models.py`** (MODIFIED):
  Adds `RecommendationStrategy` (str Enum) and `Recommendation` (Pydantic
  V2 strict model with self-recommendation guard, canonical-id validators,
  and score in [0.0, 1.0]).

- **`src/services/intelligence/citation/recommender.py`** (NEW):
  `CitationRecommender` with DI constructor. Four strategies:
  - `recommend_similar` — top-k by coupling_strength
  - `recommend_influential_predecessors` — backward BFS + PageRank
  - `recommend_active_successors` — forward BFS, last-2-years filter, velocity normalization
  - `recommend_bridge_papers` — co-citation heuristic (no NetworkX)
  - `recommend_all` — `asyncio.gather` across all four

- **`tests/unit/services/intelligence/citation/test_recommender.py`** (NEW):
  55 tests covering all strategies, isolation, log events, fuzz
  score-normalization, and edge cases.

### Parallel-dev coupling Protocol shim

Issue #128 (`CouplingAnalyzer`) is being developed in parallel on a
separate branch. This PR introduces `coupling_protocol.py` as a shim so
the recommender can ship now without a hard dependency on #128. The shim:
- Defines the interface contract (method signatures, `CouplingResult` shape)
- Is used by `CitationRecommender` as its only dependency surface
- Is exercised by tests via `AsyncMock` implementing the Protocol
- Will be removed in a follow-up commit once #128 merges and the real
  `CouplingAnalyzer` is available on `main`

### Coverage

- `recommender.py`: 100%
- `coupling_protocol.py`: 100%
- `models.py` (touched lines): 100%
- Overall project: 99.17% (above 99% threshold)

### Test plan

- [x] `./verify.sh` passes 100% (5209 tests, 0 failures, 99.17% combined coverage)
- [x] Black/Flake8/Mypy all clean
- [x] All 4 strategy methods tested with isolation, log events, and edge cases
- [x] `test_recommend_all_runs_strategies_concurrently` asserts `asyncio.gather` is used
- [x] `test_recommend_strategy_logs_failure_and_propagates` asserts fail-log + re-raise
- [x] `test_score_normalization_within_zero_one` fuzz test (100 random vectors)
- [x] Parallel-dev constraint honored — `CouplingAnalyzer` NOT implemented here

Closes #130