### PR TITLE
feat(phase-9.2): bibliographic coupling analyzer (closes #128)

### DIFF
--- a/src/services/intelligence/citation/__init__.py
+++ b/src/services/intelligence/citation/__init__.py
@@ -1,10 +1,11 @@
-"""Milestone 9.2: Citation Graph Intelligence (Week 1 + 1.5 surface).
+"""Milestone 9.2: Citation Graph Intelligence (Weeks 1 + 1.5 + 2 surface).
 
 This package builds and persists citation graphs from external APIs
 (Semantic Scholar primary, OpenAlex fallback) using the Phase 9
 ``GraphStore`` for storage. Week 1 + 1.5 deliver depth=1 graph
-construction; BFS crawler, coupling analyzer, influence scorer, and
-recommender are deferred to follow-up PRs (Weeks 2-3).
+construction and BFS crawling. Week 2 ships the bibliographic coupling
+analyzer (:class:`CouplingAnalyzer`) and the influence scorer
+(:class:`InfluenceScorer`). The recommender is deferred to Week 3.
 
 Public surface:
 
@@ -59,6 +60,12 @@ from src.services.intelligence.citation.models import (
     make_citation_edge_id,
     make_paper_node_id,
 )
+from src.services.intelligence.citation.coupling_analyzer import CouplingAnalyzer
+from src.services.intelligence.citation.coupling_repository import (
+    DEFAULT_MAX_AGE_DAYS,
+    CitationCouplingRepository,
+)
+from src.services.intelligence.citation.models import CouplingResult
 from src.services.intelligence.citation.openalex_client import (
     OpenAlexCitationClient,
 )
@@ -96,4 +103,9 @@ __all__ = [
     "DEFAULT_CACHE_TTL",
     "MAX_GRAPH_NODES_FOR_HITS",
     "MAX_GRAPH_NODES_FOR_PAGERANK",
+    # Bibliographic Coupling Analyzer (Issue #128)
+    "CouplingAnalyzer",
+    "CitationCouplingRepository",
+    "CouplingResult",
+    "DEFAULT_MAX_AGE_DAYS",
 ]

--- a/src/services/intelligence/citation/coupling_analyzer.py
+++ b/src/services/intelligence/citation/coupling_analyzer.py
@@ -17,9 +17,17 @@ Computed pairs are cached in the ``citation_coupling`` table introduced by
 :class:`CitationCouplingRepository` so the analyzer never touches the
 DB schema directly.  ``analyze_pair`` checks the cache first; a cache
 miss computes Jaccard and upserts the result via the repository.
-``analyze_for_paper`` does not consult the cache (it is a bulk scatter
-call; caching is left to the underlying ``analyze_pair`` calls if the
-caller wishes to compose them).
+``analyze_for_paper`` uses the cache indirectly — each underlying
+``analyze_pair`` call checks the cache and writes the result if a repo
+is wired in.
+
+Async safety
+------------
+Both public methods are ``async def`` wrapping sync DB/graph work via
+``asyncio.to_thread`` — the canonical pattern from CLAUDE.md "SQLite
+write retry" and mirroring :meth:`InfluenceScorer.compute_for_paper`.
+``analyze_for_paper`` fans out concurrent pair evaluations using
+``asyncio.gather`` with a bounded semaphore (concurrency 10).
 
 Failure semantics
 -----------------
@@ -27,10 +35,13 @@ Failure semantics
 - Invalid paper id → :class:`ValueError` with a clear message.
 - Cache write failure → swallowed (logged at ERROR level), in-memory
   result still returned.
+- ``candidates`` exceeds :data:`MAX_CANDIDATES` → :class:`ValueError`.
+- ``top_k`` exceeds :data:`MAX_TOP_K` → clamped to ``MAX_TOP_K``.
 """
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING, Optional
 
 import structlog
@@ -42,6 +53,7 @@ from src.services.intelligence.citation._id_validation import (
 from src.services.intelligence.citation.models import CouplingResult
 from src.services.intelligence.models import EdgeType
 from src.storage.intelligence_graph import SQLiteGraphStore
+from src.storage.intelligence_graph.connection import _trunc
 
 if TYPE_CHECKING:
     from src.services.intelligence.citation.coupling_repository import (
@@ -53,6 +65,19 @@ logger = structlog.get_logger(__name__)
 # Strict allow-list mirrored from _id_validation (single source of truth).
 _PAPER_ID_PATTERN = CANONICAL_NODE_ID_PATTERN
 _PAPER_ID_MAX_LENGTH = PAPER_ID_MAX_LENGTH
+
+# DoS guard: maximum number of candidates accepted by analyze_for_paper.
+MAX_CANDIDATES: int = 10_000
+
+# DoS guard: maximum top_k that may be requested.
+MAX_TOP_K: int = 1_000
+
+# Bounded concurrency for analyze_for_paper fan-out (mirrors MultiProviderMonitor).
+_ANALYZE_FOR_PAPER_CONCURRENCY: int = 10
+
+# DoS guard: cap on the number of outgoing CITES edges fetched per paper.
+# Reference sets larger than this are truncated after emitting an audit log.
+_MAX_REFERENCES: int = 50_000
 
 
 def _validate_paper_id(paper_id: str) -> None:
@@ -114,7 +139,7 @@ class CouplingAnalyzer:
     # Public API
     # ------------------------------------------------------------------
 
-    def analyze_pair(
+    async def analyze_pair(
         self,
         paper_a_id: str,
         paper_b_id: str,
@@ -124,6 +149,12 @@ class CouplingAnalyzer:
         Reads ``EdgeType.CITES`` outgoing edges for each paper from the
         graph store to obtain their reference sets, then computes the
         Jaccard similarity.
+
+        Async safety:
+            All repository and graph-store calls are wrapped in
+            ``asyncio.to_thread`` so synchronous DB/graph work does not
+            stall the event loop — mirrors
+            :meth:`InfluenceScorer.compute_for_paper`.
 
         Args:
             paper_a_id: Canonical node id of the first paper.
@@ -146,27 +177,27 @@ class CouplingAnalyzer:
 
         # Consult cache first (if a repo is wired in).
         if self._repo is not None:
-            cached = self._repo.get(paper_a_id, paper_b_id)
+            cached = await asyncio.to_thread(self._repo.get, paper_a_id, paper_b_id)
             if cached is not None:
                 return cached
 
-        result = self._compute_pair(paper_a_id, paper_b_id)
+        result = await asyncio.to_thread(self._compute_pair, paper_a_id, paper_b_id)
 
         # Persist to cache (swallow errors so the caller still gets the result).
         if self._repo is not None:
             try:
-                self._repo.record(result)
+                await asyncio.to_thread(self._repo.record, result)
             except Exception as exc:  # noqa: BLE001
                 logger.error(
                     "coupling_analyzer_cache_write_failed",
                     paper_a_id=paper_a_id,
                     paper_b_id=paper_b_id,
-                    error=str(exc)[:200],
+                    error=_trunc(exc),
                 )
 
         return result
 
-    def analyze_for_paper(
+    async def analyze_for_paper(
         self,
         paper_id: str,
         candidates: list[str],
@@ -175,8 +206,10 @@ class CouplingAnalyzer:
         """Find the top-K most coupled papers from a candidate list.
 
         Computes ``analyze_pair(paper_id, candidate)`` for each entry in
-        ``candidates``, then returns the ``top_k`` results sorted
-        descending by ``coupling_strength``.
+        ``candidates`` concurrently (bounded to
+        :data:`_ANALYZE_FOR_PAPER_CONCURRENCY` simultaneous tasks via a
+        semaphore), then returns the ``top_k`` results sorted descending
+        by ``coupling_strength``.
 
         Papers whose coupling strength is 0.0 are included in the sort
         so the caller has full visibility; it is their responsibility to
@@ -187,8 +220,9 @@ class CouplingAnalyzer:
             candidates: Other papers to compare with. Must not contain
                 ``paper_id`` itself (each element is validated; the
                 self-pair check in ``analyze_pair`` will raise if one
-                slips through).
+                slips through). Must not exceed :data:`MAX_CANDIDATES`.
             top_k: Maximum number of results to return. Must be >= 1.
+                Values above :data:`MAX_TOP_K` are clamped silently.
 
         Returns:
             Up to ``top_k`` :class:`CouplingResult` objects sorted by
@@ -196,16 +230,28 @@ class CouplingAnalyzer:
             ascending for a stable tie-break.
 
         Raises:
-            ValueError: If ``paper_id`` is malformed, or ``top_k < 1``.
+            ValueError: If ``paper_id`` is malformed, ``top_k < 1``, or
+                ``len(candidates)`` exceeds :data:`MAX_CANDIDATES`.
         """
         _validate_paper_id(paper_id)
         if top_k < 1:
             raise ValueError(f"top_k must be >= 1, got {top_k}")
+        if len(candidates) > MAX_CANDIDATES:
+            raise ValueError(
+                f"candidates length {len(candidates)} exceeds MAX_CANDIDATES "
+                f"({MAX_CANDIDATES})"
+            )
+        top_k = min(top_k, MAX_TOP_K)
 
-        results: list[CouplingResult] = []
-        for candidate in candidates:
-            result = self.analyze_pair(paper_id, candidate)
-            results.append(result)
+        sem = asyncio.Semaphore(_ANALYZE_FOR_PAPER_CONCURRENCY)
+
+        async def _bounded(candidate: str) -> CouplingResult:
+            async with sem:
+                return await self.analyze_pair(paper_id, candidate)
+
+        results: list[CouplingResult] = list(
+            await asyncio.gather(*[_bounded(c) for c in candidates])
+        )
 
         results.sort(key=lambda r: (-r.coupling_strength, r.paper_b_id))
         return results[:top_k]
@@ -220,6 +266,11 @@ class CouplingAnalyzer:
         Reads outgoing ``CITES`` edges from the graph store.  Each such
         edge's ``target_id`` is one reference.
 
+        If the edge count exceeds :data:`_MAX_REFERENCES`, the list is
+        truncated and a ``coupling_references_truncated`` audit event is
+        emitted so operators can monitor unexpectedly dense reference
+        sets.
+
         Args:
             paper_id: Canonical node id.
 
@@ -232,6 +283,14 @@ class CouplingAnalyzer:
             direction="outgoing",
             edge_type=EdgeType.CITES,
         )
+        if len(edges) > _MAX_REFERENCES:
+            logger.warning(
+                "coupling_references_truncated",
+                paper_id=paper_id,
+                fetched=len(edges),
+                cap=_MAX_REFERENCES,
+            )
+            edges = edges[:_MAX_REFERENCES]
         return frozenset(edge.target_id for edge in edges)
 
     def _compute_pair(
@@ -275,6 +334,10 @@ class CouplingAnalyzer:
             coupling_strength=strength,
         )
 
+        # TODO(issue #150): co_citation_count not yet computed; always 0.
+        # Full implementation requires a reverse-edge walk: find all papers
+        # with outgoing CITES edges to BOTH paper_a_id AND paper_b_id.
+        # Filed as a follow-up to keep this PR focused on Jaccard coupling.
         return CouplingResult(
             paper_a_id=paper_a_id,
             paper_b_id=paper_b_id,

--- a/src/services/intelligence/citation/coupling_analyzer.py
+++ b/src/services/intelligence/citation/coupling_analyzer.py
@@ -1,0 +1,284 @@
+"""Bibliographic coupling analyzer (Milestone 9.2 — REQ-9.2.3 / Issue #128).
+
+Computes Jaccard similarity over shared references to identify related papers:
+
+    coupling_strength = |shared_refs(A) ∩ shared_refs(B)|
+                        ─────────────────────────────────
+                        |shared_refs(A) ∪ shared_refs(B)|
+
+The degenerate case where both papers have zero references is handled
+gracefully: ``coupling_strength = 0.0`` rather than raising a
+``ZeroDivisionError``.
+
+Persistence
+-----------
+Computed pairs are cached in the ``citation_coupling`` table introduced by
+``MIGRATION_V6_CITATION_COUPLING_CACHE``. Cache CRUD is delegated to
+:class:`CitationCouplingRepository` so the analyzer never touches the
+DB schema directly.  ``analyze_pair`` checks the cache first; a cache
+miss computes Jaccard and upserts the result via the repository.
+``analyze_for_paper`` does not consult the cache (it is a bulk scatter
+call; caching is left to the underlying ``analyze_pair`` calls if the
+caller wishes to compose them).
+
+Failure semantics
+-----------------
+- Zero-reference paper → ``coupling_strength = 0.0``, no exception.
+- Invalid paper id → :class:`ValueError` with a clear message.
+- Cache write failure → swallowed (logged at ERROR level), in-memory
+  result still returned.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+import structlog
+
+from src.services.intelligence.citation._id_validation import (
+    CANONICAL_NODE_ID_PATTERN,
+    PAPER_ID_MAX_LENGTH,
+)
+from src.services.intelligence.citation.models import CouplingResult
+from src.services.intelligence.models import EdgeType
+from src.storage.intelligence_graph import SQLiteGraphStore
+
+if TYPE_CHECKING:
+    from src.services.intelligence.citation.coupling_repository import (
+        CitationCouplingRepository,
+    )
+
+logger = structlog.get_logger(__name__)
+
+# Strict allow-list mirrored from _id_validation (single source of truth).
+_PAPER_ID_PATTERN = CANONICAL_NODE_ID_PATTERN
+_PAPER_ID_MAX_LENGTH = PAPER_ID_MAX_LENGTH
+
+
+def _validate_paper_id(paper_id: str) -> None:
+    """Validate a canonical node id at the analyzer boundary.
+
+    Mirrors :meth:`InfluenceScorer._validate_paper_id` exactly so the
+    two analyzers present a consistent public contract.
+
+    Args:
+        paper_id: Caller-supplied paper id.
+
+    Raises:
+        ValueError: If the id is empty, too long, or contains illegal chars.
+    """
+    if not isinstance(paper_id, str) or not paper_id.strip():
+        raise ValueError("paper_id must be a non-empty string")
+    if len(paper_id) > _PAPER_ID_MAX_LENGTH:
+        raise ValueError(
+            f"paper_id length {len(paper_id)} exceeds max {_PAPER_ID_MAX_LENGTH}"
+        )
+    if not _PAPER_ID_PATTERN.match(paper_id):
+        raise ValueError(
+            f"Invalid paper_id format: {paper_id!r}. "
+            "Allowed: alphanumeric, colons, periods, hyphens, underscores."
+        )
+
+
+class CouplingAnalyzer:
+    """Compute bibliographic coupling scores between papers.
+
+    Uses :class:`~src.storage.intelligence_graph.SQLiteGraphStore` as the
+    source of reference edges (``EdgeType.CITES`` outgoing from a paper
+    represent what it references).
+
+    Args:
+        store: Graph store providing edge lookups.
+        repo: Optional :class:`CitationCouplingRepository` for caching.
+            When ``None``, results are computed but not persisted.
+
+    Example::
+
+        store = SQLiteGraphStore("data/graph.db")
+        store.initialize()
+        analyzer = CouplingAnalyzer(store)
+        result = analyzer.analyze_pair("paper:s2:aaa", "paper:s2:bbb")
+        print(result.coupling_strength)
+    """
+
+    def __init__(
+        self,
+        store: SQLiteGraphStore,
+        *,
+        repo: Optional["CitationCouplingRepository"] = None,
+    ) -> None:
+        self.store = store
+        self._repo = repo
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def analyze_pair(
+        self,
+        paper_a_id: str,
+        paper_b_id: str,
+    ) -> CouplingResult:
+        """Compute (or return cached) coupling between two papers.
+
+        Reads ``EdgeType.CITES`` outgoing edges for each paper from the
+        graph store to obtain their reference sets, then computes the
+        Jaccard similarity.
+
+        Args:
+            paper_a_id: Canonical node id of the first paper.
+            paper_b_id: Canonical node id of the second paper.
+
+        Returns:
+            A :class:`CouplingResult` with the Jaccard strength and the
+            sorted list of shared reference ids.
+
+        Raises:
+            ValueError: If either id is malformed, or if
+                ``paper_a_id == paper_b_id`` (self-pair).
+        """
+        _validate_paper_id(paper_a_id)
+        _validate_paper_id(paper_b_id)
+        if paper_a_id == paper_b_id:
+            raise ValueError(
+                f"paper_a_id and paper_b_id must differ; got {paper_a_id!r} for both."
+            )
+
+        # Consult cache first (if a repo is wired in).
+        if self._repo is not None:
+            cached = self._repo.get(paper_a_id, paper_b_id)
+            if cached is not None:
+                return cached
+
+        result = self._compute_pair(paper_a_id, paper_b_id)
+
+        # Persist to cache (swallow errors so the caller still gets the result).
+        if self._repo is not None:
+            try:
+                self._repo.record(result)
+            except Exception as exc:  # noqa: BLE001
+                logger.error(
+                    "coupling_analyzer_cache_write_failed",
+                    paper_a_id=paper_a_id,
+                    paper_b_id=paper_b_id,
+                    error=str(exc)[:200],
+                )
+
+        return result
+
+    def analyze_for_paper(
+        self,
+        paper_id: str,
+        candidates: list[str],
+        top_k: int = 10,
+    ) -> list[CouplingResult]:
+        """Find the top-K most coupled papers from a candidate list.
+
+        Computes ``analyze_pair(paper_id, candidate)`` for each entry in
+        ``candidates``, then returns the ``top_k`` results sorted
+        descending by ``coupling_strength``.
+
+        Papers whose coupling strength is 0.0 are included in the sort
+        so the caller has full visibility; it is their responsibility to
+        filter if they want only meaningful couplings.
+
+        Args:
+            paper_id: The paper to compare against.
+            candidates: Other papers to compare with. Must not contain
+                ``paper_id`` itself (each element is validated; the
+                self-pair check in ``analyze_pair`` will raise if one
+                slips through).
+            top_k: Maximum number of results to return. Must be >= 1.
+
+        Returns:
+            Up to ``top_k`` :class:`CouplingResult` objects sorted by
+            ``coupling_strength`` descending, then by ``paper_b_id``
+            ascending for a stable tie-break.
+
+        Raises:
+            ValueError: If ``paper_id`` is malformed, or ``top_k < 1``.
+        """
+        _validate_paper_id(paper_id)
+        if top_k < 1:
+            raise ValueError(f"top_k must be >= 1, got {top_k}")
+
+        results: list[CouplingResult] = []
+        for candidate in candidates:
+            result = self.analyze_pair(paper_id, candidate)
+            results.append(result)
+
+        results.sort(key=lambda r: (-r.coupling_strength, r.paper_b_id))
+        return results[:top_k]
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _get_references(self, paper_id: str) -> frozenset[str]:
+        """Return the set of paper ids that ``paper_id`` references.
+
+        Reads outgoing ``CITES`` edges from the graph store.  Each such
+        edge's ``target_id`` is one reference.
+
+        Args:
+            paper_id: Canonical node id.
+
+        Returns:
+            Frozenset of referenced paper ids.  Empty if the paper has
+            no outgoing citation edges.
+        """
+        edges = self.store.get_edges(
+            paper_id,
+            direction="outgoing",
+            edge_type=EdgeType.CITES,
+        )
+        return frozenset(edge.target_id for edge in edges)
+
+    def _compute_pair(
+        self,
+        paper_a_id: str,
+        paper_b_id: str,
+    ) -> CouplingResult:
+        """Core Jaccard computation (always runs, no cache interaction).
+
+        Args:
+            paper_a_id: First paper (already validated, != paper_b_id).
+            paper_b_id: Second paper (already validated).
+
+        Returns:
+            A :class:`CouplingResult` with the computed metrics.
+        """
+        refs_a = self._get_references(paper_a_id)
+        refs_b = self._get_references(paper_b_id)
+
+        shared = refs_a & refs_b
+        union = refs_a | refs_b
+
+        if not union:
+            # Both papers have zero references — coupling is undefined;
+            # return 0.0 per spec and emit an audit event.
+            logger.info(
+                "coupling_analyzer_skipped_no_refs",
+                paper_a_id=paper_a_id,
+                paper_b_id=paper_b_id,
+            )
+            strength = 0.0
+        else:
+            strength = len(shared) / len(union)
+
+        logger.info(
+            "coupling_analyzer_pair_computed",
+            paper_a_id=paper_a_id,
+            paper_b_id=paper_b_id,
+            shared=len(shared),
+            union=len(union),
+            coupling_strength=strength,
+        )
+
+        return CouplingResult(
+            paper_a_id=paper_a_id,
+            paper_b_id=paper_b_id,
+            shared_references=sorted(shared),
+            coupling_strength=strength,
+            co_citation_count=0,
+        )

--- a/src/services/intelligence/citation/coupling_repository.py
+++ b/src/services/intelligence/citation/coupling_repository.py
@@ -1,0 +1,362 @@
+"""Persistence for :class:`CouplingResult` (V6 ``citation_coupling``).
+
+Why a standalone repository
+---------------------------
+Mirrors the layering motivation of :class:`CitationInfluenceRepository`
+(PR #143): the analyzer (writer) and any future recommender (reader)
+both go through this class — no other module touches the
+``citation_coupling`` table directly.
+
+Canonical-pair ordering
+-----------------------
+``(paper_a_id, paper_b_id)`` is stored as ``(min_id, max_id)`` so a
+lookup for (A,B) and (B,A) hits the same row.  The caller-supplied
+order is preserved in the returned :class:`CouplingResult` so callers
+are not surprised by swapped ids.  The DB's ``CHECK (paper_a_id <
+paper_b_id)`` constraint enforces this at the storage layer; a
+repository that fails to call min/max before INSERT will receive a
+constraint error, which is the intended loud-failure mode.
+
+Schema (created by ``MIGRATION_V6_CITATION_COUPLING_CACHE``)
+------------------------------------------------------------
+::
+
+    citation_coupling(
+        paper_a_id             TEXT NOT NULL,
+        paper_b_id             TEXT NOT NULL,
+        coupling_strength      REAL NOT NULL CHECK (…),
+        shared_references_json TEXT NOT NULL,
+        co_citation_count      INTEGER NOT NULL CHECK (…),
+        computed_at            TEXT NOT NULL,
+        PRIMARY KEY (paper_a_id, paper_b_id),
+        CHECK (paper_a_id < paper_b_id)
+    )
+
+TTL semantics
+-------------
+``get`` filters out rows whose ``computed_at`` is older than
+``max_age_days`` (default 30).  The stale row is NOT deleted on read —
+:meth:`delete_stale` handles bulk cleanup.
+
+Concurrency model
+-----------------
+Same as :class:`CitationInfluenceRepository`: each method opens a fresh
+connection through :func:`open_connection`, applies the standard
+PRAGMAs, and closes on exit.  ``record`` uses
+:func:`retry_on_lock_contention` (issue #133).
+
+Failure semantics
+-----------------
+``record``'s outer ``try`` catches ``sqlite3.Error`` so a cache write
+failure does NOT bubble up to the analyzer caller.  The exception is
+logged via ``coupling_repo_write_failed`` and swallowed — the caller
+still receives its in-memory result.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Callable, Iterator, Optional, TypeVar
+
+import structlog
+
+from src.services.intelligence.citation.models import CouplingResult
+from src.storage.intelligence_graph.connection import (
+    DEFAULT_BACKOFF_SECONDS,
+    DEFAULT_MAX_ATTEMPTS,
+    _trunc,
+    open_connection,
+    retry_on_lock_contention,
+)
+from src.storage.intelligence_graph.migrations import MigrationManager
+from src.storage.intelligence_graph.path_utils import sanitize_storage_path
+
+logger = structlog.get_logger(__name__)
+
+_T = TypeVar("_T")
+
+# Default freshness window for ``get``.  Mirrors spec REQ-9.2.3 (30 days).
+DEFAULT_MAX_AGE_DAYS: int = 30
+
+
+class CitationCouplingRepository:
+    """Owns the V6 ``citation_coupling`` SQLite table.
+
+    Provides:
+
+    - :meth:`record` upsert one :class:`CouplingResult` row.
+    - :meth:`get` fetch by ``(paper_a_id, paper_b_id)`` honouring a TTL.
+    - :meth:`delete_stale` bulk delete rows older than a cutoff.
+
+    Async safety:
+        ALL methods are SYNC — **async callers MUST wrap invocations in**
+        ``asyncio.to_thread(...)`` per CLAUDE.md "SQLite write retry".
+    """
+
+    def __init__(self, db_path: Path | str) -> None:
+        """Initialise the repository.
+
+        Args:
+            db_path: SQLite database path. Must lie under one of the
+                approved storage roots — enforced by
+                :func:`sanitize_storage_path`.
+        """
+        self.db_path = sanitize_storage_path(db_path)
+        self._migrations = MigrationManager(self.db_path)
+        self._initialized = False
+
+    # ------------------------------------------------------------------
+    # Bookkeeping
+    # ------------------------------------------------------------------
+
+    def initialize(self) -> None:
+        """Apply pending schema migrations.
+
+        Idempotent — safe to call multiple times.  Must be called before
+        any read/write operation.
+        """
+        applied = self._migrations.migrate()
+        if applied > 0:
+            logger.info(
+                "citation_coupling_repository_migrations_applied",
+                count=applied,
+                db_path=str(self.db_path),
+            )
+        self._initialized = True
+
+    @classmethod
+    def connect(cls, db_path: Path | str) -> "CitationCouplingRepository":
+        """Construct, run pending migrations, and return a ready repo.
+
+        Side effects (disclosed):
+            1. Calls :meth:`initialize` which invokes
+               :class:`~src.storage.intelligence_graph.migrations.MigrationManager`
+               ``migrate()`` — applies any pending schema migrations up
+               to the latest version (including V6
+               ``citation_coupling`` if the DB was created by an older
+               version of the code).
+            2. Issues PRAGMA statements (via :func:`open_connection`)
+               on a temporary connection opened during ``migrate()``.
+
+        This is the intended entry-point for production callers.
+        """
+        repo = cls(db_path)
+        repo.initialize()
+        return repo
+
+    @contextmanager
+    def _connect(self) -> Iterator[sqlite3.Connection]:
+        """Open + auto-close a SQLite connection with the standard PRAGMAs."""
+        if not self._initialized:
+            raise RuntimeError(
+                "CitationCouplingRepository not initialized. "
+                "Call initialize() first."
+            )
+        with open_connection(self.db_path) as conn:
+            yield conn
+
+    def _retry(
+        self,
+        operation: Callable[[], _T],
+        *,
+        operation_name: str,
+        **extra_log_fields: object,
+    ) -> _T:
+        """Thin wrapper around :func:`retry_on_lock_contention`."""
+        return retry_on_lock_contention(
+            operation,
+            max_attempts=DEFAULT_MAX_ATTEMPTS,
+            backoff_seconds=DEFAULT_BACKOFF_SECONDS,
+            operation_name=operation_name,
+            **extra_log_fields,
+        )
+
+    # ------------------------------------------------------------------
+    # Writes
+    # ------------------------------------------------------------------
+
+    def record(self, result: CouplingResult) -> None:
+        """Upsert one :class:`CouplingResult` row.
+
+        Canonicalizes the pair (stores ``min(a,b)`` as ``paper_a_id``
+        and ``max(a,b)`` as ``paper_b_id``) to honour the DB's
+        ``CHECK (paper_a_id < paper_b_id)`` constraint.
+
+        Concurrency:
+            Uses ``BEGIN IMMEDIATE``; transient lock contention is
+            retried up to :data:`DEFAULT_MAX_ATTEMPTS` times.
+            **Async callers MUST wrap in ``asyncio.to_thread(...)``.**
+
+        Failure semantics:
+            The outer ``try`` catches ``sqlite3.Error`` so a cache write
+            failure does NOT propagate to the analyzer caller.  The
+            exception is logged via ``coupling_repo_write_failed``.
+
+        Args:
+            result: Single :class:`CouplingResult` to upsert.
+        """
+        try:
+            self._retry(
+                lambda: self._record_once(result),
+                operation_name="coupling_record",
+                paper_a_id=result.paper_a_id,
+                paper_b_id=result.paper_b_id,
+            )
+        except sqlite3.Error as exc:
+            logger.error(
+                "coupling_repo_write_failed",
+                paper_a_id=result.paper_a_id,
+                paper_b_id=result.paper_b_id,
+                error=_trunc(exc),
+            )
+
+    def _record_once(self, result: CouplingResult) -> None:
+        """Single-attempt upsert of one row."""
+        # Canonical ordering: always store (min, max) so (A,B) and (B,A)
+        # land on the same row — the DB's CHECK constraint enforces this.
+        canon_a = min(result.paper_a_id, result.paper_b_id)
+        canon_b = max(result.paper_a_id, result.paper_b_id)
+        refs_json = json.dumps(result.shared_references)
+        now_iso = datetime.now(timezone.utc).isoformat()
+
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                conn.execute(
+                    """
+                    INSERT INTO citation_coupling (
+                        paper_a_id, paper_b_id,
+                        coupling_strength, shared_references_json,
+                        co_citation_count, computed_at
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(paper_a_id, paper_b_id) DO UPDATE SET
+                        coupling_strength      = excluded.coupling_strength,
+                        shared_references_json = excluded.shared_references_json,
+                        co_citation_count      = excluded.co_citation_count,
+                        computed_at            = excluded.computed_at
+                    """,
+                    (
+                        canon_a,
+                        canon_b,
+                        result.coupling_strength,
+                        refs_json,
+                        result.co_citation_count,
+                        now_iso,
+                    ),
+                )
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                raise
+
+    def delete_stale(self, older_than: datetime) -> int:
+        """Bulk delete rows whose ``computed_at`` predates ``older_than``.
+
+        Returns:
+            The number of rows deleted.
+
+        Concurrency:
+            Same retry semantics as :meth:`record`.
+        """
+
+        def _delete_once() -> int:
+            with self._connect() as conn:
+                conn.execute("BEGIN IMMEDIATE")
+                try:
+                    cursor = conn.execute(
+                        "DELETE FROM citation_coupling WHERE computed_at < ?",
+                        (older_than.isoformat(),),
+                    )
+                    affected = cursor.rowcount
+                    conn.commit()
+                    return int(affected)
+                except Exception:
+                    conn.rollback()
+                    raise
+
+        return self._retry(
+            _delete_once,
+            operation_name="coupling_delete_stale",
+            cutoff=older_than.isoformat(),
+        )
+
+    # ------------------------------------------------------------------
+    # Reads
+    # ------------------------------------------------------------------
+
+    def get(
+        self,
+        paper_a_id: str,
+        paper_b_id: str,
+        max_age_days: int = DEFAULT_MAX_AGE_DAYS,
+    ) -> Optional[CouplingResult]:
+        """Fetch a cached row or ``None``.
+
+        TTL semantics:
+            Rows whose ``computed_at`` is older than ``max_age_days``
+            are treated as cache misses.
+
+        Concurrency:
+            Wrapped in :func:`retry_on_lock_contention` so transient
+            contention does not cause a spurious cache miss.
+
+        Args:
+            paper_a_id: First paper id.
+            paper_b_id: Second paper id.
+            max_age_days: Freshness window. Must be > 0.
+
+        Returns:
+            :class:`CouplingResult` if a fresh row exists, else ``None``.
+
+        Raises:
+            ValueError: If ``max_age_days`` is not positive.
+        """
+        if max_age_days <= 0:
+            raise ValueError("max_age_days must be positive")
+
+        # Canonicalize lookup order so (A,B) and (B,A) hit the same row.
+        canon_a = min(paper_a_id, paper_b_id)
+        canon_b = max(paper_a_id, paper_b_id)
+
+        def _get_once() -> Optional[CouplingResult]:
+            with self._connect() as conn:
+                cursor = conn.execute(
+                    """
+                    SELECT paper_a_id, paper_b_id,
+                           coupling_strength, shared_references_json,
+                           co_citation_count, computed_at
+                    FROM citation_coupling
+                    WHERE paper_a_id = ? AND paper_b_id = ?
+                    """,
+                    (canon_a, canon_b),
+                )
+                row = cursor.fetchone()
+            if row is None:
+                return None
+            computed_at = datetime.fromisoformat(row["computed_at"])
+            if computed_at.tzinfo is None:
+                computed_at = computed_at.replace(tzinfo=timezone.utc)
+            cutoff = datetime.now(timezone.utc) - timedelta(days=max_age_days)
+            if computed_at < cutoff:
+                return None
+
+            shared: list[str] = json.loads(row["shared_references_json"])
+            return CouplingResult(
+                paper_a_id=row["paper_a_id"],
+                paper_b_id=row["paper_b_id"],
+                shared_references=shared,
+                coupling_strength=row["coupling_strength"],
+                co_citation_count=row["co_citation_count"],
+            )
+
+        return self._retry(
+            _get_once,
+            operation_name="coupling_get",
+            paper_a_id=paper_a_id,
+            paper_b_id=paper_b_id,
+        )

--- a/src/services/intelligence/citation/coupling_repository.py
+++ b/src/services/intelligence/citation/coupling_repository.py
@@ -103,13 +103,22 @@ class CitationCouplingRepository:
     def __init__(self, db_path: Path | str) -> None:
         """Initialise the repository.
 
+        Disk I/O note (M-5):
+            The constructor does **not** touch the filesystem — it only
+            validates the path via :func:`sanitize_storage_path`.
+            :class:`~src.storage.intelligence_graph.migrations.MigrationManager`
+            (which calls ``_ensure_directory()``) is constructed lazily
+            inside :meth:`initialize` so callers that build a repository
+            in a loop do not pay mkdir costs up front.  The recommended
+            production path is :meth:`connect`, which calls
+            :meth:`initialize` exactly once.
+
         Args:
             db_path: SQLite database path. Must lie under one of the
                 approved storage roots — enforced by
                 :func:`sanitize_storage_path`.
         """
         self.db_path = sanitize_storage_path(db_path)
-        self._migrations = MigrationManager(self.db_path)
         self._initialized = False
 
     # ------------------------------------------------------------------
@@ -120,9 +129,11 @@ class CitationCouplingRepository:
         """Apply pending schema migrations.
 
         Idempotent — safe to call multiple times.  Must be called before
-        any read/write operation.
+        any read/write operation.  This is where :class:`MigrationManager`
+        is constructed (deferred from ``__init__`` per M-5 lesson).
         """
-        applied = self._migrations.migrate()
+        migrations = MigrationManager(self.db_path)
+        applied = migrations.migrate()
         if applied > 0:
             logger.info(
                 "citation_coupling_repository_migrations_applied",

--- a/src/services/intelligence/citation/coupling_repository.py
+++ b/src/services/intelligence/citation/coupling_repository.py
@@ -10,9 +10,12 @@ both go through this class — no other module touches the
 Canonical-pair ordering
 -----------------------
 ``(paper_a_id, paper_b_id)`` is stored as ``(min_id, max_id)`` so a
-lookup for (A,B) and (B,A) hits the same row.  The caller-supplied
-order is preserved in the returned :class:`CouplingResult` so callers
-are not surprised by swapped ids.  The DB's ``CHECK (paper_a_id <
+lookup for (A,B) and (B,A) hits the same row.  The returned
+:class:`CouplingResult` always carries the **canonical** (lexicographic
+min, max) order — ``get(B, A)`` returns a result whose ``paper_a_id``
+is ``min(A, B)`` and ``paper_b_id`` is ``max(A, B)``.  Callers that
+need to map the result back to their original ordering must re-derive
+the pair from the canonical ids.  The DB's ``CHECK (paper_a_id <
 paper_b_id)`` constraint enforces this at the storage layer; a
 repository that fails to call min/max before INSERT will receive a
 constraint error, which is the intended loud-failure mode.

--- a/src/services/intelligence/citation/coupling_repository.py
+++ b/src/services/intelligence/citation/coupling_repository.py
@@ -47,10 +47,11 @@ PRAGMAs, and closes on exit.  ``record`` uses
 
 Failure semantics
 -----------------
-``record``'s outer ``try`` catches ``sqlite3.Error`` so a cache write
-failure does NOT bubble up to the analyzer caller.  The exception is
-logged via ``coupling_repo_write_failed`` and swallowed — the caller
-still receives its in-memory result.
+``record`` RAISES :class:`sqlite3.Error` on a non-retryable write
+failure — mirrors :class:`CitationInfluenceRepository.record_metrics`
+(PR #143 pattern).  The caller (:meth:`CouplingAnalyzer.analyze_pair`)
+is responsible for the swallow-and-log pattern so callers can opt into
+loud failure if they choose a different wiring.
 """
 
 from __future__ import annotations
@@ -68,7 +69,6 @@ from src.services.intelligence.citation.models import CouplingResult
 from src.storage.intelligence_graph.connection import (
     DEFAULT_BACKOFF_SECONDS,
     DEFAULT_MAX_ATTEMPTS,
-    _trunc,
     open_connection,
     retry_on_lock_contention,
 )
@@ -192,27 +192,25 @@ class CitationCouplingRepository:
             **Async callers MUST wrap in ``asyncio.to_thread(...)``.**
 
         Failure semantics:
-            The outer ``try`` catches ``sqlite3.Error`` so a cache write
-            failure does NOT propagate to the analyzer caller.  The
-            exception is logged via ``coupling_repo_write_failed``.
+            Raises :class:`sqlite3.Error` on a non-retryable write
+            failure — mirrors :meth:`CitationInfluenceRepository.record_metrics`
+            (PR #143 pattern).  The caller (typically
+            :meth:`CouplingAnalyzer.analyze_pair`) is responsible for
+            swallowing the error if cache-write failures should not
+            propagate to end users.
 
         Args:
             result: Single :class:`CouplingResult` to upsert.
+
+        Raises:
+            sqlite3.Error: If the upsert fails after all retry attempts.
         """
-        try:
-            self._retry(
-                lambda: self._record_once(result),
-                operation_name="coupling_record",
-                paper_a_id=result.paper_a_id,
-                paper_b_id=result.paper_b_id,
-            )
-        except sqlite3.Error as exc:
-            logger.error(
-                "coupling_repo_write_failed",
-                paper_a_id=result.paper_a_id,
-                paper_b_id=result.paper_b_id,
-                error=_trunc(exc),
-            )
+        self._retry(
+            lambda: self._record_once(result),
+            operation_name="coupling_record",
+            paper_a_id=result.paper_a_id,
+            paper_b_id=result.paper_b_id,
+        )
 
     def _record_once(self, result: CouplingResult) -> None:
         """Single-attempt upsert of one row."""

--- a/src/services/intelligence/citation/models.py
+++ b/src/services/intelligence/citation/models.py
@@ -31,7 +31,7 @@ from datetime import date, datetime, timezone
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator
 
 from src.services.intelligence.citation._id_validation import (
     CANONICAL_NODE_ID_PATTERN,
@@ -394,3 +394,103 @@ class CitationEdge(BaseModel):
             target_id=self.cited_paper_id,
             properties=properties,
         )
+
+
+class CouplingResult(BaseModel):
+    """Result of bibliographic coupling analysis (REQ-9.2.3 / Issue #128).
+
+    Represents the Jaccard similarity between two papers based on their
+    shared references.  The pair is directional at the model level but
+    stored canonically (min_id, max_id) at the persistence layer.
+
+    Pydantic V2 strict — extra fields are forbidden so mis-spelled
+    kwargs fail loudly at construction time instead of being silently
+    ignored.
+    """
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    paper_a_id: str = Field(
+        ...,
+        min_length=1,
+        max_length=512,
+        description="First paper (canonical graph node id).",
+    )
+    paper_b_id: str = Field(
+        ...,
+        min_length=1,
+        max_length=512,
+        description=(
+            "Second paper (canonical graph node id). Must differ from paper_a_id."
+        ),
+    )
+    shared_references: list[str] = Field(
+        default_factory=list,
+        description="Sorted, deduplicated paper IDs cited by both papers.",
+    )
+    coupling_strength: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="Jaccard similarity of the two reference sets.",
+    )
+    co_citation_count: int = Field(
+        default=0,
+        ge=0,
+        description="Times both papers are cited together in a third paper.",
+    )
+
+    @field_validator("paper_a_id", "paper_b_id")
+    @classmethod
+    def _validate_paper_id(cls, v: str) -> str:
+        """Enforce the canonical node-id character set (post-normalization)."""
+        v = v.strip()
+        if not v:
+            raise ValueError("paper_id cannot be empty")
+        if not CANONICAL_NODE_ID_PATTERN.match(v):
+            raise ValueError(
+                f"Invalid paper_id format: {v!r}. "
+                "Allowed: alphanumeric, colons, periods, hyphens, underscores."
+            )
+        return v
+
+    @field_validator("paper_b_id")
+    @classmethod
+    def _reject_self_pair(cls, v: str, info: ValidationInfo) -> str:
+        """Reject a self-pair (paper_a_id == paper_b_id).
+
+        This guard runs *after* ``_validate_paper_id`` because validators
+        execute in field-declaration order and ``paper_b_id`` is declared
+        after ``paper_a_id``. By the time this validator fires,
+        ``info.data`` already contains the validated ``paper_a_id``.
+        """
+        paper_a = info.data.get("paper_a_id")
+        if paper_a is not None and v == paper_a:
+            raise ValueError(
+                f"paper_a_id and paper_b_id must differ; got {v!r} for both."
+            )
+        return v
+
+    @field_validator("shared_references")
+    @classmethod
+    def _validate_shared_references(cls, v: list[str]) -> list[str]:
+        """Ensure each reference ID matches the canonical pattern.
+
+        The list is also deduped and sorted here so callers that
+        build it via set operations don't need to remember to sort.
+        """
+        seen: set[str] = set()
+        validated: list[str] = []
+        for ref in v:
+            ref = ref.strip()
+            if not ref:
+                raise ValueError("shared_references entries must be non-empty strings")
+            if not CANONICAL_NODE_ID_PATTERN.match(ref):
+                raise ValueError(
+                    f"Invalid shared reference id: {ref!r}. "
+                    "Allowed: alphanumeric, colons, periods, hyphens, underscores."
+                )
+            if ref not in seen:
+                seen.add(ref)
+                validated.append(ref)
+        return sorted(validated)

--- a/src/services/intelligence/citation/models.py
+++ b/src/services/intelligence/citation/models.py
@@ -426,7 +426,12 @@ class CouplingResult(BaseModel):
     )
     shared_references: list[str] = Field(
         default_factory=list,
-        description="Sorted, deduplicated paper IDs cited by both papers.",
+        max_length=10_000,
+        description=(
+            "Sorted, deduplicated paper IDs cited by both papers. "
+            "Capped at 10,000 to bound JSON serialization cost and "
+            "cache row size."
+        ),
     )
     coupling_strength: float = Field(
         ...,

--- a/src/storage/intelligence_graph/migrations.py
+++ b/src/storage/intelligence_graph/migrations.py
@@ -411,55 +411,6 @@ MIGRATION_V4_CITATION_INFLUENCE_METRICS = Migration(
 )
 
 
-# Schema version 6: Bibliographic coupling cache.
-# Phase 9.2 — REQ-9.2.3 / Issue #128.
-#
-# Stores the result of one CouplingAnalyzer.analyze_pair() call keyed by the
-# ordered pair (paper_a_id, paper_b_id) where paper_a_id < paper_b_id. The
-# canonical-pair constraint ensures (A,B) and (B,A) occupy the same row so
-# lookups are symmetric by construction.
-#
-# Schema notes
-# ------------
-# - ``PRIMARY KEY (paper_a_id, paper_b_id)`` with the additional
-#   ``CHECK (paper_a_id < paper_b_id)`` enforces the canonical-ordering
-#   invariant at the storage layer; ``CitationCouplingRepository.record``
-#   MUST call ``min``/``max`` before INSERT.
-# - ``coupling_strength`` is REAL with ``CHECK (… >= 0.0 AND … <= 1.0)``
-#   mirroring the Pydantic field constraint so the DB rejects out-of-range
-#   rows that somehow slip past model validation.
-# - ``co_citation_count`` is INTEGER with ``CHECK (… >= 0)`` likewise.
-# - ``shared_references_json`` stores the sorted list as a JSON array.
-# - ``computed_at`` ISO-8601 string; the 30-day TTL is enforced in Python.
-# - No ``version`` column (unlike V4): the coupling table is a pure cache
-#   with no forward-compatibility concerns for its initial version.
-MIGRATION_V6_CITATION_COUPLING_CACHE = Migration(
-    version=6,
-    name="citation_coupling_cache",
-    description=(
-        "Add citation_coupling table for CouplingAnalyzer cache "
-        "(REQ-9.2.3 / Issue #128)."
-    ),
-    up="""
-    CREATE TABLE citation_coupling (
-        paper_a_id TEXT NOT NULL,
-        paper_b_id TEXT NOT NULL,
-        coupling_strength REAL NOT NULL
-            CHECK (coupling_strength >= 0.0 AND coupling_strength <= 1.0),
-        shared_references_json TEXT NOT NULL,
-        co_citation_count INTEGER NOT NULL
-            CHECK (co_citation_count >= 0),
-        computed_at TEXT NOT NULL,
-        PRIMARY KEY (paper_a_id, paper_b_id),
-        CHECK (paper_a_id < paper_b_id)
-    );
-
-    CREATE INDEX IF NOT EXISTS idx_citation_coupling_computed
-        ON citation_coupling(computed_at);
-    """,
-)
-
-
 # Schema version 5: Per-paper source provenance on monitoring_papers.
 # Phase 9.1 Tier 1 follow-up — Issue #141.
 #
@@ -543,6 +494,73 @@ MIGRATION_V5_PAPER_SOURCE_TRACKING = Migration(
     DROP TABLE monitoring_papers;
 
     ALTER TABLE monitoring_papers_new RENAME TO monitoring_papers;
+    """,
+)
+
+
+# Schema version 6: Bibliographic coupling cache.
+# Phase 9.2 — REQ-9.2.3 / Issue #128.
+#
+# Stores the result of one CouplingAnalyzer.analyze_pair() call keyed by the
+# ordered pair (paper_a_id, paper_b_id) where paper_a_id < paper_b_id. The
+# canonical-pair constraint ensures (A,B) and (B,A) occupy the same row so
+# lookups are symmetric by construction.
+#
+# Cache-only intent
+# -----------------
+# ``shared_references_json`` is a JSON array of paper ids — it captures
+# the reference overlap for display and scoring but is **opaque to SQL**.
+# Callers that need to query by individual shared reference (e.g.
+# "find all pairs that both cite paper X") cannot do so with a WHERE
+# clause on this column.  If that use-case emerges, add a V7
+# ``coupling_references`` join table:
+#
+#     coupling_references(paper_a_id, paper_b_id, shared_ref_id)
+#
+# with a FOREIGN KEY referencing ``citation_coupling(paper_a_id,
+# paper_b_id)`` and an index on ``shared_ref_id``. For now, the JSON
+# cache is sufficient for the recommender's read pattern (fetch the full
+# shared-reference list for a known pair).
+#
+# Schema notes
+# ------------
+# - ``PRIMARY KEY (paper_a_id, paper_b_id)`` with the additional
+#   ``CHECK (paper_a_id < paper_b_id)`` enforces the canonical-ordering
+#   invariant at the storage layer; ``CitationCouplingRepository.record``
+#   MUST call ``min``/``max`` before INSERT.
+# - ``coupling_strength`` is REAL with ``CHECK (… >= 0.0 AND … <= 1.0)``
+#   mirroring the Pydantic field constraint so the DB rejects out-of-range
+#   rows that somehow slip past model validation.  The drift-guard test
+#   ``test_migrate_v6_check_constraint_sql_contains_strength_and_co_citation_bounds``
+#   asserts both bounds are present in the SQL string.
+# - ``co_citation_count`` is INTEGER with ``CHECK (… >= 0)`` likewise.
+# - ``shared_references_json`` stores the sorted list as a JSON array.
+# - ``computed_at`` ISO-8601 string; the 30-day TTL is enforced in Python.
+# - No ``version`` column (unlike V4): the coupling table is a pure cache
+#   with no forward-compatibility concerns for its initial version.
+MIGRATION_V6_CITATION_COUPLING_CACHE = Migration(
+    version=6,
+    name="citation_coupling_cache",
+    description=(
+        "Add citation_coupling table for CouplingAnalyzer cache "
+        "(REQ-9.2.3 / Issue #128)."
+    ),
+    up="""
+    CREATE TABLE IF NOT EXISTS citation_coupling (
+        paper_a_id TEXT NOT NULL,
+        paper_b_id TEXT NOT NULL,
+        coupling_strength REAL NOT NULL
+            CHECK (coupling_strength >= 0.0 AND coupling_strength <= 1.0),
+        shared_references_json TEXT NOT NULL,
+        co_citation_count INTEGER NOT NULL
+            CHECK (co_citation_count >= 0),
+        computed_at TEXT NOT NULL,
+        PRIMARY KEY (paper_a_id, paper_b_id),
+        CHECK (paper_a_id < paper_b_id)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_citation_coupling_computed
+        ON citation_coupling(computed_at);
     """,
 )
 

--- a/src/storage/intelligence_graph/migrations.py
+++ b/src/storage/intelligence_graph/migrations.py
@@ -411,6 +411,55 @@ MIGRATION_V4_CITATION_INFLUENCE_METRICS = Migration(
 )
 
 
+# Schema version 6: Bibliographic coupling cache.
+# Phase 9.2 — REQ-9.2.3 / Issue #128.
+#
+# Stores the result of one CouplingAnalyzer.analyze_pair() call keyed by the
+# ordered pair (paper_a_id, paper_b_id) where paper_a_id < paper_b_id. The
+# canonical-pair constraint ensures (A,B) and (B,A) occupy the same row so
+# lookups are symmetric by construction.
+#
+# Schema notes
+# ------------
+# - ``PRIMARY KEY (paper_a_id, paper_b_id)`` with the additional
+#   ``CHECK (paper_a_id < paper_b_id)`` enforces the canonical-ordering
+#   invariant at the storage layer; ``CitationCouplingRepository.record``
+#   MUST call ``min``/``max`` before INSERT.
+# - ``coupling_strength`` is REAL with ``CHECK (… >= 0.0 AND … <= 1.0)``
+#   mirroring the Pydantic field constraint so the DB rejects out-of-range
+#   rows that somehow slip past model validation.
+# - ``co_citation_count`` is INTEGER with ``CHECK (… >= 0)`` likewise.
+# - ``shared_references_json`` stores the sorted list as a JSON array.
+# - ``computed_at`` ISO-8601 string; the 30-day TTL is enforced in Python.
+# - No ``version`` column (unlike V4): the coupling table is a pure cache
+#   with no forward-compatibility concerns for its initial version.
+MIGRATION_V6_CITATION_COUPLING_CACHE = Migration(
+    version=6,
+    name="citation_coupling_cache",
+    description=(
+        "Add citation_coupling table for CouplingAnalyzer cache "
+        "(REQ-9.2.3 / Issue #128)."
+    ),
+    up="""
+    CREATE TABLE citation_coupling (
+        paper_a_id TEXT NOT NULL,
+        paper_b_id TEXT NOT NULL,
+        coupling_strength REAL NOT NULL
+            CHECK (coupling_strength >= 0.0 AND coupling_strength <= 1.0),
+        shared_references_json TEXT NOT NULL,
+        co_citation_count INTEGER NOT NULL
+            CHECK (co_citation_count >= 0),
+        computed_at TEXT NOT NULL,
+        PRIMARY KEY (paper_a_id, paper_b_id),
+        CHECK (paper_a_id < paper_b_id)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_citation_coupling_computed
+        ON citation_coupling(computed_at);
+    """,
+)
+
+
 # Schema version 5: Per-paper source provenance on monitoring_papers.
 # Phase 9.1 Tier 1 follow-up — Issue #141.
 #
@@ -505,6 +554,7 @@ ALL_MIGRATIONS: list[Migration] = [
     MIGRATION_V3_MONITORING_RUNS_FK,
     MIGRATION_V4_CITATION_INFLUENCE_METRICS,
     MIGRATION_V5_PAPER_SOURCE_TRACKING,
+    MIGRATION_V6_CITATION_COUPLING_CACHE,
 ]
 
 
@@ -512,7 +562,7 @@ ALL_MIGRATIONS: list[Migration] = [
 # need to assert "we are on the canonical schema" import this rather
 # than counting ``ALL_MIGRATIONS`` so a future migration addition is
 # a single-line update.
-LATEST_MIGRATION_VERSION = 5
+LATEST_MIGRATION_VERSION = 6
 
 
 class MigrationManager:

--- a/tests/unit/services/intelligence/citation/test_coupling_analyzer.py
+++ b/tests/unit/services/intelligence/citation/test_coupling_analyzer.py
@@ -9,6 +9,9 @@ Covers:
 - analyze_for_paper top-k ordering and k-cap
 - Cache hit / miss (via injected repo mock)
 - Invalid paper id pattern
+- DoS guards: MAX_CANDIDATES, MAX_TOP_K
+- Tie-break determinism (L-5)
+- DEFAULT_MAX_AGE_DAYS TTL linkage (L-3)
 - Structured-log events via ``capture_logs()`` with the canonical
   "rebind logger before capture" pattern (CLAUDE.md §Test Authoring
   Conventions).
@@ -27,8 +30,13 @@ import structlog
 import structlog.testing
 
 import src.services.intelligence.citation.coupling_analyzer as analyzer_mod
-from src.services.intelligence.citation.coupling_analyzer import CouplingAnalyzer
+from src.services.intelligence.citation.coupling_analyzer import (
+    MAX_CANDIDATES,
+    MAX_TOP_K,
+    CouplingAnalyzer,
+)
 from src.services.intelligence.citation.coupling_repository import (
+    DEFAULT_MAX_AGE_DAYS,
     CitationCouplingRepository,
 )
 from src.services.intelligence.models import EdgeType, GraphEdge
@@ -111,14 +119,15 @@ def repo(db_path: Path) -> CitationCouplingRepository:
 
 
 class TestAnalyzePairJaccard:
-    def test_coupling_jaccard_exact_example_from_spec(self) -> None:
+    @pytest.mark.asyncio
+    async def test_coupling_jaccard_exact_example_from_spec(self) -> None:
         """Spec example: A:[R1..R5], B:[R2,R3,R4,R6,R7] → 3/7 ≈ 0.4286.
 
         Pinned with pytest.approx per REQ-9.2.3 §617.
         """
         store = _mock_store_with_refs({PAPER_A: REFS_A, PAPER_B: REFS_B})
         analyzer = CouplingAnalyzer(store)
-        result = analyzer.analyze_pair(PAPER_A, PAPER_B)
+        result = await analyzer.analyze_pair(PAPER_A, PAPER_B)
 
         assert result.coupling_strength == pytest.approx(3 / 7, rel=1e-6)
         assert sorted(result.shared_references) == sorted(
@@ -127,7 +136,8 @@ class TestAnalyzePairJaccard:
         assert result.paper_a_id == PAPER_A
         assert result.paper_b_id == PAPER_B
 
-    def test_coupling_no_overlap(self) -> None:
+    @pytest.mark.asyncio
+    async def test_coupling_no_overlap(self) -> None:
         """Papers with entirely disjoint reference sets → strength 0.0."""
         store = _mock_store_with_refs(
             {
@@ -136,37 +146,40 @@ class TestAnalyzePairJaccard:
             }
         )
         analyzer = CouplingAnalyzer(store)
-        result = analyzer.analyze_pair(PAPER_A, PAPER_B)
+        result = await analyzer.analyze_pair(PAPER_A, PAPER_B)
 
         assert result.coupling_strength == pytest.approx(0.0)
         assert result.shared_references == []
 
-    def test_coupling_identical_refs(self) -> None:
+    @pytest.mark.asyncio
+    async def test_coupling_identical_refs(self) -> None:
         """Papers with identical reference sets → strength 1.0."""
         refs = ["paper:s2:r1", "paper:s2:r2", "paper:s2:r3"]
         store = _mock_store_with_refs({PAPER_A: refs, PAPER_B: refs})
         analyzer = CouplingAnalyzer(store)
-        result = analyzer.analyze_pair(PAPER_A, PAPER_B)
+        result = await analyzer.analyze_pair(PAPER_A, PAPER_B)
 
         assert result.coupling_strength == pytest.approx(1.0)
         assert sorted(result.shared_references) == sorted(refs)
 
-    def test_coupling_paper_with_no_refs(self) -> None:
+    @pytest.mark.asyncio
+    async def test_coupling_paper_with_no_refs(self) -> None:
         """Both papers have zero references → strength 0.0, no ZeroDivisionError."""
         store = _mock_store_with_refs({})  # no refs for either paper
         analyzer = CouplingAnalyzer(store)
-        result = analyzer.analyze_pair(PAPER_A, PAPER_B)
+        result = await analyzer.analyze_pair(PAPER_A, PAPER_B)
 
         assert result.coupling_strength == pytest.approx(0.0)
         assert result.shared_references == []
 
-    def test_coupling_one_paper_no_refs(self) -> None:
+    @pytest.mark.asyncio
+    async def test_coupling_one_paper_no_refs(self) -> None:
         """One paper has refs, the other has none → strength 0.0."""
         store = _mock_store_with_refs(
             {PAPER_A: ["paper:s2:r1", "paper:s2:r2"], PAPER_B: []}
         )
         analyzer = CouplingAnalyzer(store)
-        result = analyzer.analyze_pair(PAPER_A, PAPER_B)
+        result = await analyzer.analyze_pair(PAPER_A, PAPER_B)
 
         assert result.coupling_strength == pytest.approx(0.0)
         assert result.shared_references == []
@@ -178,38 +191,42 @@ class TestAnalyzePairJaccard:
 
 
 class TestAnalyzePairValidation:
-    def test_coupling_self_pair_raises(self) -> None:
+    @pytest.mark.asyncio
+    async def test_coupling_self_pair_raises(self) -> None:
         """analyze_pair with paper_a_id == paper_b_id raises ValueError."""
         store = _mock_store_with_refs({})
         analyzer = CouplingAnalyzer(store)
 
         with pytest.raises(ValueError, match="must differ"):
-            analyzer.analyze_pair(PAPER_A, PAPER_A)
+            await analyzer.analyze_pair(PAPER_A, PAPER_A)
 
-    def test_invalid_paper_id_pattern_raises(self) -> None:
+    @pytest.mark.asyncio
+    async def test_invalid_paper_id_pattern_raises(self) -> None:
         """analyze_pair with an id containing disallowed chars raises ValueError."""
         store = _mock_store_with_refs({})
         analyzer = CouplingAnalyzer(store)
 
         with pytest.raises(ValueError, match="Invalid paper_id format"):
-            analyzer.analyze_pair("paper:s2:a b c", PAPER_B)
+            await analyzer.analyze_pair("paper:s2:a b c", PAPER_B)
 
-    def test_invalid_paper_id_empty_raises(self) -> None:
+    @pytest.mark.asyncio
+    async def test_invalid_paper_id_empty_raises(self) -> None:
         """analyze_pair with an empty id raises ValueError."""
         store = _mock_store_with_refs({})
         analyzer = CouplingAnalyzer(store)
 
         with pytest.raises(ValueError, match="non-empty string"):
-            analyzer.analyze_pair("", PAPER_B)
+            await analyzer.analyze_pair("", PAPER_B)
 
-    def test_invalid_paper_id_too_long_raises(self) -> None:
+    @pytest.mark.asyncio
+    async def test_invalid_paper_id_too_long_raises(self) -> None:
         """analyze_pair with an id exceeding the length cap raises ValueError."""
         store = _mock_store_with_refs({})
         analyzer = CouplingAnalyzer(store)
         long_id = "paper:s2:" + "a" * 600
 
         with pytest.raises(ValueError, match="exceeds max"):
-            analyzer.analyze_pair(long_id, PAPER_B)
+            await analyzer.analyze_pair(long_id, PAPER_B)
 
 
 # ---------------------------------------------------------------------------
@@ -218,7 +235,8 @@ class TestAnalyzePairValidation:
 
 
 class TestAnalyzeForPaper:
-    def test_analyze_for_paper_top_k_ordering(self) -> None:
+    @pytest.mark.asyncio
+    async def test_analyze_for_paper_top_k_ordering(self) -> None:
         """analyze_for_paper returns results sorted DESC by coupling_strength."""
         # PAPER_A is the query paper.
         # PAPER_B shares 2 refs with A (out of 3), PAPER_C shares 1 (out of 3).
@@ -230,7 +248,9 @@ class TestAnalyzeForPaper:
             }
         )
         analyzer = CouplingAnalyzer(store)
-        results = analyzer.analyze_for_paper(PAPER_A, [PAPER_B, PAPER_C], top_k=10)
+        results = await analyzer.analyze_for_paper(
+            PAPER_A, [PAPER_B, PAPER_C], top_k=10
+        )
 
         assert len(results) == 2
         # B has higher coupling than C.
@@ -238,7 +258,8 @@ class TestAnalyzeForPaper:
         assert results[1].paper_b_id == PAPER_C
         assert results[0].coupling_strength > results[1].coupling_strength
 
-    def test_analyze_for_paper_respects_top_k(self) -> None:
+    @pytest.mark.asyncio
+    async def test_analyze_for_paper_respects_top_k(self) -> None:
         """analyze_for_paper returns at most top_k results."""
         papers = [f"paper:s2:cand{i:03d}" for i in range(20)]
         # All candidates share the same 1 ref → equal strength; top_k=5.
@@ -249,26 +270,77 @@ class TestAnalyzeForPaper:
             }
         )
         analyzer = CouplingAnalyzer(store)
-        results = analyzer.analyze_for_paper(PAPER_A, papers, top_k=5)
+        results = await analyzer.analyze_for_paper(PAPER_A, papers, top_k=5)
 
         assert len(results) == 5
 
-    def test_analyze_for_paper_invalid_top_k_raises(self) -> None:
+    @pytest.mark.asyncio
+    async def test_analyze_for_paper_invalid_top_k_raises(self) -> None:
         """analyze_for_paper with top_k < 1 raises ValueError."""
         store = _mock_store_with_refs({})
         analyzer = CouplingAnalyzer(store)
 
         with pytest.raises(ValueError, match="top_k must be >= 1"):
-            analyzer.analyze_for_paper(PAPER_A, [PAPER_B], top_k=0)
+            await analyzer.analyze_for_paper(PAPER_A, [PAPER_B], top_k=0)
 
-    def test_analyze_for_paper_empty_candidates(self) -> None:
+    @pytest.mark.asyncio
+    async def test_analyze_for_paper_empty_candidates(self) -> None:
         """analyze_for_paper with empty candidate list returns empty list."""
         store = _mock_store_with_refs({})
         analyzer = CouplingAnalyzer(store)
 
-        results = analyzer.analyze_for_paper(PAPER_A, [], top_k=10)
+        results = await analyzer.analyze_for_paper(PAPER_A, [], top_k=10)
 
         assert results == []
+
+    @pytest.mark.asyncio
+    async def test_analyze_for_paper_exceeds_max_candidates_raises(self) -> None:
+        """analyze_for_paper raises ValueError when candidates > MAX_CANDIDATES."""
+        store = _mock_store_with_refs({})
+        analyzer = CouplingAnalyzer(store)
+        too_many = [f"paper:s2:c{i:06d}" for i in range(MAX_CANDIDATES + 1)]
+
+        with pytest.raises(ValueError, match="MAX_CANDIDATES"):
+            await analyzer.analyze_for_paper(PAPER_A, too_many, top_k=10)
+
+    @pytest.mark.asyncio
+    async def test_analyze_for_paper_clamps_top_k_to_max(self) -> None:
+        """analyze_for_paper silently clamps top_k > MAX_TOP_K."""
+        papers = [f"paper:s2:c{i:04d}" for i in range(5)]
+        store = _mock_store_with_refs(
+            {PAPER_A: ["paper:s2:r1"], **{p: ["paper:s2:r1"] for p in papers}}
+        )
+        analyzer = CouplingAnalyzer(store)
+        # top_k above MAX_TOP_K should be accepted (no raise) and clamped.
+        results = await analyzer.analyze_for_paper(
+            PAPER_A, papers, top_k=MAX_TOP_K + 999
+        )
+        # We only have 5 candidates, so max 5 results returned.
+        assert len(results) <= 5
+
+    @pytest.mark.asyncio
+    async def test_analyze_for_paper_ties_broken_by_paper_b_id_ascending(
+        self,
+    ) -> None:
+        """L-5: Equal coupling_strength ties are broken by paper_b_id ascending."""
+        # All candidates share the same single reference → equal strength.
+        papers = [
+            "paper:s2:zzz",
+            "paper:s2:aaa",
+            "paper:s2:mmm",
+        ]
+        store = _mock_store_with_refs(
+            {
+                PAPER_A: ["paper:s2:shared"],
+                **{p: ["paper:s2:shared"] for p in papers},
+            }
+        )
+        analyzer = CouplingAnalyzer(store)
+        results = await analyzer.analyze_for_paper(PAPER_A, papers, top_k=10)
+
+        # All strengths equal → alphabetical ascending on paper_b_id.
+        b_ids = [r.paper_b_id for r in results]
+        assert b_ids == sorted(b_ids)
 
 
 # ---------------------------------------------------------------------------
@@ -277,7 +349,10 @@ class TestAnalyzeForPaper:
 
 
 class TestStructuredLogging:
-    def test_pair_computed_event_emitted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    @pytest.mark.asyncio
+    async def test_pair_computed_event_emitted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """``coupling_analyzer_pair_computed`` event is logged on each compute."""
         # Rebind logger BEFORE entering capture_logs() per CLAUDE.md §Test
         # Authoring Conventions (cache_logger_on_first_use pattern).
@@ -288,7 +363,7 @@ class TestStructuredLogging:
         analyzer = CouplingAnalyzer(store)
 
         with structlog.testing.capture_logs() as logs:
-            analyzer.analyze_pair(PAPER_A, PAPER_B)
+            await analyzer.analyze_pair(PAPER_A, PAPER_B)
 
         events = [
             e for e in logs if e.get("event") == "coupling_analyzer_pair_computed"
@@ -299,7 +374,8 @@ class TestStructuredLogging:
         assert events[0]["shared"] == 1
         assert events[0]["union"] == 2
 
-    def test_skipped_no_refs_event_emitted(
+    @pytest.mark.asyncio
+    async def test_skipped_no_refs_event_emitted(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """``coupling_analyzer_skipped_no_refs`` is logged when both have 0 refs."""
@@ -308,7 +384,7 @@ class TestStructuredLogging:
         analyzer = CouplingAnalyzer(store)
 
         with structlog.testing.capture_logs() as logs:
-            analyzer.analyze_pair(PAPER_A, PAPER_B)
+            await analyzer.analyze_pair(PAPER_A, PAPER_B)
 
         events = [
             e for e in logs if e.get("event") == "coupling_analyzer_skipped_no_refs"
@@ -324,16 +400,19 @@ class TestStructuredLogging:
 
 
 class TestCacheIntegration:
-    def test_persistence_cache_hit(self, repo: CitationCouplingRepository) -> None:
+    @pytest.mark.asyncio
+    async def test_persistence_cache_hit(
+        self, repo: CitationCouplingRepository
+    ) -> None:
         """Second call within TTL returns the cached row without re-computing."""
         store = _mock_store_with_refs({PAPER_A: REFS_A, PAPER_B: REFS_B})
         analyzer = CouplingAnalyzer(store, repo=repo)
 
-        first = analyzer.analyze_pair(PAPER_A, PAPER_B)
+        first = await analyzer.analyze_pair(PAPER_A, PAPER_B)
         # Reset the store mock so a second store call would be detectable.
         store.get_edges.reset_mock()
 
-        second = analyzer.analyze_pair(PAPER_A, PAPER_B)
+        second = await analyzer.analyze_pair(PAPER_A, PAPER_B)
 
         # Values must match.
         assert second.coupling_strength == pytest.approx(first.coupling_strength)
@@ -341,7 +420,8 @@ class TestCacheIntegration:
         # The store must NOT have been called again (cache hit path).
         store.get_edges.assert_not_called()
 
-    def test_persistence_cache_miss_after_ttl(
+    @pytest.mark.asyncio
+    async def test_persistence_cache_miss_after_ttl(
         self,
         repo: CitationCouplingRepository,
         db_path: Path,
@@ -371,12 +451,15 @@ class TestCacheIntegration:
         cached = repo.get(PAPER_A, PAPER_B, max_age_days=30)
         assert cached is None  # stale row → cache miss
 
-        # Re-run via the analyzer; the store WILL be called.
+        # Re-run via the analyzer; the store WILL be called (M-8 pattern).
         store.get_edges.reset_mock()
-        analyzer.analyze_pair(PAPER_A, PAPER_B)
-        assert store.get_edges.called
+        await analyzer.analyze_pair(PAPER_A, PAPER_B)
+        store.get_edges.assert_any_call(
+            PAPER_A, direction="outgoing", edge_type=EdgeType.CITES
+        )
 
-    def test_cache_write_failure_swallowed(self, db_path: Path) -> None:
+    @pytest.mark.asyncio
+    async def test_cache_write_failure_swallowed(self, db_path: Path) -> None:
         """A repo write failure does not propagate to the caller."""
         failing_repo = MagicMock(spec=CitationCouplingRepository)
         failing_repo.get.return_value = None  # always cache miss
@@ -386,10 +469,11 @@ class TestCacheIntegration:
         analyzer = CouplingAnalyzer(store, repo=failing_repo)
 
         # Must not raise even though repo.record raises.
-        result = analyzer.analyze_pair(PAPER_A, PAPER_B)
+        result = await analyzer.analyze_pair(PAPER_A, PAPER_B)
         assert result.coupling_strength == pytest.approx(3 / 7, rel=1e-6)
 
-    def test_cache_write_failure_logs_error(
+    @pytest.mark.asyncio
+    async def test_cache_write_failure_logs_error(
         self,
         db_path: Path,
         monkeypatch: pytest.MonkeyPatch,
@@ -404,10 +488,20 @@ class TestCacheIntegration:
         analyzer = CouplingAnalyzer(store, repo=failing_repo)
 
         with structlog.testing.capture_logs() as logs:
-            analyzer.analyze_pair(PAPER_A, PAPER_B)
+            await analyzer.analyze_pair(PAPER_A, PAPER_B)
 
         events = [
             e for e in logs if e.get("event") == "coupling_analyzer_cache_write_failed"
         ]
         assert len(events) == 1
         assert "disk full" in events[0]["error"]
+
+    def test_analyzer_uses_default_ttl_from_repo(self) -> None:
+        """L-3: DEFAULT_MAX_AGE_DAYS from the repo module is a stable constant.
+
+        The analyzer's cache lookups rely on the repo's TTL default.
+        This test pins that the constant is reachable and positive so
+        any future accidental rename/removal fails loudly here.
+        """
+        assert DEFAULT_MAX_AGE_DAYS > 0
+        assert isinstance(DEFAULT_MAX_AGE_DAYS, int)

--- a/tests/unit/services/intelligence/citation/test_coupling_analyzer.py
+++ b/tests/unit/services/intelligence/citation/test_coupling_analyzer.py
@@ -505,3 +505,43 @@ class TestCacheIntegration:
         """
         assert DEFAULT_MAX_AGE_DAYS > 0
         assert isinstance(DEFAULT_MAX_AGE_DAYS, int)
+
+
+# ---------------------------------------------------------------------------
+# 6. References truncation guard (M-10)
+# ---------------------------------------------------------------------------
+
+
+class TestReferencesTruncation:
+    @pytest.mark.asyncio
+    async def test_references_truncated_event_emitted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """coupling_references_truncated warning is emitted when refs exceed cap.
+
+        M-10: _get_references caps the edge list at _MAX_REFERENCES and
+        emits an audit event so operators can detect unexpectedly dense
+        reference sets.
+        """
+        from src.services.intelligence.citation.coupling_analyzer import (
+            _MAX_REFERENCES,
+        )
+
+        monkeypatch.setattr(analyzer_mod, "logger", structlog.get_logger())
+        # Produce _MAX_REFERENCES + 1 edges for PAPER_A to trigger the cap.
+        oversized_refs = [f"paper:s2:r{i:06d}" for i in range(_MAX_REFERENCES + 1)]
+        store = _mock_store_with_refs({PAPER_A: oversized_refs, PAPER_B: []})
+        analyzer = CouplingAnalyzer(store)
+
+        with structlog.testing.capture_logs() as logs:
+            result = await analyzer.analyze_pair(PAPER_A, PAPER_B)
+
+        trunc_events = [
+            e for e in logs if e.get("event") == "coupling_references_truncated"
+        ]
+        assert len(trunc_events) >= 1
+        assert trunc_events[0]["paper_id"] == PAPER_A
+        assert trunc_events[0]["fetched"] == _MAX_REFERENCES + 1
+        assert trunc_events[0]["cap"] == _MAX_REFERENCES
+        # Computation still succeeds; PAPER_B has no refs so strength=0.
+        assert result.coupling_strength == pytest.approx(0.0)

--- a/tests/unit/services/intelligence/citation/test_coupling_analyzer.py
+++ b/tests/unit/services/intelligence/citation/test_coupling_analyzer.py
@@ -1,0 +1,413 @@
+"""Tests for :class:`CouplingAnalyzer` (Issue #128 / REQ-9.2.3).
+
+Covers:
+- Exact spec example: A:[R1..R5], B:[R2,R3,R4,R6,R7] → 3/7 ≈ 0.4286
+- No-overlap pair (strength 0.0)
+- Identical reference sets (strength 1.0)
+- Self-pair rejection
+- Zero-reference papers (handles 0/0 gracefully → 0.0)
+- analyze_for_paper top-k ordering and k-cap
+- Cache hit / miss (via injected repo mock)
+- Invalid paper id pattern
+- Structured-log events via ``capture_logs()`` with the canonical
+  "rebind logger before capture" pattern (CLAUDE.md §Test Authoring
+  Conventions).
+"""
+
+from __future__ import annotations
+
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Iterator
+from unittest.mock import MagicMock
+
+import pytest
+import structlog
+import structlog.testing
+
+import src.services.intelligence.citation.coupling_analyzer as analyzer_mod
+from src.services.intelligence.citation.coupling_analyzer import CouplingAnalyzer
+from src.services.intelligence.citation.coupling_repository import (
+    CitationCouplingRepository,
+)
+from src.services.intelligence.models import EdgeType, GraphEdge
+from src.storage.intelligence_graph import SQLiteGraphStore
+
+# ---------------------------------------------------------------------------
+# Helpers and fixtures
+# ---------------------------------------------------------------------------
+
+PAPER_A = "paper:s2:alpha"
+PAPER_B = "paper:s2:beta"
+PAPER_C = "paper:s2:gamma"
+
+# Spec example reference sets (REQ-9.2.3 §617)
+REFS_A = [
+    "paper:s2:r1",
+    "paper:s2:r2",
+    "paper:s2:r3",
+    "paper:s2:r4",
+    "paper:s2:r5",
+]
+REFS_B = [
+    "paper:s2:r2",
+    "paper:s2:r3",
+    "paper:s2:r4",
+    "paper:s2:r6",
+    "paper:s2:r7",
+]
+
+
+def _make_edge(source: str, target: str) -> GraphEdge:
+    """Build a minimal CITES GraphEdge for testing."""
+    return GraphEdge(
+        edge_id=f"edge:cites:{source}-{target}",
+        edge_type=EdgeType.CITES,
+        source_id=source,
+        target_id=target,
+        properties={},
+    )
+
+
+def _mock_store_with_refs(refs_map: dict[str, list[str]]) -> MagicMock:
+    """Return a mock SQLiteGraphStore whose get_edges returns controlled data.
+
+    ``refs_map`` maps paper_id → list of cited paper_ids (outgoing CITES).
+    """
+    store = MagicMock(spec=SQLiteGraphStore)
+
+    def _get_edges(
+        node_id: str,
+        direction: str = "both",
+        edge_type: EdgeType | None = None,
+    ) -> list[GraphEdge]:
+        if direction == "outgoing" and edge_type == EdgeType.CITES:
+            return [_make_edge(node_id, ref) for ref in refs_map.get(node_id, [])]
+        return []
+
+    store.get_edges.side_effect = _get_edges
+    return store
+
+
+@pytest.fixture
+def db_path() -> Iterator[Path]:
+    """Temporary SQLite file cleaned up after each test."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        path = Path(f.name)
+    path.unlink(missing_ok=True)
+    yield path
+    path.unlink(missing_ok=True)
+
+
+@pytest.fixture
+def repo(db_path: Path) -> CitationCouplingRepository:
+    return CitationCouplingRepository.connect(db_path)
+
+
+# ---------------------------------------------------------------------------
+# 1. Core Jaccard computation
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzePairJaccard:
+    def test_coupling_jaccard_exact_example_from_spec(self) -> None:
+        """Spec example: A:[R1..R5], B:[R2,R3,R4,R6,R7] → 3/7 ≈ 0.4286.
+
+        Pinned with pytest.approx per REQ-9.2.3 §617.
+        """
+        store = _mock_store_with_refs({PAPER_A: REFS_A, PAPER_B: REFS_B})
+        analyzer = CouplingAnalyzer(store)
+        result = analyzer.analyze_pair(PAPER_A, PAPER_B)
+
+        assert result.coupling_strength == pytest.approx(3 / 7, rel=1e-6)
+        assert sorted(result.shared_references) == sorted(
+            ["paper:s2:r2", "paper:s2:r3", "paper:s2:r4"]
+        )
+        assert result.paper_a_id == PAPER_A
+        assert result.paper_b_id == PAPER_B
+
+    def test_coupling_no_overlap(self) -> None:
+        """Papers with entirely disjoint reference sets → strength 0.0."""
+        store = _mock_store_with_refs(
+            {
+                PAPER_A: ["paper:s2:r1", "paper:s2:r2"],
+                PAPER_B: ["paper:s2:r3", "paper:s2:r4"],
+            }
+        )
+        analyzer = CouplingAnalyzer(store)
+        result = analyzer.analyze_pair(PAPER_A, PAPER_B)
+
+        assert result.coupling_strength == pytest.approx(0.0)
+        assert result.shared_references == []
+
+    def test_coupling_identical_refs(self) -> None:
+        """Papers with identical reference sets → strength 1.0."""
+        refs = ["paper:s2:r1", "paper:s2:r2", "paper:s2:r3"]
+        store = _mock_store_with_refs({PAPER_A: refs, PAPER_B: refs})
+        analyzer = CouplingAnalyzer(store)
+        result = analyzer.analyze_pair(PAPER_A, PAPER_B)
+
+        assert result.coupling_strength == pytest.approx(1.0)
+        assert sorted(result.shared_references) == sorted(refs)
+
+    def test_coupling_paper_with_no_refs(self) -> None:
+        """Both papers have zero references → strength 0.0, no ZeroDivisionError."""
+        store = _mock_store_with_refs({})  # no refs for either paper
+        analyzer = CouplingAnalyzer(store)
+        result = analyzer.analyze_pair(PAPER_A, PAPER_B)
+
+        assert result.coupling_strength == pytest.approx(0.0)
+        assert result.shared_references == []
+
+    def test_coupling_one_paper_no_refs(self) -> None:
+        """One paper has refs, the other has none → strength 0.0."""
+        store = _mock_store_with_refs(
+            {PAPER_A: ["paper:s2:r1", "paper:s2:r2"], PAPER_B: []}
+        )
+        analyzer = CouplingAnalyzer(store)
+        result = analyzer.analyze_pair(PAPER_A, PAPER_B)
+
+        assert result.coupling_strength == pytest.approx(0.0)
+        assert result.shared_references == []
+
+
+# ---------------------------------------------------------------------------
+# 2. Validation / error paths
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzePairValidation:
+    def test_coupling_self_pair_raises(self) -> None:
+        """analyze_pair with paper_a_id == paper_b_id raises ValueError."""
+        store = _mock_store_with_refs({})
+        analyzer = CouplingAnalyzer(store)
+
+        with pytest.raises(ValueError, match="must differ"):
+            analyzer.analyze_pair(PAPER_A, PAPER_A)
+
+    def test_invalid_paper_id_pattern_raises(self) -> None:
+        """analyze_pair with an id containing disallowed chars raises ValueError."""
+        store = _mock_store_with_refs({})
+        analyzer = CouplingAnalyzer(store)
+
+        with pytest.raises(ValueError, match="Invalid paper_id format"):
+            analyzer.analyze_pair("paper:s2:a b c", PAPER_B)
+
+    def test_invalid_paper_id_empty_raises(self) -> None:
+        """analyze_pair with an empty id raises ValueError."""
+        store = _mock_store_with_refs({})
+        analyzer = CouplingAnalyzer(store)
+
+        with pytest.raises(ValueError, match="non-empty string"):
+            analyzer.analyze_pair("", PAPER_B)
+
+    def test_invalid_paper_id_too_long_raises(self) -> None:
+        """analyze_pair with an id exceeding the length cap raises ValueError."""
+        store = _mock_store_with_refs({})
+        analyzer = CouplingAnalyzer(store)
+        long_id = "paper:s2:" + "a" * 600
+
+        with pytest.raises(ValueError, match="exceeds max"):
+            analyzer.analyze_pair(long_id, PAPER_B)
+
+
+# ---------------------------------------------------------------------------
+# 3. analyze_for_paper ordering and top-k
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeForPaper:
+    def test_analyze_for_paper_top_k_ordering(self) -> None:
+        """analyze_for_paper returns results sorted DESC by coupling_strength."""
+        # PAPER_A is the query paper.
+        # PAPER_B shares 2 refs with A (out of 3), PAPER_C shares 1 (out of 3).
+        store = _mock_store_with_refs(
+            {
+                PAPER_A: ["paper:s2:r1", "paper:s2:r2", "paper:s2:r3"],
+                PAPER_B: ["paper:s2:r1", "paper:s2:r2", "paper:s2:r4"],  # 2/4
+                PAPER_C: ["paper:s2:r1", "paper:s2:r5"],  # 1/4
+            }
+        )
+        analyzer = CouplingAnalyzer(store)
+        results = analyzer.analyze_for_paper(PAPER_A, [PAPER_B, PAPER_C], top_k=10)
+
+        assert len(results) == 2
+        # B has higher coupling than C.
+        assert results[0].paper_b_id == PAPER_B
+        assert results[1].paper_b_id == PAPER_C
+        assert results[0].coupling_strength > results[1].coupling_strength
+
+    def test_analyze_for_paper_respects_top_k(self) -> None:
+        """analyze_for_paper returns at most top_k results."""
+        papers = [f"paper:s2:cand{i:03d}" for i in range(20)]
+        # All candidates share the same 1 ref → equal strength; top_k=5.
+        store = _mock_store_with_refs(
+            {
+                PAPER_A: ["paper:s2:ref001"],
+                **{p: ["paper:s2:ref001"] for p in papers},
+            }
+        )
+        analyzer = CouplingAnalyzer(store)
+        results = analyzer.analyze_for_paper(PAPER_A, papers, top_k=5)
+
+        assert len(results) == 5
+
+    def test_analyze_for_paper_invalid_top_k_raises(self) -> None:
+        """analyze_for_paper with top_k < 1 raises ValueError."""
+        store = _mock_store_with_refs({})
+        analyzer = CouplingAnalyzer(store)
+
+        with pytest.raises(ValueError, match="top_k must be >= 1"):
+            analyzer.analyze_for_paper(PAPER_A, [PAPER_B], top_k=0)
+
+    def test_analyze_for_paper_empty_candidates(self) -> None:
+        """analyze_for_paper with empty candidate list returns empty list."""
+        store = _mock_store_with_refs({})
+        analyzer = CouplingAnalyzer(store)
+
+        results = analyzer.analyze_for_paper(PAPER_A, [], top_k=10)
+
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# 4. Structured-log event assertions
+# ---------------------------------------------------------------------------
+
+
+class TestStructuredLogging:
+    def test_pair_computed_event_emitted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``coupling_analyzer_pair_computed`` event is logged on each compute."""
+        # Rebind logger BEFORE entering capture_logs() per CLAUDE.md §Test
+        # Authoring Conventions (cache_logger_on_first_use pattern).
+        monkeypatch.setattr(analyzer_mod, "logger", structlog.get_logger())
+        store = _mock_store_with_refs(
+            {PAPER_A: ["paper:s2:r1"], PAPER_B: ["paper:s2:r1", "paper:s2:r2"]}
+        )
+        analyzer = CouplingAnalyzer(store)
+
+        with structlog.testing.capture_logs() as logs:
+            analyzer.analyze_pair(PAPER_A, PAPER_B)
+
+        events = [
+            e for e in logs if e.get("event") == "coupling_analyzer_pair_computed"
+        ]
+        assert len(events) == 1
+        assert events[0]["paper_a_id"] == PAPER_A
+        assert events[0]["paper_b_id"] == PAPER_B
+        assert events[0]["shared"] == 1
+        assert events[0]["union"] == 2
+
+    def test_skipped_no_refs_event_emitted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``coupling_analyzer_skipped_no_refs`` is logged when both have 0 refs."""
+        monkeypatch.setattr(analyzer_mod, "logger", structlog.get_logger())
+        store = _mock_store_with_refs({})
+        analyzer = CouplingAnalyzer(store)
+
+        with structlog.testing.capture_logs() as logs:
+            analyzer.analyze_pair(PAPER_A, PAPER_B)
+
+        events = [
+            e for e in logs if e.get("event") == "coupling_analyzer_skipped_no_refs"
+        ]
+        assert len(events) == 1
+        assert events[0]["paper_a_id"] == PAPER_A
+        assert events[0]["paper_b_id"] == PAPER_B
+
+
+# ---------------------------------------------------------------------------
+# 5. Cache integration (repo wired in)
+# ---------------------------------------------------------------------------
+
+
+class TestCacheIntegration:
+    def test_persistence_cache_hit(self, repo: CitationCouplingRepository) -> None:
+        """Second call within TTL returns the cached row without re-computing."""
+        store = _mock_store_with_refs({PAPER_A: REFS_A, PAPER_B: REFS_B})
+        analyzer = CouplingAnalyzer(store, repo=repo)
+
+        first = analyzer.analyze_pair(PAPER_A, PAPER_B)
+        # Reset the store mock so a second store call would be detectable.
+        store.get_edges.reset_mock()
+
+        second = analyzer.analyze_pair(PAPER_A, PAPER_B)
+
+        # Values must match.
+        assert second.coupling_strength == pytest.approx(first.coupling_strength)
+        assert second.shared_references == first.shared_references
+        # The store must NOT have been called again (cache hit path).
+        store.get_edges.assert_not_called()
+
+    def test_persistence_cache_miss_after_ttl(
+        self,
+        repo: CitationCouplingRepository,
+        db_path: Path,
+    ) -> None:
+        """Stale row (older than TTL) triggers recompute, not a cache hit."""
+        from src.storage.intelligence_graph.connection import open_connection
+
+        store = _mock_store_with_refs({PAPER_A: REFS_A, PAPER_B: REFS_B})
+        analyzer = CouplingAnalyzer(store, repo=repo)
+
+        # Insert a row with an old timestamp directly so we can control staleness.
+        old_ts = (datetime.now(timezone.utc) - timedelta(days=40)).isoformat()
+        # Canonicalize pair for insert.
+        canon_a = min(PAPER_A, PAPER_B)
+        canon_b = max(PAPER_A, PAPER_B)
+        with open_connection(db_path) as conn:
+            conn.execute(
+                "INSERT INTO citation_coupling"
+                " (paper_a_id, paper_b_id, coupling_strength,"
+                "  shared_references_json, co_citation_count, computed_at)"
+                " VALUES (?, ?, ?, ?, ?, ?)",
+                (canon_a, canon_b, 0.5, "[]", 0, old_ts),
+            )
+            conn.commit()
+
+        # Verify: direct repo.get with max_age_days=30 treats old row as stale.
+        cached = repo.get(PAPER_A, PAPER_B, max_age_days=30)
+        assert cached is None  # stale row → cache miss
+
+        # Re-run via the analyzer; the store WILL be called.
+        store.get_edges.reset_mock()
+        analyzer.analyze_pair(PAPER_A, PAPER_B)
+        assert store.get_edges.called
+
+    def test_cache_write_failure_swallowed(self, db_path: Path) -> None:
+        """A repo write failure does not propagate to the caller."""
+        failing_repo = MagicMock(spec=CitationCouplingRepository)
+        failing_repo.get.return_value = None  # always cache miss
+        failing_repo.record.side_effect = Exception("disk full")
+
+        store = _mock_store_with_refs({PAPER_A: REFS_A, PAPER_B: REFS_B})
+        analyzer = CouplingAnalyzer(store, repo=failing_repo)
+
+        # Must not raise even though repo.record raises.
+        result = analyzer.analyze_pair(PAPER_A, PAPER_B)
+        assert result.coupling_strength == pytest.approx(3 / 7, rel=1e-6)
+
+    def test_cache_write_failure_logs_error(
+        self,
+        db_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A repo write failure emits ``coupling_analyzer_cache_write_failed``."""
+        monkeypatch.setattr(analyzer_mod, "logger", structlog.get_logger())
+        failing_repo = MagicMock(spec=CitationCouplingRepository)
+        failing_repo.get.return_value = None
+        failing_repo.record.side_effect = Exception("disk full")
+
+        store = _mock_store_with_refs({PAPER_A: REFS_A, PAPER_B: REFS_B})
+        analyzer = CouplingAnalyzer(store, repo=failing_repo)
+
+        with structlog.testing.capture_logs() as logs:
+            analyzer.analyze_pair(PAPER_A, PAPER_B)
+
+        events = [
+            e for e in logs if e.get("event") == "coupling_analyzer_cache_write_failed"
+        ]
+        assert len(events) == 1
+        assert "disk full" in events[0]["error"]

--- a/tests/unit/services/intelligence/citation/test_coupling_repository.py
+++ b/tests/unit/services/intelligence/citation/test_coupling_repository.py
@@ -411,10 +411,13 @@ class TestRetryOnContention:
         # After the retry it must have persisted.
         assert repo.get(PAPER_A, PAPER_B) is not None
 
-    def test_record_swallows_non_contention_sqlite_error(
+    def test_record_raises_non_contention_sqlite_error(
         self, repo: CitationCouplingRepository, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Non-contention sqlite3.Error is swallowed (don't-fail-the-caller)."""
+        """Non-contention sqlite3.Error is raised (H-6: repo raises, caller swallows).
+
+        Mirrors CitationInfluenceRepository.record_metrics pattern (PR #143).
+        """
         real_open = conn_mod.open_connection
 
         @contextmanager
@@ -446,52 +449,8 @@ class TestRetryOnContention:
                 yield _Proxy()  # type: ignore[misc]
 
         monkeypatch.setattr(repo_mod, "open_connection", boom_open)
-        # Must not raise.
-        repo.record(_result())
-
-    def test_record_swallowed_error_logs_write_failed(
-        self,
-        repo: CitationCouplingRepository,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """Swallowed sqlite3.Error emits ``coupling_repo_write_failed``."""
-        monkeypatch.setattr(repo_mod, "logger", structlog.get_logger())
-        real_open = conn_mod.open_connection
-
-        @contextmanager
-        def boom_open(p: Path) -> Iterator[sqlite3.Connection]:
-            with real_open(p) as conn:
-
-                class _Proxy:
-                    def execute(self, sql: str, *args: Any, **kwargs: Any) -> Any:
-                        if sql == "BEGIN IMMEDIATE":
-                            raise sqlite3.DatabaseError("boom")
-                        return conn.execute(sql, *args, **kwargs)
-
-                    def commit(self) -> None:
-                        conn.commit()
-
-                    def rollback(self) -> None:
-                        conn.rollback()
-
-                    @property
-                    def row_factory(self) -> Any:
-                        return conn.row_factory
-
-                    @row_factory.setter
-                    def row_factory(self, v: Any) -> None:
-                        conn.row_factory = v
-
-                yield _Proxy()  # type: ignore[misc]
-
-        monkeypatch.setattr(repo_mod, "open_connection", boom_open)
-        with structlog.testing.capture_logs() as logs:
+        with pytest.raises(sqlite3.DatabaseError, match="disk I/O error"):
             repo.record(_result())
-
-        events = [e for e in logs if e.get("event") == "coupling_repo_write_failed"]
-        assert len(events) == 1
-        assert events[0]["paper_a_id"] == PAPER_A
-        assert events[0]["paper_b_id"] == PAPER_B
 
     def test_record_once_rollback_on_insert_failure(
         self, repo: CitationCouplingRepository, monkeypatch: pytest.MonkeyPatch
@@ -499,9 +458,9 @@ class TestRetryOnContention:
         """If the INSERT fails after BEGIN, the rollback path is exercised.
 
         The INSERT raises a non-contention OperationalError, which:
-        1. Triggers conn.rollback() inside _record_once (lines 253-255).
+        1. Triggers conn.rollback() inside _record_once.
         2. Propagates through _retry (no retry for non-contention errors).
-        3. Is caught by the outer sqlite3.Error handler in record() and swallowed.
+        3. Is re-raised by record() to the caller (H-6 fix).
         """
         real_open = conn_mod.open_connection
 
@@ -540,8 +499,9 @@ class TestRetryOnContention:
                 yield _Proxy()  # type: ignore[misc]
 
         monkeypatch.setattr(repo_mod, "open_connection", boom_insert_open)
-        # Must not raise — outer sqlite3.Error handler swallows it.
-        repo.record(_result())
+        # H-6: repo now raises; caller (analyzer) is responsible for swallowing.
+        with pytest.raises(sqlite3.OperationalError, match="disk full"):
+            repo.record(_result())
 
     def test_delete_stale_rollback_on_failure(
         self, repo: CitationCouplingRepository, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/services/intelligence/citation/test_coupling_repository.py
+++ b/tests/unit/services/intelligence/citation/test_coupling_repository.py
@@ -266,6 +266,28 @@ class TestCanonicalOrdering:
         assert fetched is not None
         assert fetched.coupling_strength == pytest.approx(0.55)
 
+    def test_get_ba_returns_canonical_order_not_caller_order(
+        self, repo: CitationCouplingRepository
+    ) -> None:
+        """H-2 regression: get(B, A) returns canonical (min, max) ids, not (B, A).
+
+        The old docstring claimed caller order was preserved; the real
+        implementation always returns canonical order. This test pins
+        the actual behaviour so future readers don't reintroduce the lie.
+        """
+        paper_aaa = "paper:s2:aaa"
+        paper_zzz = "paper:s2:zzz"  # zzz > aaa lexicographically
+
+        repo.record(_result(paper_aaa, paper_zzz, strength=0.7))
+        # Reversed lookup: caller asks for (zzz, aaa).
+        fetched = repo.get(paper_zzz, paper_aaa)
+
+        assert fetched is not None
+        # Returned result carries canonical ids, not caller-supplied order.
+        assert fetched.paper_a_id == paper_aaa  # min
+        assert fetched.paper_b_id == paper_zzz  # max
+        assert fetched.coupling_strength == pytest.approx(0.7)
+
 
 # ---------------------------------------------------------------------------
 # TTL semantics

--- a/tests/unit/services/intelligence/citation/test_coupling_repository.py
+++ b/tests/unit/services/intelligence/citation/test_coupling_repository.py
@@ -1,0 +1,623 @@
+"""Tests for :class:`CitationCouplingRepository` (Issue #128).
+
+Covers:
+- Round-trip persistence (record + get).
+- TTL semantics on the read path — stale rows return ``None``.
+- ``delete_stale`` row count.
+- Canonical-pair ordering: (A,B) and (B,A) hit the same row.
+- ``record`` retry path on lock contention.
+- ``record`` swallows non-contention ``sqlite3.Error``.
+- ``connect`` factory initialises migrations.
+- Structured-log event assertions via ``capture_logs()`` with the
+  canonical "rebind logger before capture" pattern (CLAUDE.md §Test
+  Authoring Conventions).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Iterator
+
+import pytest
+import structlog
+import structlog.testing
+
+import src.services.intelligence.citation.coupling_repository as repo_mod
+from src.services.intelligence.citation.coupling_repository import (
+    CitationCouplingRepository,
+)
+from src.services.intelligence.citation.models import CouplingResult
+from src.storage.intelligence_graph import connection as conn_mod
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+PAPER_A = "paper:s2:alpha"
+PAPER_B = "paper:s2:beta"
+SHARED_REFS = ["paper:s2:r1", "paper:s2:r2"]
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db_path() -> Iterator[Path]:
+    """Fresh on-disk SQLite path per test (auto-cleaned)."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        path = Path(f.name)
+    path.unlink(missing_ok=True)
+    yield path
+    path.unlink(missing_ok=True)
+
+
+@pytest.fixture
+def repo(db_path: Path) -> CitationCouplingRepository:
+    return CitationCouplingRepository.connect(db_path)
+
+
+def _result(
+    paper_a: str = PAPER_A,
+    paper_b: str = PAPER_B,
+    *,
+    strength: float = 0.5,
+    refs: list[str] | None = None,
+    co_citations: int = 0,
+) -> CouplingResult:
+    """Convenience constructor."""
+    return CouplingResult(
+        paper_a_id=paper_a,
+        paper_b_id=paper_b,
+        shared_references=refs if refs is not None else SHARED_REFS,
+        coupling_strength=strength,
+        co_citation_count=co_citations,
+    )
+
+
+def _make_begin_immediate_failure_open(
+    error_message: str,
+    *,
+    sqlite_errorcode: int | None = None,
+    max_failures: int | None = None,
+) -> tuple[Any, dict]:
+    """Proxy ``open_connection`` whose ``BEGIN IMMEDIATE`` raises.
+
+    Mirrors the pattern from ``test_influence_repository.py`` so the
+    contention semantics are exercised consistently.
+    """
+    real_open = conn_mod.open_connection
+    attempts: dict[str, int] = {"n": 0, "failures": 0}
+
+    class _ConnProxy:
+        def __init__(self, real_conn: sqlite3.Connection) -> None:
+            self._real = real_conn
+
+        def execute(self, sql: str, *args: Any, **kwargs: Any) -> Any:
+            if sql == "BEGIN IMMEDIATE":
+                if max_failures is None or attempts["failures"] < max_failures:
+                    attempts["failures"] += 1
+                    exc = sqlite3.OperationalError(error_message)
+                    if sqlite_errorcode is not None:
+                        exc.sqlite_errorcode = (  # type: ignore[attr-defined]
+                            sqlite_errorcode
+                        )
+                    raise exc
+            return self._real.execute(sql, *args, **kwargs)
+
+        def executemany(self, sql: str, *args: Any, **kwargs: Any) -> Any:
+            return self._real.executemany(sql, *args, **kwargs)
+
+        def commit(self) -> None:
+            self._real.commit()
+
+        def rollback(self) -> None:
+            self._real.rollback()
+
+        @property
+        def row_factory(self) -> Any:
+            return self._real.row_factory
+
+        @row_factory.setter
+        def row_factory(self, v: Any) -> None:
+            self._real.row_factory = v
+
+    @contextmanager
+    def fake_open(p: Path) -> Iterator[_ConnProxy]:
+        with real_open(p) as conn:
+            attempts["n"] += 1
+            yield _ConnProxy(conn)  # type: ignore[misc]
+
+    return fake_open, attempts
+
+
+# ---------------------------------------------------------------------------
+# Initialization / factory
+# ---------------------------------------------------------------------------
+
+
+class TestInitialize:
+    def test_connect_initializes_migrations(self, db_path: Path) -> None:
+        """``connect`` runs the migration manager so the table exists."""
+        r = CitationCouplingRepository.connect(db_path)
+        # If migrations ran, recording a row succeeds (no "no such table").
+        r.record(_result())
+        assert r.get(PAPER_A, PAPER_B) is not None
+
+    def test_record_requires_initialize(self, db_path: Path) -> None:
+        """Calling record before initialize raises RuntimeError."""
+        r = CitationCouplingRepository(db_path)  # no initialize()
+        with pytest.raises(RuntimeError, match="not initialized"):
+            r.record(_result())
+
+    def test_get_requires_initialize(self, db_path: Path) -> None:
+        """Calling get before initialize raises RuntimeError."""
+        r = CitationCouplingRepository(db_path)  # no initialize()
+        with pytest.raises(RuntimeError, match="not initialized"):
+            r.get(PAPER_A, PAPER_B)
+
+    def test_initialize_is_idempotent(self, db_path: Path) -> None:
+        """Calling initialize() twice leaves the repo in a usable state."""
+        r = CitationCouplingRepository(db_path)
+        r.initialize()
+        r.initialize()  # second call does nothing surprising
+        r.record(_result())
+
+    def test_initialize_logs_when_migrations_apply(
+        self, db_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """First initialize emits migration-applied event."""
+        monkeypatch.setattr(repo_mod, "logger", structlog.get_logger())
+        with structlog.testing.capture_logs() as logs:
+            CitationCouplingRepository(db_path).initialize()
+        events = [
+            e
+            for e in logs
+            if e.get("event") == "citation_coupling_repository_migrations_applied"
+        ]
+        assert len(events) == 1
+        assert events[0]["count"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# Round-trip persistence
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    def test_record_and_get_round_trips_all_fields(
+        self, repo: CitationCouplingRepository
+    ) -> None:
+        """record then get returns the exact same CouplingResult."""
+        original = _result(strength=0.75, refs=["paper:s2:r1", "paper:s2:r2"])
+        repo.record(original)
+        fetched = repo.get(PAPER_A, PAPER_B)
+
+        assert fetched is not None
+        assert fetched.paper_a_id == PAPER_A
+        assert fetched.paper_b_id == PAPER_B
+        assert fetched.coupling_strength == pytest.approx(0.75)
+        assert fetched.shared_references == sorted(["paper:s2:r1", "paper:s2:r2"])
+        assert fetched.co_citation_count == 0
+
+    def test_record_upserts_existing_row(
+        self, repo: CitationCouplingRepository
+    ) -> None:
+        """Second record for the same pair overwrites the first."""
+        repo.record(_result(strength=0.3))
+        repo.record(_result(strength=0.9))
+        fetched = repo.get(PAPER_A, PAPER_B)
+
+        assert fetched is not None
+        assert fetched.coupling_strength == pytest.approx(0.9)
+
+    def test_get_returns_none_for_missing_row(
+        self, repo: CitationCouplingRepository
+    ) -> None:
+        """get returns None when no row exists."""
+        fetched = repo.get(PAPER_A, PAPER_B)
+        assert fetched is None
+
+    def test_get_with_zero_strength_round_trips(
+        self, repo: CitationCouplingRepository
+    ) -> None:
+        """Zero coupling_strength is stored and retrieved correctly."""
+        repo.record(_result(strength=0.0, refs=[]))
+        fetched = repo.get(PAPER_A, PAPER_B)
+
+        assert fetched is not None
+        assert fetched.coupling_strength == pytest.approx(0.0)
+        assert fetched.shared_references == []
+
+
+# ---------------------------------------------------------------------------
+# Canonical-pair ordering
+# ---------------------------------------------------------------------------
+
+
+class TestCanonicalOrdering:
+    def test_ab_and_ba_hit_same_row(self, repo: CitationCouplingRepository) -> None:
+        """Storing (A,B) and retrieving (B,A) returns the same row."""
+        repo.record(_result(PAPER_A, PAPER_B, strength=0.42))
+        fetched_ba = repo.get(PAPER_B, PAPER_A)
+
+        assert fetched_ba is not None
+        # The DB stores min/max, so paper_a_id is always the lexicographic minimum.
+        assert fetched_ba.coupling_strength == pytest.approx(0.42)
+
+    def test_record_ba_retrievable_as_ab(
+        self, repo: CitationCouplingRepository
+    ) -> None:
+        """Recording in reverse order is still retrievable in forward order."""
+        # PAPER_B > PAPER_A lexicographically, so create a result with B,A
+        # where paper_b_id is PAPER_A (B > A, so we need to produce a valid pair).
+        # Use distinct IDs where reversed lookup hits the canonical row.
+        paper_x = "paper:s2:xxx"
+        paper_y = "paper:s2:yyy"  # y > x
+        # Record (paper_x, paper_y); retrieve as (paper_y, paper_x) to verify
+        # canonical ordering lets us find the same row.
+        repo.record(_result(paper_x, paper_y, strength=0.55))
+        fetched = repo.get(paper_y, paper_x)  # reversed lookup
+
+        assert fetched is not None
+        assert fetched.coupling_strength == pytest.approx(0.55)
+
+
+# ---------------------------------------------------------------------------
+# TTL semantics
+# ---------------------------------------------------------------------------
+
+
+class TestTTL:
+    def test_get_returns_fresh_row(self, repo: CitationCouplingRepository) -> None:
+        """Fresh row (within TTL) is returned."""
+        repo.record(_result())
+        fetched = repo.get(PAPER_A, PAPER_B, max_age_days=30)
+        assert fetched is not None
+
+    def test_get_returns_none_for_stale_row(
+        self, repo: CitationCouplingRepository, db_path: Path
+    ) -> None:
+        """Row older than max_age_days is treated as a cache miss."""
+        # Insert directly with an old timestamp.
+        from src.storage.intelligence_graph.connection import open_connection
+
+        old_ts = (datetime.now(timezone.utc) - timedelta(days=40)).isoformat()
+        with open_connection(db_path) as conn:
+            conn.execute(
+                "INSERT INTO citation_coupling"
+                " (paper_a_id, paper_b_id, coupling_strength,"
+                "  shared_references_json, co_citation_count, computed_at)"
+                " VALUES (?, ?, ?, ?, ?, ?)",
+                (PAPER_A, PAPER_B, 0.5, "[]", 0, old_ts),
+            )
+            conn.commit()
+
+        fetched = repo.get(PAPER_A, PAPER_B, max_age_days=30)
+        assert fetched is None
+
+    def test_get_max_age_days_zero_raises(
+        self, repo: CitationCouplingRepository
+    ) -> None:
+        """max_age_days=0 raises ValueError."""
+        with pytest.raises(ValueError, match="max_age_days must be positive"):
+            repo.get(PAPER_A, PAPER_B, max_age_days=0)
+
+    def test_get_max_age_days_negative_raises(
+        self, repo: CitationCouplingRepository
+    ) -> None:
+        """Negative max_age_days raises ValueError."""
+        with pytest.raises(ValueError, match="max_age_days must be positive"):
+            repo.get(PAPER_A, PAPER_B, max_age_days=-1)
+
+
+# ---------------------------------------------------------------------------
+# delete_stale
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteStale:
+    def test_delete_stale_removes_old_rows(
+        self, repo: CitationCouplingRepository, db_path: Path
+    ) -> None:
+        """delete_stale removes rows older than the cutoff."""
+        from src.storage.intelligence_graph.connection import open_connection
+
+        old_ts = (datetime.now(timezone.utc) - timedelta(days=40)).isoformat()
+        # Insert an old row directly.
+        with open_connection(db_path) as conn:
+            conn.execute(
+                "INSERT INTO citation_coupling"
+                " (paper_a_id, paper_b_id, coupling_strength,"
+                "  shared_references_json, co_citation_count, computed_at)"
+                " VALUES (?, ?, ?, ?, ?, ?)",
+                (PAPER_A, PAPER_B, 0.5, "[]", 0, old_ts),
+            )
+            conn.commit()
+
+        cutoff = datetime.now(timezone.utc) - timedelta(days=30)
+        deleted = repo.delete_stale(cutoff)
+
+        assert deleted == 1
+        assert repo.get(PAPER_A, PAPER_B) is None
+
+    def test_delete_stale_preserves_fresh_rows(
+        self, repo: CitationCouplingRepository
+    ) -> None:
+        """delete_stale does not remove rows within the cutoff."""
+        repo.record(_result())
+        cutoff = datetime.now(timezone.utc) - timedelta(days=30)
+        deleted = repo.delete_stale(cutoff)
+
+        assert deleted == 0
+        assert repo.get(PAPER_A, PAPER_B) is not None
+
+    def test_delete_stale_returns_count(
+        self, repo: CitationCouplingRepository, db_path: Path
+    ) -> None:
+        """delete_stale returns the correct row count for multiple old rows."""
+        from src.storage.intelligence_graph.connection import open_connection
+
+        old_ts = (datetime.now(timezone.utc) - timedelta(days=40)).isoformat()
+        paper_c = "paper:s2:ccc"
+        paper_d = "paper:s2:ddd"
+        with open_connection(db_path) as conn:
+            conn.execute(
+                "INSERT INTO citation_coupling"
+                " (paper_a_id, paper_b_id, coupling_strength,"
+                "  shared_references_json, co_citation_count, computed_at)"
+                " VALUES (?, ?, ?, ?, ?, ?)",
+                (PAPER_A, PAPER_B, 0.1, "[]", 0, old_ts),
+            )
+            conn.execute(
+                "INSERT INTO citation_coupling"
+                " (paper_a_id, paper_b_id, coupling_strength,"
+                "  shared_references_json, co_citation_count, computed_at)"
+                " VALUES (?, ?, ?, ?, ?, ?)",
+                (paper_c, paper_d, 0.2, "[]", 0, old_ts),
+            )
+            conn.commit()
+
+        cutoff = datetime.now(timezone.utc) - timedelta(days=30)
+        deleted = repo.delete_stale(cutoff)
+        assert deleted == 2
+
+
+# ---------------------------------------------------------------------------
+# Retry / contention handling
+# ---------------------------------------------------------------------------
+
+
+class TestRetryOnContention:
+    def test_record_retries_on_lock_contention_and_succeeds(
+        self, repo: CitationCouplingRepository, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """record retries once on SQLITE_BUSY and then succeeds."""
+        fake_open, attempts = _make_begin_immediate_failure_open(
+            "database is locked",
+            sqlite_errorcode=5,  # SQLITE_BUSY
+            max_failures=1,
+        )
+        monkeypatch.setattr(repo_mod, "open_connection", fake_open)
+
+        repo.record(_result())
+
+        assert attempts["failures"] == 1  # exactly one contention
+        assert attempts["n"] >= 2  # retried at least once
+        # After the retry it must have persisted.
+        assert repo.get(PAPER_A, PAPER_B) is not None
+
+    def test_record_swallows_non_contention_sqlite_error(
+        self, repo: CitationCouplingRepository, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Non-contention sqlite3.Error is swallowed (don't-fail-the-caller)."""
+        real_open = conn_mod.open_connection
+
+        @contextmanager
+        def boom_open(p: Path) -> Iterator[sqlite3.Connection]:
+            with real_open(p) as conn:
+
+                class _Proxy:
+                    def execute(self, sql: str, *args: Any, **kwargs: Any) -> Any:
+                        if sql == "BEGIN IMMEDIATE":
+                            exc = sqlite3.DatabaseError("disk I/O error")
+                            # No sqlite_errorcode → non-contention path
+                            raise exc
+                        return conn.execute(sql, *args, **kwargs)
+
+                    def commit(self) -> None:
+                        conn.commit()
+
+                    def rollback(self) -> None:
+                        conn.rollback()
+
+                    @property
+                    def row_factory(self) -> Any:
+                        return conn.row_factory
+
+                    @row_factory.setter
+                    def row_factory(self, v: Any) -> None:
+                        conn.row_factory = v
+
+                yield _Proxy()  # type: ignore[misc]
+
+        monkeypatch.setattr(repo_mod, "open_connection", boom_open)
+        # Must not raise.
+        repo.record(_result())
+
+    def test_record_swallowed_error_logs_write_failed(
+        self,
+        repo: CitationCouplingRepository,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Swallowed sqlite3.Error emits ``coupling_repo_write_failed``."""
+        monkeypatch.setattr(repo_mod, "logger", structlog.get_logger())
+        real_open = conn_mod.open_connection
+
+        @contextmanager
+        def boom_open(p: Path) -> Iterator[sqlite3.Connection]:
+            with real_open(p) as conn:
+
+                class _Proxy:
+                    def execute(self, sql: str, *args: Any, **kwargs: Any) -> Any:
+                        if sql == "BEGIN IMMEDIATE":
+                            raise sqlite3.DatabaseError("boom")
+                        return conn.execute(sql, *args, **kwargs)
+
+                    def commit(self) -> None:
+                        conn.commit()
+
+                    def rollback(self) -> None:
+                        conn.rollback()
+
+                    @property
+                    def row_factory(self) -> Any:
+                        return conn.row_factory
+
+                    @row_factory.setter
+                    def row_factory(self, v: Any) -> None:
+                        conn.row_factory = v
+
+                yield _Proxy()  # type: ignore[misc]
+
+        monkeypatch.setattr(repo_mod, "open_connection", boom_open)
+        with structlog.testing.capture_logs() as logs:
+            repo.record(_result())
+
+        events = [e for e in logs if e.get("event") == "coupling_repo_write_failed"]
+        assert len(events) == 1
+        assert events[0]["paper_a_id"] == PAPER_A
+        assert events[0]["paper_b_id"] == PAPER_B
+
+    def test_record_once_rollback_on_insert_failure(
+        self, repo: CitationCouplingRepository, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If the INSERT fails after BEGIN, the rollback path is exercised.
+
+        The INSERT raises a non-contention OperationalError, which:
+        1. Triggers conn.rollback() inside _record_once (lines 253-255).
+        2. Propagates through _retry (no retry for non-contention errors).
+        3. Is caught by the outer sqlite3.Error handler in record() and swallowed.
+        """
+        real_open = conn_mod.open_connection
+
+        @contextmanager
+        def boom_insert_open(p: Path) -> Iterator[sqlite3.Connection]:
+            with real_open(p) as conn:
+
+                class _Proxy:
+                    def __init__(self) -> None:
+                        self._past_immediate = False
+
+                    def execute(self, sql: str, *args: Any, **kwargs: Any) -> Any:
+                        if sql == "BEGIN IMMEDIATE":
+                            self._past_immediate = True
+                            return conn.execute(sql, *args, **kwargs)
+                        # The INSERT SQL starts with whitespace in the f-string.
+                        if self._past_immediate and "INSERT" in sql:
+                            # Non-contention error: no sqlite_errorcode attribute.
+                            raise sqlite3.OperationalError("disk full")
+                        return conn.execute(sql, *args, **kwargs)
+
+                    def commit(self) -> None:
+                        conn.commit()
+
+                    def rollback(self) -> None:
+                        conn.rollback()
+
+                    @property
+                    def row_factory(self) -> Any:
+                        return conn.row_factory
+
+                    @row_factory.setter
+                    def row_factory(self, v: Any) -> None:
+                        conn.row_factory = v
+
+                yield _Proxy()  # type: ignore[misc]
+
+        monkeypatch.setattr(repo_mod, "open_connection", boom_insert_open)
+        # Must not raise — outer sqlite3.Error handler swallows it.
+        repo.record(_result())
+
+    def test_delete_stale_rollback_on_failure(
+        self, repo: CitationCouplingRepository, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """delete_stale rolls back and propagates when the DELETE itself fails."""
+        real_open = conn_mod.open_connection
+
+        @contextmanager
+        def boom_delete_open(p: Path) -> Iterator[sqlite3.Connection]:
+            with real_open(p) as conn:
+
+                class _Proxy:
+                    def __init__(self) -> None:
+                        self._past_immediate = False
+
+                    def execute(self, sql: str, *args: Any, **kwargs: Any) -> Any:
+                        if sql == "BEGIN IMMEDIATE":
+                            self._past_immediate = True
+                            return conn.execute(sql, *args, **kwargs)
+                        if self._past_immediate and "DELETE" in sql:
+                            raise sqlite3.OperationalError("forced delete failure")
+                        return conn.execute(sql, *args, **kwargs)
+
+                    def commit(self) -> None:
+                        conn.commit()
+
+                    def rollback(self) -> None:
+                        conn.rollback()
+
+                    @property
+                    def row_factory(self) -> Any:
+                        return conn.row_factory
+
+                    @row_factory.setter
+                    def row_factory(self, v: Any) -> None:
+                        conn.row_factory = v
+
+                yield _Proxy()  # type: ignore[misc]
+
+        monkeypatch.setattr(repo_mod, "open_connection", boom_delete_open)
+        cutoff = datetime.now(timezone.utc) - timedelta(days=30)
+        with pytest.raises(sqlite3.OperationalError, match="forced delete failure"):
+            repo.delete_stale(cutoff)
+
+
+# ---------------------------------------------------------------------------
+# Naive-datetime timezone fix path
+# ---------------------------------------------------------------------------
+
+
+class TestNaiveDatetimeFix:
+    def test_get_handles_naive_computed_at_timestamp(
+        self, repo: CitationCouplingRepository, db_path: Path
+    ) -> None:
+        """get() handles a naive (no-tz) ``computed_at`` value in the DB.
+
+        Older rows stored without a ``+00:00`` suffix must not crash the
+        TTL comparison — they are treated as UTC and the comparison is
+        apples-to-apples.
+        """
+        from src.storage.intelligence_graph.connection import open_connection
+
+        # Insert a row with a naive ISO timestamp (no tz suffix).
+        naive_ts = "2099-12-31T00:00:00"  # far future — will be fresh
+        with open_connection(db_path) as conn:
+            conn.execute(
+                "INSERT INTO citation_coupling"
+                " (paper_a_id, paper_b_id, coupling_strength,"
+                "  shared_references_json, co_citation_count, computed_at)"
+                " VALUES (?, ?, ?, ?, ?, ?)",
+                (PAPER_A, PAPER_B, 0.7, "[]", 0, naive_ts),
+            )
+            conn.commit()
+
+        fetched = repo.get(PAPER_A, PAPER_B, max_age_days=30)
+        # The naive timestamp is far in the future, so it must pass the
+        # freshness check and return a result (not None).
+        assert fetched is not None
+        assert fetched.coupling_strength == pytest.approx(0.7)

--- a/tests/unit/services/intelligence/citation/test_coupling_repository.py
+++ b/tests/unit/services/intelligence/citation/test_coupling_repository.py
@@ -5,8 +5,10 @@ Covers:
 - TTL semantics on the read path — stale rows return ``None``.
 - ``delete_stale`` row count.
 - Canonical-pair ordering: (A,B) and (B,A) hit the same row.
+- Canonical-order return semantics: get(B, A) returns min/max ids.
 - ``record`` retry path on lock contention.
-- ``record`` swallows non-contention ``sqlite3.Error``.
+- ``record`` raises non-contention ``sqlite3.Error`` (H-6).
+- Path security: constructor rejects unsanitized paths (H-8).
 - ``connect`` factory initialises migrations.
 - Structured-log event assertions via ``capture_logs()`` with the
   canonical "rebind logger before capture" pattern (CLAUDE.md §Test
@@ -32,6 +34,7 @@ from src.services.intelligence.citation.coupling_repository import (
 )
 from src.services.intelligence.citation.models import CouplingResult
 from src.storage.intelligence_graph import connection as conn_mod
+from src.utils.security import SecurityError
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -181,6 +184,16 @@ class TestInitialize:
         ]
         assert len(events) == 1
         assert events[0]["count"] >= 1
+
+    def test_constructor_rejects_unsanitized_path(self) -> None:
+        """H-8: Constructor rejects paths outside approved storage roots.
+
+        Mirrors PR #143 C-2 canonical security-rejection pattern so
+        CitationCouplingRepository is covered by the same path-safety
+        guarantee as CitationInfluenceRepository.
+        """
+        with pytest.raises(SecurityError, match="outside approved storage roots"):
+            CitationCouplingRepository("/etc/passwd.db")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/intelligence/citation/test_models.py
+++ b/tests/unit/services/intelligence/citation/test_models.py
@@ -70,12 +70,12 @@ def test_make_paper_node_id_sanitizes_doi_with_slashes():
 
 
 def test_make_paper_node_id_rejects_empty_external_id():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="empty after sanitization"):
         make_paper_node_id("s2", "")
 
 
 def test_make_paper_node_id_rejects_empty_source():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="empty after sanitization"):
         make_paper_node_id("", "abc123")
 
 
@@ -146,7 +146,7 @@ def test_citation_direction_membership():
 
 
 def test_citation_direction_rejects_unknown_value():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="is not a valid"):
         CitationDirection("sideways")
 
 
@@ -197,11 +197,8 @@ def test_citation_node_paper_id_strips_whitespace():
 
 
 def test_citation_node_paper_id_rejects_empty_after_strip():
-    with pytest.raises(ValidationError) as exc:
+    with pytest.raises(ValidationError, match="cannot be empty|at least 1 character"):
         CitationNode(paper_id="   ", title="t")
-    assert "cannot be empty" in str(exc.value) or "at least 1 character" in str(
-        exc.value
-    )
 
 
 def test_citation_node_paper_id_rejects_invalid_chars():
@@ -210,22 +207,22 @@ def test_citation_node_paper_id_rejects_invalid_chars():
 
 
 def test_citation_node_paper_id_rejects_min_length_violation():
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match="at least 1 character"):
         CitationNode(paper_id="", title="t")
 
 
 def test_citation_node_title_required():
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match="at least 1 character"):
         CitationNode(paper_id="paper:s2:abc", title="")
 
 
 def test_citation_node_year_lower_bound():
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match="greater than or equal to 1800"):
         CitationNode(paper_id="paper:s2:abc", title="t", year=1799)
 
 
 def test_citation_node_year_upper_bound():
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match="less than or equal to 2100"):
         CitationNode(paper_id="paper:s2:abc", title="t", year=2101)
 
 
@@ -235,12 +232,12 @@ def test_citation_node_year_accepts_valid_range():
 
 
 def test_citation_node_citation_count_negative_rejected():
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match="greater than or equal to 0"):
         CitationNode(paper_id="paper:s2:abc", title="t", citation_count=-1)
 
 
 def test_citation_node_reference_count_negative_rejected():
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match="greater than or equal to 0"):
         CitationNode(paper_id="paper:s2:abc", title="t", reference_count=-1)
 
 
@@ -266,7 +263,7 @@ def test_citation_node_external_ids_rejects_whitespace_value():
 
 def test_citation_node_external_ids_rejects_non_string_key():
     # Pydantic itself coerces here when possible; but ints will raise
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match="Input should be a valid string"):
         CitationNode.model_validate(
             {
                 "paper_id": "paper:s2:abc",
@@ -277,7 +274,7 @@ def test_citation_node_external_ids_rejects_non_string_key():
 
 
 def test_citation_node_external_ids_rejects_non_string_value():
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match="Input should be a valid string"):
         CitationNode.model_validate(
             {
                 "paper_id": "paper:s2:abc",
@@ -288,7 +285,7 @@ def test_citation_node_external_ids_rejects_non_string_value():
 
 
 def test_citation_node_extra_fields_forbidden():
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
         CitationNode.model_validate(
             {
                 "paper_id": "paper:s2:abc",
@@ -386,7 +383,7 @@ def test_citation_edge_strips_id_whitespace():
 
 
 def test_citation_edge_rejects_blank_citing_id():
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match="cannot be empty"):
         CitationEdge(citing_paper_id="   ", cited_paper_id="paper:s2:b")
 
 
@@ -401,14 +398,14 @@ def test_citation_edge_rejects_invalid_cited_id():
 
 
 def test_citation_edge_rejects_blank_source():
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match="at least 1 character"):
         CitationEdge(
             citing_paper_id="paper:s2:a", cited_paper_id="paper:s2:b", source=""
         )
 
 
 def test_citation_edge_extra_fields_forbidden():
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
         CitationEdge.model_validate(
             {
                 "citing_paper_id": "paper:s2:a",

--- a/tests/unit/services/intelligence/citation/test_models.py
+++ b/tests/unit/services/intelligence/citation/test_models.py
@@ -1,4 +1,4 @@
-"""Tests for citation domain models (Milestone 9.2 — Week 1)."""
+"""Tests for citation domain models (Milestone 9.2 — Week 1 + 2)."""
 
 from __future__ import annotations
 
@@ -12,6 +12,7 @@ from src.services.intelligence.citation.models import (
     CitationDirection,
     CitationEdge,
     CitationNode,
+    CouplingResult,
     CrawlDirection,
     LegacyCitationDirection,
     _normalize_id_segment,
@@ -541,3 +542,161 @@ def test_citation_direction_backward_compat_alias():
     assert CitationDirection.OUT.value == "out"
     assert CitationDirection.IN.value == "in"
     assert CitationDirection.BOTH.value == "both"
+
+
+# ---------------------------------------------------------------------------
+# CouplingResult (REQ-9.2.3 / Issue #128)
+# ---------------------------------------------------------------------------
+
+
+class TestCouplingResult:
+    """Tests for :class:`CouplingResult` Pydantic V2 strict model."""
+
+    def test_coupling_result_basic_construction(self) -> None:
+        """Happy-path construction with minimal fields."""
+        result = CouplingResult(
+            paper_a_id="paper:s2:aaa",
+            paper_b_id="paper:s2:bbb",
+            shared_references=["paper:s2:r1"],
+            coupling_strength=0.5,
+            co_citation_count=0,
+        )
+        assert result.coupling_strength == 0.5
+        assert result.paper_a_id == "paper:s2:aaa"
+        assert result.paper_b_id == "paper:s2:bbb"
+
+    def test_coupling_result_shared_references_sorted(self) -> None:
+        """shared_references is sorted and deduped at validation time."""
+        result = CouplingResult(
+            paper_a_id="paper:s2:aaa",
+            paper_b_id="paper:s2:bbb",
+            shared_references=["paper:s2:zzz", "paper:s2:aaa", "paper:s2:aaa"],
+            coupling_strength=0.3,
+            co_citation_count=0,
+        )
+        # Deduped: only 2 unique, sorted.
+        assert result.shared_references == ["paper:s2:aaa", "paper:s2:zzz"]
+
+    def test_coupling_result_rejects_self_pair(self) -> None:
+        """paper_a_id == paper_b_id raises ValidationError."""
+        with pytest.raises(ValidationError, match="must differ"):
+            CouplingResult(
+                paper_a_id="paper:s2:same",
+                paper_b_id="paper:s2:same",
+                shared_references=[],
+                coupling_strength=0.0,
+                co_citation_count=0,
+            )
+
+    def test_coupling_result_rejects_invalid_paper_id(self) -> None:
+        """paper_a_id with disallowed chars raises ValidationError."""
+        with pytest.raises(ValidationError, match="Invalid paper_id format"):
+            CouplingResult(
+                paper_a_id="paper:s2:a b",  # space is disallowed
+                paper_b_id="paper:s2:bbb",
+                shared_references=[],
+                coupling_strength=0.0,
+                co_citation_count=0,
+            )
+
+    def test_coupling_result_rejects_invalid_shared_reference(self) -> None:
+        """Shared reference with disallowed chars raises ValidationError."""
+        with pytest.raises(ValidationError, match="Invalid shared reference"):
+            CouplingResult(
+                paper_a_id="paper:s2:aaa",
+                paper_b_id="paper:s2:bbb",
+                shared_references=["bad id with spaces"],
+                coupling_strength=0.0,
+                co_citation_count=0,
+            )
+
+    def test_coupling_result_rejects_negative_co_citation_count(self) -> None:
+        """co_citation_count < 0 raises ValidationError."""
+        with pytest.raises(ValidationError, match="greater than or equal to 0"):
+            CouplingResult(
+                paper_a_id="paper:s2:aaa",
+                paper_b_id="paper:s2:bbb",
+                shared_references=[],
+                coupling_strength=0.0,
+                co_citation_count=-1,
+            )
+
+    def test_coupling_result_rejects_coupling_strength_above_one(self) -> None:
+        """coupling_strength > 1.0 raises ValidationError."""
+        with pytest.raises(ValidationError, match="less than or equal to 1"):
+            CouplingResult(
+                paper_a_id="paper:s2:aaa",
+                paper_b_id="paper:s2:bbb",
+                shared_references=[],
+                coupling_strength=1.1,
+                co_citation_count=0,
+            )
+
+    def test_coupling_result_rejects_coupling_strength_below_zero(self) -> None:
+        """coupling_strength < 0.0 raises ValidationError."""
+        with pytest.raises(ValidationError, match="greater than or equal to 0"):
+            CouplingResult(
+                paper_a_id="paper:s2:aaa",
+                paper_b_id="paper:s2:bbb",
+                shared_references=[],
+                coupling_strength=-0.1,
+                co_citation_count=0,
+            )
+
+    def test_coupling_result_rejects_extra_fields(self) -> None:
+        """Extra fields are forbidden (extra='forbid')."""
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            CouplingResult(
+                paper_a_id="paper:s2:aaa",
+                paper_b_id="paper:s2:bbb",
+                shared_references=[],
+                coupling_strength=0.0,
+                co_citation_count=0,
+                unknown_field="bad",  # type: ignore[call-arg]
+            )
+
+    def test_coupling_result_boundary_strength_zero(self) -> None:
+        """coupling_strength=0.0 is accepted (boundary value)."""
+        result = CouplingResult(
+            paper_a_id="paper:s2:aaa",
+            paper_b_id="paper:s2:bbb",
+            shared_references=[],
+            coupling_strength=0.0,
+            co_citation_count=0,
+        )
+        assert result.coupling_strength == 0.0
+
+    def test_coupling_result_boundary_strength_one(self) -> None:
+        """coupling_strength=1.0 is accepted (boundary value)."""
+        result = CouplingResult(
+            paper_a_id="paper:s2:aaa",
+            paper_b_id="paper:s2:bbb",
+            shared_references=["paper:s2:r1"],
+            coupling_strength=1.0,
+            co_citation_count=0,
+        )
+        assert result.coupling_strength == 1.0
+
+    def test_coupling_result_rejects_whitespace_paper_id(self) -> None:
+        """Whitespace-only paper_a_id raises ValidationError (empty after strip)."""
+        with pytest.raises(ValidationError, match="paper_id cannot be empty"):
+            CouplingResult(
+                paper_a_id="   ",
+                paper_b_id="paper:s2:bbb",
+                shared_references=[],
+                coupling_strength=0.0,
+                co_citation_count=0,
+            )
+
+    def test_coupling_result_rejects_empty_shared_reference_string(self) -> None:
+        """Whitespace-only shared reference raises ValidationError."""
+        with pytest.raises(
+            ValidationError, match="shared_references entries must be non-empty"
+        ):
+            CouplingResult(
+                paper_a_id="paper:s2:aaa",
+                paper_b_id="paper:s2:bbb",
+                shared_references=["   "],
+                coupling_strength=0.0,
+                co_citation_count=0,
+            )

--- a/tests/unit/storage/intelligence_graph/test_migrations.py
+++ b/tests/unit/storage/intelligence_graph/test_migrations.py
@@ -1758,6 +1758,85 @@ class TestMigrationV6CitationCouplingCache:
                     ),
                 )
 
+    def test_migrate_v6_check_rejects_strength_above_one(self, temp_db: Path) -> None:
+        """H-7: CHECK (coupling_strength <= 1.0) rejects 1.5."""
+        manager = MigrationManager(temp_db)
+        manager.migrate()
+        with open_connection(temp_db) as conn:
+            with pytest.raises(sqlite3.IntegrityError, match="CHECK constraint"):
+                conn.execute(
+                    "INSERT INTO citation_coupling "
+                    "(paper_a_id, paper_b_id, coupling_strength, "
+                    "shared_references_json, co_citation_count, computed_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?)",
+                    (
+                        "paper:s2:aaa",
+                        "paper:s2:bbb",
+                        1.5,  # > 1.0 — violates CHECK
+                        "[]",
+                        0,
+                        "2025-01-01T00:00:00+00:00",
+                    ),
+                )
+
+    def test_migrate_v6_check_rejects_strength_below_zero(self, temp_db: Path) -> None:
+        """H-7: CHECK (coupling_strength >= 0.0) rejects -0.1."""
+        manager = MigrationManager(temp_db)
+        manager.migrate()
+        with open_connection(temp_db) as conn:
+            with pytest.raises(sqlite3.IntegrityError, match="CHECK constraint"):
+                conn.execute(
+                    "INSERT INTO citation_coupling "
+                    "(paper_a_id, paper_b_id, coupling_strength, "
+                    "shared_references_json, co_citation_count, computed_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?)",
+                    (
+                        "paper:s2:aaa",
+                        "paper:s2:bbb",
+                        -0.1,  # < 0.0 — violates CHECK
+                        "[]",
+                        0,
+                        "2025-01-01T00:00:00+00:00",
+                    ),
+                )
+
+    def test_migrate_v6_check_rejects_negative_co_citation_count(
+        self, temp_db: Path
+    ) -> None:
+        """H-7: CHECK (co_citation_count >= 0) rejects -1."""
+        manager = MigrationManager(temp_db)
+        manager.migrate()
+        with open_connection(temp_db) as conn:
+            with pytest.raises(sqlite3.IntegrityError, match="CHECK constraint"):
+                conn.execute(
+                    "INSERT INTO citation_coupling "
+                    "(paper_a_id, paper_b_id, coupling_strength, "
+                    "shared_references_json, co_citation_count, computed_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?)",
+                    (
+                        "paper:s2:aaa",
+                        "paper:s2:bbb",
+                        0.5,
+                        "[]",
+                        -1,  # < 0 — violates CHECK
+                        "2025-01-01T00:00:00+00:00",
+                    ),
+                )
+
+    def test_migrate_v6_check_constraint_sql_contains_strength_and_co_citation_bounds(
+        self,
+    ) -> None:
+        """M-4: SQL drift-guard — both bounds present in V6 SQL string.
+
+        Mirrors the V3/V5 enum drift-guard tests in spirit. Protects
+        against a future SQL refactor silently dropping a CHECK clause.
+        """
+        sql = MIGRATION_V6_CITATION_COUPLING_CACHE.up
+        assert "coupling_strength >= 0.0" in sql
+        assert "coupling_strength <= 1.0" in sql
+        assert "co_citation_count >= 0" in sql
+        assert "paper_a_id < paper_b_id" in sql
+
     def test_migrate_v6_records_version(self, temp_db: Path) -> None:
         """V6 migration is recorded in schema_migrations."""
         manager = MigrationManager(temp_db)

--- a/tests/unit/storage/intelligence_graph/test_migrations.py
+++ b/tests/unit/storage/intelligence_graph/test_migrations.py
@@ -25,6 +25,7 @@ from src.storage.intelligence_graph.migrations import (
     MIGRATION_V3_MONITORING_RUNS_FK,
     MIGRATION_V4_CITATION_INFLUENCE_METRICS,
     MIGRATION_V5_PAPER_SOURCE_TRACKING,
+    MIGRATION_V6_CITATION_COUPLING_CACHE,
 )
 from src.utils.security import SecurityError
 
@@ -1657,6 +1658,235 @@ class TestMigrationV5PaperSourceTracking:
             assert paper_row["source"] == "arxiv"
 
 
+class TestMigrationV6CitationCouplingCache:
+    """Tests for ``MIGRATION_V6_CITATION_COUPLING_CACHE`` (Issue #128)."""
+
+    def test_migrate_v6_creates_citation_coupling_table(self, temp_db: Path) -> None:
+        """V6 migration creates the citation_coupling table."""
+        manager = MigrationManager(temp_db)
+        manager.migrate()
+        with open_connection(temp_db) as conn:
+            cursor = conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name='citation_coupling'"
+            )
+            assert cursor.fetchone() is not None
+
+    def test_migrate_v6_table_has_expected_columns(self, temp_db: Path) -> None:
+        """citation_coupling table has the full column set."""
+        manager = MigrationManager(temp_db)
+        manager.migrate()
+        with open_connection(temp_db) as conn:
+            cursor = conn.execute("PRAGMA table_info(citation_coupling)")
+            cols = {row["name"] for row in cursor.fetchall()}
+        assert cols == {
+            "paper_a_id",
+            "paper_b_id",
+            "coupling_strength",
+            "shared_references_json",
+            "co_citation_count",
+            "computed_at",
+        }
+
+    def test_migrate_v6_composite_primary_key(self, temp_db: Path) -> None:
+        """Both paper_a_id and paper_b_id form the primary key."""
+        manager = MigrationManager(temp_db)
+        manager.migrate()
+        with open_connection(temp_db) as conn:
+            cursor = conn.execute("PRAGMA table_info(citation_coupling)")
+            pk_cols = sorted(row["name"] for row in cursor.fetchall() if row["pk"] > 0)
+        assert pk_cols == ["paper_a_id", "paper_b_id"]
+
+    def test_migrate_v6_duplicate_pair_raises_integrity_error(
+        self, temp_db: Path
+    ) -> None:
+        """Inserting a duplicate (paper_a_id, paper_b_id) pair raises IntegrityError."""
+        manager = MigrationManager(temp_db)
+        manager.migrate()
+        with open_connection(temp_db) as conn:
+            conn.execute(
+                "INSERT INTO citation_coupling "
+                "(paper_a_id, paper_b_id, coupling_strength, "
+                "shared_references_json, co_citation_count, computed_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    "paper:s2:aaa",
+                    "paper:s2:bbb",
+                    0.5,
+                    "[]",
+                    0,
+                    "2025-01-01T00:00:00+00:00",
+                ),
+            )
+            conn.commit()
+            with pytest.raises(sqlite3.IntegrityError, match="UNIQUE constraint"):
+                conn.execute(
+                    "INSERT INTO citation_coupling "
+                    "(paper_a_id, paper_b_id, coupling_strength, "
+                    "shared_references_json, co_citation_count, computed_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?)",
+                    (
+                        "paper:s2:aaa",
+                        "paper:s2:bbb",
+                        0.3,
+                        "[]",
+                        0,
+                        "2025-01-02T00:00:00+00:00",
+                    ),
+                )
+
+    def test_migrate_v6_check_constraint_enforces_canonical_ordering(
+        self, temp_db: Path
+    ) -> None:
+        """CHECK (paper_a_id < paper_b_id) rejects reversed pairs."""
+        manager = MigrationManager(temp_db)
+        manager.migrate()
+        with open_connection(temp_db) as conn:
+            with pytest.raises(sqlite3.IntegrityError, match="CHECK constraint"):
+                conn.execute(
+                    "INSERT INTO citation_coupling "
+                    "(paper_a_id, paper_b_id, coupling_strength, "
+                    "shared_references_json, co_citation_count, computed_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?)",
+                    (
+                        "paper:s2:zzz",  # > paper_b_id — violates CHECK
+                        "paper:s2:aaa",
+                        0.5,
+                        "[]",
+                        0,
+                        "2025-01-01T00:00:00+00:00",
+                    ),
+                )
+
+    def test_migrate_v6_records_version(self, temp_db: Path) -> None:
+        """V6 migration is recorded in schema_migrations."""
+        manager = MigrationManager(temp_db)
+        manager.migrate()
+        applied = manager.get_applied_migrations()
+        versions = [m["version"] for m in applied]
+        assert 6 in versions
+
+    def test_migrate_v6_preserves_data_inserted_under_v5_schema(
+        self, temp_db: Path
+    ) -> None:
+        """H-1: V6 isolation upgrade test.
+
+        Apply V1+V2+V3+V4+V5 only, insert known rows into all tables
+        (nodes, subscriptions, monitoring_runs, monitoring_papers,
+        citation_influence_metrics), then apply V6 in isolation. V6
+        must (a) create the ``citation_coupling`` table and (b) not
+        disturb any pre-existing rows in other tables. Mirrors the V5
+        isolation test at
+        ``test_migrate_v5_preserves_data_inserted_under_v4_schema``.
+        """
+        manager = MigrationManager(temp_db)
+        # Apply only V1–V5; stop short of V6.
+        conn = manager._get_connection()
+        try:
+            manager._ensure_migrations_table(conn)
+            manager.apply_migration(conn, MIGRATION_V1_INITIAL)
+            manager.apply_migration(conn, MIGRATION_V2_MONITORING_RUNS)
+            manager.apply_migration(conn, MIGRATION_V3_MONITORING_RUNS_FK)
+            manager.apply_migration(conn, MIGRATION_V4_CITATION_INFLUENCE_METRICS)
+            manager.apply_migration(conn, MIGRATION_V5_PAPER_SOURCE_TRACKING)
+        finally:
+            conn.close()
+
+        # Insert rows into all V5 tables.
+        with open_connection(temp_db) as conn:
+            conn.execute(
+                "INSERT INTO nodes"
+                " (node_id, node_type, properties, created_at, updated_at)"
+                " VALUES (?, ?, ?, ?, ?)",
+                (
+                    "paper:s2:v5node",
+                    "paper",
+                    "{}",
+                    "2025-01-01T00:00:00+00:00",
+                    "2025-01-01T00:00:00+00:00",
+                ),
+            )
+            conn.execute(
+                "INSERT INTO subscriptions (subscription_id, user_id, name, config)"
+                " VALUES (?, ?, ?, ?)",
+                ("sub-v5-iso", "bob", "V5 Iso Sub", "{}"),
+            )
+            conn.execute(
+                "INSERT INTO monitoring_runs"
+                " (run_id, subscription_id, user_id, started_at, status)"
+                " VALUES (?, ?, ?, ?, ?)",
+                (
+                    "run-v5-iso",
+                    "sub-v5-iso",
+                    "bob",
+                    "2025-01-01T00:00:00+00:00",
+                    "success",
+                ),
+            )
+            conn.execute(
+                "INSERT INTO monitoring_papers"
+                " (run_id, paper_id, registered, source)"
+                " VALUES (?, ?, ?, ?)",
+                ("run-v5-iso", "paper:v5:iso001", 1, "arxiv"),
+            )
+            conn.execute(
+                "INSERT INTO citation_influence_metrics"
+                " (paper_id, computed_at)"
+                " VALUES (?, ?)",
+                ("paper:s2:v5metrics", "2025-01-01T00:00:00+00:00"),
+            )
+            conn.commit()
+
+        # Apply V6 in isolation.
+        conn = manager._get_connection()
+        try:
+            manager._ensure_migrations_table(conn)
+            manager.apply_migration(conn, MIGRATION_V6_CITATION_COUPLING_CACHE)
+        finally:
+            conn.close()
+
+        with open_connection(temp_db) as conn:
+            # (a) citation_coupling table now exists.
+            cursor = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+                " AND name='citation_coupling'"
+            )
+            assert cursor.fetchone() is not None
+
+            # (b) All V5 rows survive intact.
+            node_row = conn.execute(
+                "SELECT node_id FROM nodes WHERE node_id = ?",
+                ("paper:s2:v5node",),
+            ).fetchone()
+            assert node_row is not None
+
+            sub_row = conn.execute(
+                "SELECT subscription_id FROM subscriptions WHERE subscription_id = ?",
+                ("sub-v5-iso",),
+            ).fetchone()
+            assert sub_row is not None
+
+            run_row = conn.execute(
+                "SELECT run_id, status FROM monitoring_runs WHERE run_id = ?",
+                ("run-v5-iso",),
+            ).fetchone()
+            assert run_row is not None
+            assert run_row["status"] == "success"
+
+            paper_row = conn.execute(
+                "SELECT paper_id, source FROM monitoring_papers WHERE paper_id = ?",
+                ("paper:v5:iso001",),
+            ).fetchone()
+            assert paper_row is not None
+            assert paper_row["source"] == "arxiv"
+
+            metrics_row = conn.execute(
+                "SELECT paper_id FROM citation_influence_metrics WHERE paper_id = ?",
+                ("paper:s2:v5metrics",),
+            ).fetchone()
+            assert metrics_row is not None
+
+
 class TestLatestMigrationVersion:
     """``LATEST_MIGRATION_VERSION`` mirrors the highest entry in
     ``ALL_MIGRATIONS`` so callers (or future cross-references) have
@@ -1666,7 +1896,7 @@ class TestLatestMigrationVersion:
     def test_latest_version_constant_matches_all_migrations(self) -> None:
         assert LATEST_MIGRATION_VERSION == max(m.version for m in ALL_MIGRATIONS)
 
-    def test_latest_version_is_5(self) -> None:
+    def test_latest_version_is_6(self) -> None:
         # Pinned literal so an accidental version bump shows up in
         # review even if ``ALL_MIGRATIONS`` is also extended.
-        assert LATEST_MIGRATION_VERSION == 5
+        assert LATEST_MIGRATION_VERSION == 6

--- a/tests/unit/storage/intelligence_graph/test_migrations.py
+++ b/tests/unit/storage/intelligence_graph/test_migrations.py
@@ -501,7 +501,7 @@ class TestMigrationPathTraversalRejection:
     )
     def test_migration_rejects_traversal_path(self, bad_path: str) -> None:
         """MigrationManager must reject paths outside approved roots."""
-        with pytest.raises(SecurityError):
+        with pytest.raises(SecurityError, match="outside approved storage roots"):
             MigrationManager(bad_path)
 
 
@@ -1167,7 +1167,7 @@ class TestMigrationV4CitationInfluenceMetrics:
                 "(paper_id, computed_at) VALUES (?, ?)",
                 ("paper:s2:dup", "2025-01-01T00:00:00+00:00"),
             )
-            with pytest.raises(sqlite3.IntegrityError):
+            with pytest.raises(sqlite3.IntegrityError, match="UNIQUE"):
                 conn.execute(
                     "INSERT INTO citation_influence_metrics "
                     "(paper_id, computed_at) VALUES (?, ?)",


### PR DESCRIPTION
## Summary

Implements REQ-9.2.3 — Bibliographic Coupling Analyzer — in full:

- **V6 migration** (`citation_coupling` cache table with canonical-pair `CHECK`, strength/count range `CHECK`s, TTL `computed_at` column)
- **`CouplingResult`** Pydantic V2 strict model with field validators (canonical node-id pattern, self-pair rejection, sorted+deduped `shared_references`)
- **`CitationCouplingRepository`** — `connect()` factory, `record()` with `retry_on_lock_contention`, `(min,max)` canonical ordering, `get()` with TTL, `delete_stale()`; swallows non-contention errors and emits structured-log audit events
- **`CouplingAnalyzer`** — `analyze_pair()` (Jaccard over `EdgeType.CITES` outgoing edges, 0/0 safe), `analyze_for_paper()` (top-k DESC), optional repo DI, structured-log events

Closes #128.

## Commits

- `cf23551` feat(phase-9.2): V6 migration for citation_coupling cache table
- `64b77e8` feat(phase-9.2): CouplingResult model + validators
- `1f3d273` feat(phase-9.2): CitationCouplingRepository with retry + canonical ordering
- `fd6bc83` feat(phase-9.2): CouplingAnalyzer (Jaccard over shared references)

## Tests

- New tests: **88** (across `test_coupling_analyzer.py`, `test_coupling_repository.py`, `test_models.py` additions, `test_migrations.py` V6 block)
- Total project: **5217 pass, 0 fail**
- All 9 issue-listed scenarios covered; spec Jaccard example (3/7 ≈ 0.4286) pinned with `pytest.approx`
- Every `pytest.raises` uses `match=`; every log assertion uses `monkeypatch.setattr` rebind before `capture_logs()`

## Coverage

- `coupling_analyzer.py`: **100%**
- `coupling_repository.py`: **100%**
- `models.py` (V6 additions): **100%**
- `migrations.py` (V6 area): **100%**
- Combined project: **99.17%**

## Verification

`./verify.sh` passes 100%: Black ✓, Flake8 ✓, Mypy ✓, Pytest+Coverage ✓