### PR TITLE
feat(phase-9.2): arisp citation CLI (closes #131)

### DIFF
--- a/src/cli/__init__.py
+++ b/src/cli/__init__.py
@@ -28,6 +28,7 @@ from src.cli.catalog import catalog_app, catalog_command
 from src.cli.schedule import schedule_app, schedule_command
 from src.cli.health import health_command
 from src.cli.monitor import monitor_app
+from src.cli.citation import citation_app
 from src.cli.synthesize import synthesize_command
 from src.cli.feedback import app as feedback_app
 from src.cli.research import research_app
@@ -47,6 +48,7 @@ app.add_typer(catalog_app, name="catalog")
 app.add_typer(schedule_app, name="schedule")
 app.add_typer(feedback_app, name="feedback")
 app.add_typer(monitor_app, name="monitor")
+app.add_typer(citation_app, name="citation")
 app.add_typer(research_app, name="research")
 app.add_typer(trajectories_app, name="trajectories")
 
@@ -71,4 +73,5 @@ __all__ = [
     "monitor_app",
     "research_app",
     "trajectories_app",
+    "citation_app",
 ]

--- a/src/cli/citation.py
+++ b/src/cli/citation.py
@@ -1,0 +1,491 @@
+"""``arisp citation`` CLI commands (REQ-9.2.6).
+
+Sub-app for the citation graph intelligence milestone (Phase 9.2 Week 3).
+Mirrors ``src/cli/monitor.py``'s structure: a Typer sub-app registered
+against the main ``arisp`` CLI in ``src/cli/__init__.py``.
+
+Commands:
+
+- ``arisp citation build <paper_id>`` -- bootstrap a depth-1 citation graph
+  for a seed paper using :class:`CitationGraphBuilder`.
+- ``arisp citation expand <paper_id>`` -- BFS-crawl outward via
+  :class:`CitationCrawler`.
+- ``arisp citation related <paper_id>`` -- list top-K related papers via
+  :class:`CitationRecommender` using all four strategies.
+- ``arisp citation influence <paper_id>`` -- show PageRank + citation velocity
+  from :class:`InfluenceScorer`.
+- ``arisp citation path <from_paper_id> <to_paper_id>`` -- find shortest
+  citation path via :class:`SQLiteGraphStore.shortest_path`.
+
+All commands wire through factory helpers that are patchable at the module
+boundary (DI seam for tests — mirror of PR #143 H-5 lesson).
+
+DB path
+-------
+The SQLite database that hosts the citation graph is read from the
+``ARISP_CITATION_DB`` environment variable (default ``./data/citation.db``).
+
+Error handling
+--------------
+- Invalid paper_id format: ``ValueError`` from ``_validate_paper_id``,
+  re-raised as ``typer.BadParameter`` with a matchable message.
+- Missing seed paper in graph: user-friendly message + exit 1 +
+  structured log event ``citation_cli_paper_not_found``.
+- Empty results: "no results" (not an error).
+- Service failures: structured log + exit code 1 via ``@handle_errors``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+from typing import Any, Optional
+
+import structlog
+import typer
+
+from src.cli.utils import display_error, display_info, display_success, handle_errors
+from src.services.intelligence.citation._id_validation import (
+    CANONICAL_NODE_ID_PATTERN,
+    PAPER_ID_MAX_LENGTH,
+)
+from src.services.intelligence.citation.models import (
+    CrawlDirection,
+    RecommendationStrategy,
+)
+
+logger = structlog.get_logger()
+
+_DEFAULT_DB_RELATIVE = Path("./data/citation.db")
+_DB_ENV_VAR = "ARISP_CITATION_DB"
+
+citation_app = typer.Typer(help="Citation graph intelligence (Phase 9.2)")
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_paper_id(paper_id: str) -> None:
+    """Validate a paper id against the canonical node-id pattern.
+
+    Raises:
+        typer.BadParameter: If ``paper_id`` is malformed.
+    """
+    if not isinstance(paper_id, str) or not paper_id.strip():
+        raise typer.BadParameter("paper_id must be a non-empty string")
+    if len(paper_id) > PAPER_ID_MAX_LENGTH:
+        raise typer.BadParameter(
+            f"paper_id length {len(paper_id)} exceeds max {PAPER_ID_MAX_LENGTH}"
+        )
+    if not CANONICAL_NODE_ID_PATTERN.match(paper_id):
+        raise typer.BadParameter(
+            f"Invalid paper_id format: {paper_id!r}. "
+            "Allowed: alphanumeric, colons, periods, hyphens, underscores."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Wiring helpers (patchable at module boundary — DI seam for tests)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_db_path() -> Path:
+    """Return the configured SQLite DB path for citation tables."""
+    env_value = os.environ.get(_DB_ENV_VAR)
+    return Path(env_value) if env_value else _DEFAULT_DB_RELATIVE
+
+
+def _build_graph_builder(*, db_path: Optional[Path] = None) -> Any:
+    """Construct a :class:`CitationGraphBuilder` from a DB path.
+
+    Args:
+        db_path: Path to the SQLite DB. Defaults to ``_resolve_db_path()``.
+
+    Returns:
+        A ready-to-use ``CitationGraphBuilder``.
+    """
+    from src.services.intelligence.citation.graph_builder import CitationGraphBuilder
+    from src.services.intelligence.citation.openalex_client import (
+        OpenAlexCitationClient,
+    )
+    from src.services.intelligence.citation.semantic_scholar_client import (
+        SemanticScholarCitationClient,
+    )
+    from src.storage.intelligence_graph.unified_graph import SQLiteGraphStore
+
+    resolved = db_path or _resolve_db_path()
+    store = SQLiteGraphStore(resolved)
+    store.initialize()
+    return CitationGraphBuilder(
+        store=store,
+        s2_client=SemanticScholarCitationClient(),
+        openalex_client=OpenAlexCitationClient(),
+    )
+
+
+def _build_crawler(*, db_path: Optional[Path] = None) -> Any:
+    """Construct a :class:`CitationCrawler` from a DB path.
+
+    Args:
+        db_path: Path to the SQLite DB. Defaults to ``_resolve_db_path()``.
+
+    Returns:
+        A ready-to-use ``CitationCrawler``.
+    """
+    from src.services.intelligence.citation.crawler import CitationCrawler
+
+    resolved = db_path or _resolve_db_path()
+    return CitationCrawler.from_paths(db_path=resolved)
+
+
+def _build_recommender(*, db_path: Optional[Path] = None) -> Any:
+    """Construct a :class:`CitationRecommender` from a DB path.
+
+    Args:
+        db_path: Path to the SQLite DB. Defaults to ``_resolve_db_path()``.
+
+    Returns:
+        A ready-to-use ``CitationRecommender``.
+    """
+    from src.services.intelligence.citation.recommender import CitationRecommender
+
+    resolved = db_path or _resolve_db_path()
+    return CitationRecommender.connect(db_path=resolved)
+
+
+def _build_scorer(*, db_path: Optional[Path] = None) -> Any:
+    """Construct an :class:`InfluenceScorer` from a DB path.
+
+    Args:
+        db_path: Path to the SQLite DB. Defaults to ``_resolve_db_path()``.
+
+    Returns:
+        A ready-to-use ``InfluenceScorer``.
+    """
+    from src.services.intelligence.citation.influence_scorer import InfluenceScorer
+
+    resolved = db_path or _resolve_db_path()
+    return InfluenceScorer.from_paths(db_path=resolved)
+
+
+def _build_store(*, db_path: Optional[Path] = None) -> Any:
+    """Construct a :class:`SQLiteGraphStore` from a DB path.
+
+    Args:
+        db_path: Path to the SQLite DB. Defaults to ``_resolve_db_path()``.
+
+    Returns:
+        A ready-to-use ``SQLiteGraphStore``.
+    """
+    from src.storage.intelligence_graph.unified_graph import SQLiteGraphStore
+
+    resolved = db_path or _resolve_db_path()
+    st = SQLiteGraphStore(resolved)
+    st.initialize()
+    return st
+
+
+# ---------------------------------------------------------------------------
+# `arisp citation build`
+# ---------------------------------------------------------------------------
+
+
+@citation_app.command("build")
+@handle_errors
+def build_command(
+    paper_id: str = typer.Argument(..., help="Seed paper id"),
+    depth: int = typer.Option(1, "--depth", help="Graph depth (currently fixed at 1)"),
+    db_path: Optional[Path] = typer.Option(
+        None, "--db-path", help="Override citation DB path"
+    ),
+    emit_json: bool = typer.Option(False, "--json", help="Emit JSON output"),
+) -> None:
+    """Bootstrap a citation graph for a seed paper."""
+    _validate_paper_id(paper_id)
+
+    gb = _build_graph_builder(db_path=db_path)
+
+    from src.services.intelligence.citation.models import CitationDirection
+
+    result = asyncio.run(
+        gb.build_for_paper(paper_id, depth=depth, direction=CitationDirection.BOTH)
+    )
+
+    if emit_json:
+        typer.echo(
+            json.dumps(
+                {
+                    "seed_paper_id": result.seed_paper_id,
+                    "nodes_added": result.nodes_added,
+                    "edges_added": result.edges_added,
+                    "provider_used": str(result.provider_used),
+                    "errors": result.errors,
+                }
+            )
+        )
+        return
+
+    display_success(f"Graph built for {result.seed_paper_id}")
+    display_info(f"  nodes_added: {result.nodes_added}")
+    display_info(f"  edges_added: {result.edges_added}")
+    display_info(f"  provider_used: {result.provider_used}")
+    if result.errors:
+        for err in result.errors:
+            display_error(f"  warning: {err}")
+
+
+# ---------------------------------------------------------------------------
+# `arisp citation expand`
+# ---------------------------------------------------------------------------
+
+
+@citation_app.command("expand")
+@handle_errors
+def expand_command(
+    paper_id: str = typer.Argument(..., help="Seed paper id"),
+    depth: int = typer.Option(1, "--depth", min=1, max=3, help="BFS depth (1-3)"),
+    max_papers: int = typer.Option(50, "--max-papers", help="Max papers per BFS level"),
+    direction: CrawlDirection = typer.Option(
+        CrawlDirection.BOTH, "--direction", help="Crawl direction"
+    ),
+    db_path: Optional[Path] = typer.Option(
+        None, "--db-path", help="Override citation DB path"
+    ),
+    emit_json: bool = typer.Option(False, "--json", help="Emit JSON output"),
+) -> None:
+    """BFS-crawl the citation graph outward from a seed paper."""
+    _validate_paper_id(paper_id)
+
+    from src.services.intelligence.citation.crawler import CrawlConfig
+
+    config = CrawlConfig(
+        max_depth=depth,
+        max_papers_per_level=max_papers,
+        direction=direction,
+    )
+
+    cr = _build_crawler(db_path=db_path)
+    result = asyncio.run(cr.crawl(paper_id, config=config))
+
+    if emit_json:
+        typer.echo(
+            json.dumps(
+                {
+                    "papers_visited": result.papers_visited,
+                    "levels_reached": result.levels_reached,
+                    "edges_added": result.edges_added,
+                    "api_calls_made": result.api_calls_made,
+                    "budget_exhausted": result.budget_exhausted,
+                    "persistence_aborted": result.persistence_aborted,
+                }
+            )
+        )
+        return
+
+    display_success(f"Crawl complete for {paper_id}")
+    display_info(f"  papers_visited: {result.papers_visited}")
+    display_info(f"  levels_reached: {result.levels_reached}")
+    display_info(f"  edges_added: {result.edges_added}")
+    display_info(f"  api_calls_made: {result.api_calls_made}")
+    if result.budget_exhausted:
+        display_error("  warning: API budget exhausted before crawl completed")
+    if result.persistence_aborted:
+        display_error("  warning: Persistence failure aborted crawl")
+
+
+# ---------------------------------------------------------------------------
+# `arisp citation related`
+# ---------------------------------------------------------------------------
+
+_STRATEGY_ALL = "all"
+_VALID_STRATEGIES = [
+    RecommendationStrategy.SIMILAR.value,
+    RecommendationStrategy.INFLUENTIAL_PREDECESSOR.value,
+    RecommendationStrategy.ACTIVE_SUCCESSOR.value,
+    RecommendationStrategy.BRIDGE.value,
+    _STRATEGY_ALL,
+]
+
+
+@citation_app.command("related")
+@handle_errors
+def related_command(
+    paper_id: str = typer.Argument(..., help="Seed paper id"),
+    k: int = typer.Option(5, "--k", help="Results per strategy"),
+    strategy: str = typer.Option(
+        _STRATEGY_ALL,
+        "--strategy",
+        help=(
+            "Strategy to use: similar, influential_predecessor, "
+            "active_successor, bridge, all"
+        ),
+    ),
+    db_path: Optional[Path] = typer.Option(
+        None, "--db-path", help="Override citation DB path"
+    ),
+    emit_json: bool = typer.Option(False, "--json", help="Emit JSON output"),
+) -> None:
+    """List top-K related papers using citation recommendation strategies."""
+    _validate_paper_id(paper_id)
+
+    if strategy not in _VALID_STRATEGIES:
+        raise typer.BadParameter(
+            f"Invalid strategy {strategy!r}. "
+            f"Choose from: {', '.join(_VALID_STRATEGIES)}"
+        )
+
+    rec = _build_recommender(db_path=db_path)
+
+    if strategy == _STRATEGY_ALL:
+        results_by_strategy = asyncio.run(rec.recommend_all(paper_id, k_per_strategy=k))
+    else:
+        strat_enum = RecommendationStrategy(strategy)
+        method_map = {
+            RecommendationStrategy.SIMILAR: rec.recommend_similar,
+            RecommendationStrategy.INFLUENTIAL_PREDECESSOR: (
+                rec.recommend_influential_predecessors
+            ),
+            RecommendationStrategy.ACTIVE_SUCCESSOR: rec.recommend_active_successors,
+            RecommendationStrategy.BRIDGE: rec.recommend_bridge_papers,
+        }
+        recs = asyncio.run(method_map[strat_enum](paper_id, k=k))
+        results_by_strategy = {strat_enum: recs}
+
+    if emit_json:
+        typer.echo(
+            json.dumps(
+                {
+                    strat.value: [
+                        {
+                            "paper_id": r.paper_id,
+                            "score": r.score,
+                            "reasoning": r.reasoning,
+                        }
+                        for r in recs_list
+                    ]
+                    for strat, recs_list in results_by_strategy.items()
+                }
+            )
+        )
+        return
+
+    any_results = False
+    for strat, recs_list in results_by_strategy.items():
+        typer.echo(f"\n--- {strat.value} ---")
+        if not recs_list:
+            typer.echo("  (no results)")
+            continue
+        any_results = True
+        for i, rec_item in enumerate(recs_list, 1):
+            typer.echo(f"  {i}. {rec_item.paper_id}  score={rec_item.score:.4f}")
+            typer.echo(f"     {rec_item.reasoning}")
+
+    if not any_results:
+        display_info("No related papers found.")
+
+
+# ---------------------------------------------------------------------------
+# `arisp citation influence`
+# ---------------------------------------------------------------------------
+
+
+@citation_app.command("influence")
+@handle_errors
+def influence_command(
+    paper_id: str = typer.Argument(..., help="Seed paper id"),
+    max_age_days: int = typer.Option(7, "--max-age-days", help="Cache TTL in days"),
+    db_path: Optional[Path] = typer.Option(
+        None, "--db-path", help="Override citation DB path"
+    ),
+    emit_json: bool = typer.Option(False, "--json", help="Emit JSON output"),
+) -> None:
+    """Show PageRank + citation velocity for a paper."""
+    _validate_paper_id(paper_id)
+
+    from datetime import timedelta
+
+    from src.services.intelligence.citation.influence_scorer import InfluenceScorer
+
+    resolved = db_path or _resolve_db_path()
+    sc = InfluenceScorer.from_paths(
+        db_path=resolved, cache_ttl=timedelta(days=max_age_days)
+    )
+
+    metrics = asyncio.run(sc.compute_for_paper(paper_id))
+
+    if emit_json:
+        typer.echo(
+            json.dumps(
+                {
+                    "paper_id": metrics.paper_id,
+                    "citation_count": metrics.citation_count,
+                    "citation_velocity": metrics.citation_velocity,
+                    "pagerank_score": metrics.pagerank_score,
+                    "hub_score": metrics.hub_score,
+                    "authority_score": metrics.authority_score,
+                }
+            )
+        )
+        return
+
+    typer.echo(f"paper_id:          {metrics.paper_id}")
+    typer.echo(f"citation_count:    {metrics.citation_count}")
+    typer.echo(f"citation_velocity: {metrics.citation_velocity:.4f}")
+    typer.echo(f"pagerank_score:    {metrics.pagerank_score:.6f}")
+    typer.echo(f"hub_score:         {metrics.hub_score:.6f}")
+    typer.echo(f"authority_score:   {metrics.authority_score:.6f}")
+
+
+# ---------------------------------------------------------------------------
+# `arisp citation path`
+# ---------------------------------------------------------------------------
+
+
+@citation_app.command("path")
+@handle_errors
+def path_command(
+    from_paper_id: str = typer.Argument(..., help="Source paper id"),
+    to_paper_id: str = typer.Argument(..., help="Target paper id"),
+    max_depth: int = typer.Option(6, "--max-depth", help="Max BFS depth"),
+    db_path: Optional[Path] = typer.Option(
+        None, "--db-path", help="Override citation DB path"
+    ),
+    emit_json: bool = typer.Option(False, "--json", help="Emit JSON output"),
+) -> None:
+    """Find shortest citation path between two papers."""
+    _validate_paper_id(from_paper_id)
+    _validate_paper_id(to_paper_id)
+
+    gs = _build_store(db_path=db_path)
+
+    path_nodes = gs.shortest_path(from_paper_id, to_paper_id)
+
+    if path_nodes is None:
+        logger.info(
+            "citation_cli_paper_not_found",
+            from_paper_id=from_paper_id,
+            to_paper_id=to_paper_id,
+        )
+        if emit_json:
+            typer.echo(
+                json.dumps({"path": None, "from": from_paper_id, "to": to_paper_id})
+            )
+        else:
+            display_info(
+                f"No path found between {from_paper_id!r} and {to_paper_id!r} "
+                f"(max_depth={max_depth})"
+            )
+        raise typer.Exit(code=1)
+
+    path_ids = [n.node_id for n in path_nodes]
+
+    if emit_json:
+        typer.echo(json.dumps({"path": path_ids, "length": len(path_ids) - 1}))
+        return
+
+    typer.echo(" -> ".join(path_ids))
+    display_info(f"Path length: {len(path_ids) - 1} hop(s)")

--- a/src/cli/citation.py
+++ b/src/cli/citation.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+from datetime import timedelta
 from pathlib import Path
 from typing import Any, Optional
 
@@ -55,6 +56,7 @@ from src.services.intelligence.citation.models import (
     CrawlDirection,
     RecommendationStrategy,
 )
+from src.storage.intelligence_graph.path_utils import sanitize_storage_path
 
 logger = structlog.get_logger()
 
@@ -94,9 +96,13 @@ def _validate_paper_id(paper_id: str) -> None:
 
 
 def _resolve_db_path() -> Path:
-    """Return the configured SQLite DB path for citation tables."""
+    """Return the configured SQLite DB path for citation tables.
+
+    Sanitizes the path at the CLI boundary to prevent directory traversal.
+    Raises ``SecurityError`` if the resolved path is outside approved roots.
+    """
     env_value = os.environ.get(_DB_ENV_VAR)
-    return Path(env_value) if env_value else _DEFAULT_DB_RELATIVE
+    return sanitize_storage_path(env_value or _DEFAULT_DB_RELATIVE)
 
 
 def _build_graph_builder(*, db_path: Optional[Path] = None) -> Any:
@@ -157,11 +163,17 @@ def _build_recommender(*, db_path: Optional[Path] = None) -> Any:
     return CitationRecommender.connect(db_path=resolved)
 
 
-def _build_scorer(*, db_path: Optional[Path] = None) -> Any:
+def _build_scorer(
+    *,
+    db_path: Optional[Path] = None,
+    cache_ttl: timedelta = timedelta(days=7),
+) -> Any:
     """Construct an :class:`InfluenceScorer` from a DB path.
 
     Args:
         db_path: Path to the SQLite DB. Defaults to ``_resolve_db_path()``.
+        cache_ttl: Cache time-to-live for influence computations.
+            Defaults to 7 days.
 
     Returns:
         A ready-to-use ``InfluenceScorer``.
@@ -169,7 +181,7 @@ def _build_scorer(*, db_path: Optional[Path] = None) -> Any:
     from src.services.intelligence.citation.influence_scorer import InfluenceScorer
 
     resolved = db_path or _resolve_db_path()
-    return InfluenceScorer.from_paths(db_path=resolved)
+    return InfluenceScorer.from_paths(db_path=resolved, cache_ttl=cache_ttl)
 
 
 def _build_store(*, db_path: Optional[Path] = None) -> Any:
@@ -412,14 +424,7 @@ def influence_command(
     """Show PageRank + citation velocity for a paper."""
     _validate_paper_id(paper_id)
 
-    from datetime import timedelta
-
-    from src.services.intelligence.citation.influence_scorer import InfluenceScorer
-
-    resolved = db_path or _resolve_db_path()
-    sc = InfluenceScorer.from_paths(
-        db_path=resolved, cache_ttl=timedelta(days=max_age_days)
-    )
+    sc = _build_scorer(db_path=db_path, cache_ttl=timedelta(days=max_age_days))
 
     metrics = asyncio.run(sc.compute_for_paper(paper_id))
 

--- a/src/cli/citation.py
+++ b/src/cli/citation.py
@@ -361,7 +361,7 @@ def related_command(
     if strategy == _STRATEGY_ALL:
         results_by_strategy = asyncio.run(rec.recommend_all(paper_id, k_per_strategy=k))
     else:
-        strat_enum = RecommendationStrategy(strategy)
+        strategy_enum = RecommendationStrategy(strategy)
         method_map = {
             RecommendationStrategy.SIMILAR: rec.recommend_similar,
             RecommendationStrategy.INFLUENTIAL_PREDECESSOR: (
@@ -370,14 +370,14 @@ def related_command(
             RecommendationStrategy.ACTIVE_SUCCESSOR: rec.recommend_active_successors,
             RecommendationStrategy.BRIDGE: rec.recommend_bridge_papers,
         }
-        recs = asyncio.run(method_map[strat_enum](paper_id, k=k))
-        results_by_strategy = {strat_enum: recs}
+        recs = asyncio.run(method_map[strategy_enum](paper_id, k=k))
+        results_by_strategy = {strategy_enum: recs}
 
     if emit_json:
         typer.echo(
             json.dumps(
                 {
-                    strat.value: [
+                    strategy_enum.value: [
                         {
                             "paper_id": r.paper_id,
                             "score": r.score,
@@ -385,15 +385,15 @@ def related_command(
                         }
                         for r in recs_list
                     ]
-                    for strat, recs_list in results_by_strategy.items()
+                    for strategy_enum, recs_list in results_by_strategy.items()
                 }
             )
         )
         return
 
     any_results = False
-    for strat, recs_list in results_by_strategy.items():
-        typer.echo(f"\n--- {strat.value} ---")
+    for strategy_enum, recs_list in results_by_strategy.items():
+        typer.echo(f"\n--- {strategy_enum.value} ---")
         if not recs_list:
             typer.echo("  (no results)")
             continue

--- a/src/cli/citation.py
+++ b/src/cli/citation.py
@@ -198,7 +198,9 @@ def _build_store(*, db_path: Optional[Path] = None) -> Any:
 @handle_errors
 def build_command(
     paper_id: str = typer.Argument(..., help="Seed paper id"),
-    depth: int = typer.Option(1, "--depth", help="Graph depth (currently fixed at 1)"),
+    depth: int = typer.Option(
+        1, "--depth", min=1, max=1, help="Graph depth (currently fixed at 1)"
+    ),
     db_path: Optional[Path] = typer.Option(
         None, "--db-path", help="Override citation DB path"
     ),
@@ -248,7 +250,9 @@ def build_command(
 def expand_command(
     paper_id: str = typer.Argument(..., help="Seed paper id"),
     depth: int = typer.Option(1, "--depth", min=1, max=3, help="BFS depth (1-3)"),
-    max_papers: int = typer.Option(50, "--max-papers", help="Max papers per BFS level"),
+    max_papers: int = typer.Option(
+        50, "--max-papers", min=10, max=200, help="Max papers per BFS level (10-200)"
+    ),
     direction: CrawlDirection = typer.Option(
         CrawlDirection.BOTH, "--direction", help="Crawl direction"
     ),
@@ -315,7 +319,9 @@ _VALID_STRATEGIES = [
 @handle_errors
 def related_command(
     paper_id: str = typer.Argument(..., help="Seed paper id"),
-    k: int = typer.Option(5, "--k", help="Results per strategy"),
+    k: int = typer.Option(
+        5, "--k", min=1, max=100, help="Results per strategy (1-100)"
+    ),
     strategy: str = typer.Option(
         _STRATEGY_ALL,
         "--strategy",
@@ -450,7 +456,9 @@ def influence_command(
 def path_command(
     from_paper_id: str = typer.Argument(..., help="Source paper id"),
     to_paper_id: str = typer.Argument(..., help="Target paper id"),
-    max_depth: int = typer.Option(6, "--max-depth", help="Max BFS depth"),
+    max_depth: int = typer.Option(
+        6, "--max-depth", min=1, max=10, help="Max BFS depth (1-10)"
+    ),
     db_path: Optional[Path] = typer.Option(
         None, "--db-path", help="Override citation DB path"
     ),
@@ -462,7 +470,7 @@ def path_command(
 
     gs = _build_store(db_path=db_path)
 
-    path_nodes = gs.shortest_path(from_paper_id, to_paper_id)
+    path_nodes = gs.shortest_path(from_paper_id, to_paper_id, max_depth=max_depth)
 
     if path_nodes is None:
         logger.info(

--- a/src/cli/utils.py
+++ b/src/cli/utils.py
@@ -10,8 +10,9 @@ from typing import Callable, TypeVar
 import structlog
 import typer
 
-from src.services.config_manager import ConfigManager, ConfigValidationError
 from src.models.config import ResearchConfig
+from src.services.config_manager import ConfigManager, ConfigValidationError
+from src.storage.intelligence_graph.connection import _trunc
 from src.utils.logging import configure_logging
 
 # Configure structured logging
@@ -60,9 +61,17 @@ def handle_errors(func: F) -> F:
             return func(*args, **kwargs)
         except typer.Exit:
             raise
-        except Exception as e:
-            logger.exception("command_failed")
-            typer.secho(f"Error: {e}", fg=typer.colors.RED)
+        except Exception as exc:
+            typer.secho(
+                "Operation failed (see logs for details)",
+                fg=typer.colors.RED,
+                err=True,
+            )
+            logger.error(
+                "command_failed",
+                error=_trunc(exc),
+                error_type=type(exc).__name__,
+            )
             raise typer.Exit(code=1)
 
     return wrapper  # type: ignore[return-value]

--- a/src/storage/intelligence_graph/unified_graph.py
+++ b/src/storage/intelligence_graph/unified_graph.py
@@ -283,16 +283,21 @@ class GraphStore(Protocol):
         ...  # pragma: no cover - Protocol abstract method
 
     def shortest_path(
-        self, source_id: str, target_id: str
+        self,
+        source_id: str,
+        target_id: str,
+        max_depth: Optional[int] = None,
     ) -> Optional[list[GraphNode]]:
         """Find shortest path between two nodes.
 
         Args:
             source_id: Source node ID
             target_id: Target node ID
+            max_depth: Maximum BFS depth. ``None`` means unbounded.
 
         Returns:
-            List of nodes in path, or None if no path exists
+            List of nodes in path, or None if no path exists or target
+            is beyond ``max_depth`` hops from source.
         """
         ...  # pragma: no cover - Protocol abstract method
 
@@ -1028,7 +1033,10 @@ class SQLiteGraphStore:
         return out
 
     def shortest_path(
-        self, source_id: str, target_id: str
+        self,
+        source_id: str,
+        target_id: str,
+        max_depth: Optional[int] = None,
     ) -> Optional[list[GraphNode]]:
         """Find shortest path between two nodes using BFS.
 
@@ -1042,6 +1050,14 @@ class SQLiteGraphStore:
         The bidirectional neighbor query uses ``UNION ALL``; the BFS
         ``visited`` set already deduplicates, so plain ``UNION`` is wasted
         work.
+
+        Args:
+            source_id: Source node ID.
+            target_id: Target node ID.
+            max_depth: Maximum BFS depth. ``None`` means unbounded.
+                When set, the BFS stops expanding nodes whose depth
+                would exceed this bound, and ``None`` is returned if the
+                target has not been found within the bound.
         """
         conn = self._get_connection()
         try:
@@ -1050,16 +1066,23 @@ class SQLiteGraphStore:
             # so the early-exit goes through one consistent code path
             # instead of opening a separate connection via ``get_node``.
             if source_id == target_id:
+                # depth-0 path: never exceeds any max_depth bound
                 fetched = self._fetch_nodes_by_ids(conn, [source_id])
                 node = fetched.get(source_id)
                 return [node] if node else None
 
             visited: set[str] = {source_id}
             parent: dict[str, Optional[str]] = {source_id: None}
-            queue: deque[str] = deque([source_id])
+            # Queue stores (node_id, depth_from_source) so the depth
+            # bound can be enforced without an additional lookup.
+            queue: deque[tuple[str, int]] = deque([(source_id, 0)])
 
             while queue:
-                current_id = queue.popleft()
+                current_id, current_depth = queue.popleft()
+
+                # Do not expand beyond the caller-supplied depth cap.
+                if max_depth is not None and current_depth >= max_depth:
+                    continue
 
                 # Get all neighbors (UNION ALL: visited dedupes already)
                 cursor = conn.execute(
@@ -1095,7 +1118,7 @@ class SQLiteGraphStore:
                         # strict consistency should re-check counts.
                         return [fetched[nid] for nid in path_ids if nid in fetched]
 
-                    queue.append(neighbor_id)
+                    queue.append((neighbor_id, current_depth + 1))
 
             return None  # No path found
         finally:

--- a/tests/unit/cli/test_citation_cli.py
+++ b/tests/unit/cli/test_citation_cli.py
@@ -1,0 +1,1173 @@
+"""Tests for ``arisp citation`` CLI commands (Phase 9.2, REQ-9.2.6).
+
+All commands run end-to-end through ``typer.testing.CliRunner``. Heavy
+collaborators (``CitationGraphBuilder``, ``CitationCrawler``, etc.) are
+patched at the CLI module boundary via ``monkeypatch.setattr`` on the
+``_build_*`` helper functions (PR #143 H-5 lesson: mock at module boundary).
+
+Test naming convention: ``test_<function>_<scenario>``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import structlog
+import structlog.testing
+from typer.testing import CliRunner
+
+from src.cli.citation import (
+    _DB_ENV_VAR,
+    _build_crawler,
+    _build_graph_builder,
+    _build_recommender,
+    _build_scorer,
+    _build_store,
+    _resolve_db_path,
+    _validate_paper_id,
+    citation_app,
+)
+from src.services.intelligence.citation.models import (
+    CrawlDirection,
+    Recommendation,
+    RecommendationStrategy,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def db_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Point the CLI's citation DB env var at a temp file."""
+    db_path = tmp_path / "citation.db"
+    monkeypatch.setenv(_DB_ENV_VAR, str(db_path))
+    return db_path
+
+
+# ---------------------------------------------------------------------------
+# _resolve_db_path
+# ---------------------------------------------------------------------------
+
+
+class TestResolveDbPath:
+    def test_env_unset_returns_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(_DB_ENV_VAR, raising=False)
+        assert _resolve_db_path() == Path("./data/citation.db")
+
+    def test_env_set_returns_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(_DB_ENV_VAR, "/tmp/cit.db")
+        assert _resolve_db_path() == Path("/tmp/cit.db")
+
+
+# ---------------------------------------------------------------------------
+# _validate_paper_id
+# ---------------------------------------------------------------------------
+
+
+class TestValidatePaperId:
+    def test_valid_id_passes(self) -> None:
+        # Should not raise
+        _validate_paper_id("paper:s2:abc123")
+
+    def test_empty_string_raises_bad_parameter(self) -> None:
+        with pytest.raises(Exception, match="non-empty"):
+            _validate_paper_id("")
+
+    def test_whitespace_only_raises_bad_parameter(self) -> None:
+        with pytest.raises(Exception, match="non-empty"):
+            _validate_paper_id("   ")
+
+    def test_too_long_raises_bad_parameter(self) -> None:
+        with pytest.raises(Exception, match="exceeds max"):
+            _validate_paper_id("a" * 513)
+
+    def test_invalid_chars_raises_bad_parameter(self) -> None:
+        with pytest.raises(Exception, match="Invalid paper_id format"):
+            _validate_paper_id("paper/with/slashes")
+
+
+# ---------------------------------------------------------------------------
+# Helpers: build functions (no-injection path)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildHelpers:
+    def test_build_graph_builder_constructs_from_path(self, tmp_path: Path) -> None:
+        from src.services.intelligence.citation.graph_builder import (
+            CitationGraphBuilder,
+        )
+
+        gb = _build_graph_builder(db_path=tmp_path / "c.db")
+        assert isinstance(gb, CitationGraphBuilder)
+
+    def test_build_crawler_constructs_from_path(self, tmp_path: Path) -> None:
+        from src.services.intelligence.citation.crawler import CitationCrawler
+
+        cr = _build_crawler(db_path=tmp_path / "c.db")
+        assert isinstance(cr, CitationCrawler)
+
+    def test_build_recommender_constructs_from_path(self, tmp_path: Path) -> None:
+        from src.services.intelligence.citation.recommender import CitationRecommender
+
+        rec = _build_recommender(db_path=tmp_path / "c.db")
+        assert isinstance(rec, CitationRecommender)
+
+    def test_build_scorer_constructs_from_path(self, tmp_path: Path) -> None:
+        from src.services.intelligence.citation.influence_scorer import InfluenceScorer
+
+        sc = _build_scorer(db_path=tmp_path / "c.db")
+        assert isinstance(sc, InfluenceScorer)
+
+    def test_build_store_constructs_from_path(self, tmp_path: Path) -> None:
+        from src.storage.intelligence_graph.unified_graph import SQLiteGraphStore
+
+        st = _build_store(db_path=tmp_path / "c.db")
+        assert isinstance(st, SQLiteGraphStore)
+
+    def test_build_graph_builder_uses_env_db_when_no_path(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from src.services.intelligence.citation.graph_builder import (
+            CitationGraphBuilder,
+        )
+
+        monkeypatch.setenv(_DB_ENV_VAR, str(tmp_path / "env.db"))
+        gb = _build_graph_builder()
+        assert isinstance(gb, CitationGraphBuilder)
+
+    def test_build_crawler_uses_env_db_when_no_path(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from src.services.intelligence.citation.crawler import CitationCrawler
+
+        monkeypatch.setenv(_DB_ENV_VAR, str(tmp_path / "env.db"))
+        cr = _build_crawler()
+        assert isinstance(cr, CitationCrawler)
+
+    def test_build_recommender_uses_env_db_when_no_path(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from src.services.intelligence.citation.recommender import CitationRecommender
+
+        monkeypatch.setenv(_DB_ENV_VAR, str(tmp_path / "env.db"))
+        rec = _build_recommender()
+        assert isinstance(rec, CitationRecommender)
+
+    def test_build_scorer_uses_env_db_when_no_path(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from src.services.intelligence.citation.influence_scorer import InfluenceScorer
+
+        monkeypatch.setenv(_DB_ENV_VAR, str(tmp_path / "env.db"))
+        sc = _build_scorer()
+        assert isinstance(sc, InfluenceScorer)
+
+    def test_build_store_uses_env_db_when_no_path(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from src.storage.intelligence_graph.unified_graph import SQLiteGraphStore
+
+        monkeypatch.setenv(_DB_ENV_VAR, str(tmp_path / "env.db"))
+        st = _build_store()
+        assert isinstance(st, SQLiteGraphStore)
+
+
+# ---------------------------------------------------------------------------
+# `arisp citation build`
+# ---------------------------------------------------------------------------
+
+
+def _make_graph_build_result(
+    *,
+    seed_paper_id: str = "paper:s2:abc123",
+    nodes_added: int = 5,
+    edges_added: int = 4,
+    provider_used: str = "s2",
+    errors: Optional[list] = None,
+) -> MagicMock:
+    result = MagicMock()
+    result.seed_paper_id = seed_paper_id
+    result.nodes_added = nodes_added
+    result.edges_added = edges_added
+    result.provider_used = provider_used
+    result.errors = errors or []
+    return result
+
+
+class TestBuildCommand:
+    def test_build_happy_path(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        result_obj = _make_graph_build_result()
+        mock_gb = MagicMock()
+        mock_gb.build_for_paper = AsyncMock(return_value=result_obj)
+
+        import src.cli.citation as citation_module
+
+        monkeypatch.setattr(
+            citation_module, "_build_graph_builder", lambda **kw: mock_gb
+        )
+
+        result = runner.invoke(citation_app, ["build", "paper:s2:abc123"])
+        assert result.exit_code == 0, result.output
+        assert "paper:s2:abc123" in result.output
+        assert "nodes_added" in result.output
+        mock_gb.build_for_paper.assert_called_once()
+
+    def test_build_json_flag(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        result_obj = _make_graph_build_result()
+        mock_gb = MagicMock()
+        mock_gb.build_for_paper = AsyncMock(return_value=result_obj)
+
+        import src.cli.citation as citation_module
+
+        monkeypatch.setattr(
+            citation_module, "_build_graph_builder", lambda **kw: mock_gb
+        )
+
+        result = runner.invoke(citation_app, ["build", "paper:s2:abc123", "--json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["seed_paper_id"] == "paper:s2:abc123"
+        assert data["nodes_added"] == 5
+        assert "provider_used" in data
+
+    def test_build_invalid_paper_id_exits_nonzero(self, runner: CliRunner) -> None:
+        result = runner.invoke(citation_app, ["build", "bad/id/format"])
+        assert result.exit_code != 0
+
+    def test_build_service_failure_exits_nonzero(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mock_gb = MagicMock()
+        mock_gb.build_for_paper = AsyncMock(
+            side_effect=RuntimeError("DB connection failed")
+        )
+
+        import src.cli.citation as citation_module
+
+        monkeypatch.setattr(
+            citation_module, "_build_graph_builder", lambda **kw: mock_gb
+        )
+
+        result = runner.invoke(citation_app, ["build", "paper:s2:abc123"])
+        assert result.exit_code != 0
+
+    def test_build_with_errors_in_result_shows_warnings(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        result_obj = _make_graph_build_result(errors=["S2 rate limited"])
+        mock_gb = MagicMock()
+        mock_gb.build_for_paper = AsyncMock(return_value=result_obj)
+
+        import src.cli.citation as citation_module
+
+        monkeypatch.setattr(
+            citation_module, "_build_graph_builder", lambda **kw: mock_gb
+        )
+
+        result = runner.invoke(citation_app, ["build", "paper:s2:abc123"])
+        assert result.exit_code == 0
+        assert "S2 rate limited" in result.output
+
+    def test_build_with_depth_option(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        result_obj = _make_graph_build_result()
+        mock_gb = MagicMock()
+        mock_gb.build_for_paper = AsyncMock(return_value=result_obj)
+
+        import src.cli.citation as citation_module
+
+        monkeypatch.setattr(
+            citation_module, "_build_graph_builder", lambda **kw: mock_gb
+        )
+
+        result = runner.invoke(
+            citation_app, ["build", "paper:s2:abc123", "--depth", "1"]
+        )
+        assert result.exit_code == 0
+
+    def test_build_constructs_builder_correctly(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """_build_graph_builder is called with db_path from --db-path option."""
+        captured: dict = {}
+        result_obj = _make_graph_build_result()
+        mock_gb = MagicMock()
+        mock_gb.build_for_paper = AsyncMock(return_value=result_obj)
+
+        def fake_builder(*, db_path: Optional[Path] = None) -> MagicMock:
+            captured["db_path"] = db_path
+            return mock_gb
+
+        import src.cli.citation as citation_module
+
+        monkeypatch.setattr(citation_module, "_build_graph_builder", fake_builder)
+
+        result = runner.invoke(
+            citation_app,
+            ["build", "paper:s2:abc123", "--db-path", "/tmp/test.db"],
+        )
+        assert result.exit_code == 0, result.output
+        assert captured["db_path"] == Path("/tmp/test.db")
+
+
+# ---------------------------------------------------------------------------
+# `arisp citation expand`
+# ---------------------------------------------------------------------------
+
+
+def _make_crawl_result(
+    *,
+    papers_visited: int = 10,
+    levels_reached: int = 2,
+    edges_added: int = 8,
+    api_calls_made: int = 3,
+    budget_exhausted: bool = False,
+    persistence_aborted: bool = False,
+) -> MagicMock:
+    result = MagicMock()
+    result.papers_visited = papers_visited
+    result.levels_reached = levels_reached
+    result.edges_added = edges_added
+    result.api_calls_made = api_calls_made
+    result.budget_exhausted = budget_exhausted
+    result.persistence_aborted = persistence_aborted
+    return result
+
+
+class TestExpandCommand:
+    def test_expand_happy_path(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        crawl_result = _make_crawl_result()
+        mock_crawler = MagicMock()
+        mock_crawler.crawl = AsyncMock(return_value=crawl_result)
+
+        import src.cli.citation as citation_module
+
+        monkeypatch.setattr(
+            citation_module, "_build_crawler", lambda **kw: mock_crawler
+        )
+
+        result = runner.invoke(citation_app, ["expand", "paper:s2:abc123"])
+        assert result.exit_code == 0, result.output
+        assert "papers_visited" in result.output
+        assert "10" in result.output
+        mock_crawler.crawl.assert_called_once()
+
+    def test_expand_invalid_paper_id_exits_nonzero(self, runner: CliRunner) -> None:
+        result = runner.invoke(citation_app, ["expand", "bad/id"])
+        assert result.exit_code != 0
+
+    def test_expand_service_failure_exits_nonzero(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mock_crawler = MagicMock()
+        mock_crawler.crawl = AsyncMock(side_effect=RuntimeError("network error"))
+
+        import src.cli.citation as citation_module
+
+        monkeypatch.setattr(
+            citation_module, "_build_crawler", lambda **kw: mock_crawler
+        )
+
+        result = runner.invoke(citation_app, ["expand", "paper:s2:abc123"])
+        assert result.exit_code != 0
+
+    def test_expand_json_flag(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        crawl_result = _make_crawl_result(papers_visited=7, edges_added=5)
+        mock_crawler = MagicMock()
+        mock_crawler.crawl = AsyncMock(return_value=crawl_result)
+
+        import src.cli.citation as citation_module
+
+        monkeypatch.setattr(
+            citation_module, "_build_crawler", lambda **kw: mock_crawler
+        )
+
+        result = runner.invoke(citation_app, ["expand", "paper:s2:abc123", "--json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["papers_visited"] == 7
+        assert data["edges_added"] == 5
+
+    def test_expand_budget_exhausted_shows_warning(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        crawl_result = _make_crawl_result(budget_exhausted=True)
+        mock_crawler = MagicMock()
+        mock_crawler.crawl = AsyncMock(return_value=crawl_result)
+
+        import src.cli.citation as citation_module
+
+        monkeypatch.setattr(
+            citation_module, "_build_crawler", lambda **kw: mock_crawler
+        )
+
+        result = runner.invoke(citation_app, ["expand", "paper:s2:abc123"])
+        assert result.exit_code == 0
+        assert "budget exhausted" in result.output
+
+    def test_expand_persistence_aborted_shows_warning(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        crawl_result = _make_crawl_result(persistence_aborted=True)
+        mock_crawler = MagicMock()
+        mock_crawler.crawl = AsyncMock(return_value=crawl_result)
+
+        import src.cli.citation as citation_module
+
+        monkeypatch.setattr(
+            citation_module, "_build_crawler", lambda **kw: mock_crawler
+        )
+
+        result = runner.invoke(citation_app, ["expand", "paper:s2:abc123"])
+        assert result.exit_code == 0
+        assert "Persistence failure" in result.output
+
+    def test_expand_with_direction_forward(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        crawl_result = _make_crawl_result()
+        mock_crawler = MagicMock()
+        mock_crawler.crawl = AsyncMock(return_value=crawl_result)
+
+        import src.cli.citation as citation_module
+
+        monkeypatch.setattr(
+            citation_module, "_build_crawler", lambda **kw: mock_crawler
+        )
+
+        result = runner.invoke(
+            citation_app,
+            ["expand", "paper:s2:abc123", "--direction", "forward"],
+        )
+        assert result.exit_code == 0, result.output
+        # Confirm CrawlConfig got direction=forward
+        call_args = mock_crawler.crawl.call_args
+        # call may be positional or keyword
+        config = (
+            call_args.args[1]
+            if len(call_args.args) > 1
+            else call_args.kwargs.get("config")
+        )
+        assert config.direction == CrawlDirection.FORWARD
+
+    def test_expand_with_max_papers_option(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        crawl_result = _make_crawl_result()
+        mock_crawler = MagicMock()
+        mock_crawler.crawl = AsyncMock(return_value=crawl_result)
+
+        import src.cli.citation as citation_module
+
+        monkeypatch.setattr(
+            citation_module, "_build_crawler", lambda **kw: mock_crawler
+        )
+
+        result = runner.invoke(
+            citation_app,
+            ["expand", "paper:s2:abc123", "--max-papers", "10"],
+        )
+        assert result.exit_code == 0, result.output
+        call_args = mock_crawler.crawl.call_args
+        config = (
+            call_args.args[1]
+            if len(call_args.args) > 1
+            else call_args.kwargs.get("config")
+        )
+        assert config.max_papers_per_level == 10
+
+    def test_expand_db_path_forwarded_to_builder(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: dict = {}
+        crawl_result = _make_crawl_result()
+        mock_crawler = MagicMock()
+        mock_crawler.crawl = AsyncMock(return_value=crawl_result)
+
+        def fake_build_crawler(*, db_path: Optional[Path] = None) -> MagicMock:
+            captured["db_path"] = db_path
+            return mock_crawler
+
+        import src.cli.citation as citation_module
+
+        monkeypatch.setattr(citation_module, "_build_crawler", fake_build_crawler)
+
+        result = runner.invoke(
+            citation_app,
+            ["expand", "paper:s2:abc123", "--db-path", "/tmp/x.db"],
+        )
+        assert result.exit_code == 0, result.output
+        assert captured["db_path"] == Path("/tmp/x.db")
+
+
+# ---------------------------------------------------------------------------
+# `arisp citation related`
+# ---------------------------------------------------------------------------
+
+
+def _make_recommendation(
+    paper_id: str = "paper:s2:related1",
+    score: float = 0.85,
+    strategy: RecommendationStrategy = RecommendationStrategy.SIMILAR,
+    reasoning: str = "shared references",
+    seed_paper_id: str = "paper:s2:abc123",
+) -> MagicMock:
+    rec = MagicMock(spec=Recommendation)
+    rec.paper_id = paper_id
+    rec.score = score
+    rec.strategy = strategy
+    rec.reasoning = reasoning
+    rec.seed_paper_id = seed_paper_id
+    return rec
+
+
+class TestRelatedCommand:
+    def _make_recommender(
+        self,
+        all_results: Optional[dict] = None,
+        single_results: Optional[list] = None,
+    ) -> MagicMock:
+        mock_rec = MagicMock()
+        if all_results is not None:
+            mock_rec.recommend_all = AsyncMock(return_value=all_results)
+        if single_results is not None:
+            mock_rec.recommend_similar = AsyncMock(return_value=single_results)
+            mock_rec.recommend_influential_predecessors = AsyncMock(
+                return_value=single_results
+            )
+            mock_rec.recommend_active_successors = AsyncMock(
+                return_value=single_results
+            )
+            mock_rec.recommend_bridge_papers = AsyncMock(return_value=single_results)
+        return mock_rec
+
+    def test_related_happy_path_all_strategies(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        rec1 = _make_recommendation()
+        all_results = {
+            RecommendationStrategy.SIMILAR: [rec1],
+            RecommendationStrategy.INFLUENTIAL_PREDECESSOR: [],
+            RecommendationStrategy.ACTIVE_SUCCESSOR: [],
+            RecommendationStrategy.BRIDGE: [],
+        }
+        mock_rec = self._make_recommender(all_results=all_results)
+
+        import src.cli.citation as citation_module
+
+        monkeypatch.setattr(
+            citation_module, "_build_recommender", lambda **kw: mock_rec
+        )
+
+        result = runner.invoke(citation_app, ["related", "paper:s2:abc123"])
+        assert result.exit_code == 0, result.output
+        assert "similar" in result.output
+        assert "paper:s2:related1" in result.output
+        mock_rec.recommend_all.assert_called_once_with(
+            "paper:s2:abc123", k_per_strategy=5
+        )
+
+    def test_related_single_strategy_similar(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        rec1 = _make_recommendation()
+        mock_rec = self._make_recommender(single_results=[rec1])
+
+        import src.cli.citation as citation_module
+
+        monkeypatch.setattr(
+            citation_module, "_build_recommender", lambda **kw: mock_rec
+        )
+
+        result = runner.invoke(
+            citation_app,
+            ["related", "paper:s2:abc123", "--strategy", "similar"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "similar" in result.output
+        mock_rec.recommend_similar.assert_called_once_with("paper:s2:abc123", k=5)
+
+    def test_related_single_strategy_influential_predecessor(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        rec1 = _make_recommendation(
+            strategy=RecommendationStrategy.INFLUENTIAL_PREDECESSOR
+        )
+        mock_rec = self._make_recommender(single_results=[rec1])
+
+        import src.cli.citation as citation_module
+
+        monkeypatch.setattr(
+            citation_module, "_build_recommender", lambda **kw: mock_rec
+        )
+
+        result = runner.invoke(
+            citation_app,
+            [
+                "related",
+                "paper:s2:abc123",
+                "--strategy",
+                "influential_predecessor",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        mock_rec.recommend_influential_predecessors.assert_called_once_with(
+            "paper:s2:abc123", k=5
+        )
+
+    def test_related_single_strategy_active_successor(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        rec1 = _make_recommendation(strategy=RecommendationStrategy.ACTIVE_SUCCESSOR)
+        mock_rec = self._make_recommender(single_results=[rec1])
+
+        import src.cli.citation as citation_module
+
+        monkeypatch.setattr(
+            citation_module, "_build_recommender", lambda **kw: mock_rec
+        )
+
+        result = runner.invoke(
+            citation_app,
+            ["related", "paper:s2:abc123", "--strategy", "active_successor"],
+        )
+        assert result.exit_code == 0, result.output
+        mock_rec.recommend_active_successors.assert_called_once_with(
+            "paper:s2:abc123", k=5
+        )
+
+    def test_related_single_strategy_bridge(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        rec1 = _make_recommendation(strategy=RecommendationStrategy.BRIDGE)
+        mock_rec = self._make_recommender(single_results=[rec1])
+
+        import src.cli.citation as citation_module
+
+        monkeypatch.setattr(
+            citation_module, "_build_recommender", lambda **kw: mock_rec
+        )
+
+        result = runner.invoke(
+            citation_app,
+            ["related", "paper:s2:abc123", "--strategy", "bridge"],
+        )
+        assert result.exit_code == 0, result.output
+        mock_rec.recommend_bridge_papers.assert_called_once_with("paper:s2:abc123", k=5)
+
+    def test_related_invalid_paper_id_exits_nonzero(self, runner: CliRunner) -> None:
+        result = runner.invoke(citation_app, ["related", "bad/id"])
+        assert result.exit_code != 0
+
+    def test_related_invalid_strategy_exits_nonzero(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mock_rec = MagicMock()
+        mock_rec.recommend_all = AsyncMock(return_value={})
+
+        import src.cli.citation as citation_module
+
+        monkeypatch.setattr(
+            citation_module, "_build_recommender", lambda **kw: mock_rec
+        )
+
+        result = runner.invoke(
+            citation_app,
+            ["related", "paper:s2:abc123", "--strategy", "nonexistent"],
+        )
+        assert result.exit_code != 0
+
+    def test_related_service_failure_exits_nonzero(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mock_rec = MagicMock()
+        mock_rec.recommend_all = AsyncMock(side_effect=RuntimeError("DB error"))
+
+        import src.cli.citation as citation_module
+
+        monkeypatch.setattr(
+            citation_module, "_build_recommender", lambda **kw: mock_rec
+        )
+
+        result = runner.invoke(citation_app, ["related", "paper:s2:abc123"])
+        assert result.exit_code != 0
+
+    def test_related_empty_results_prints_no_results(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        all_results = {
+            RecommendationStrategy.SIMILAR: [],
+            RecommendationStrategy.INFLUENTIAL_PREDECESSOR: [],
+            RecommendationStrategy.ACTIVE_SUCCESSOR: [],
+            RecommendationStrategy.BRIDGE: [],
+        }
+        mock_rec = self._make_recommender(all_results=all_results)
+
+        import src.cli.citation as citation_module
+
+        monkeypatch.setattr(
+            citation_module, "_build_recommender", lambda **kw: mock_rec
+        )
+
+        result = runner.invoke(citation_app, ["related", "paper:s2:abc123"])
+        assert result.exit_code == 0
+        assert "No related papers found" in result.output
+
+    def test_related_json_flag(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        rec1 = _make_recommendation()
+        all_results = {
+            RecommendationStrategy.SIMILAR: [rec1],
+            RecommendationStrategy.INFLUENTIAL_PREDECESSOR: [],
+            RecommendationStrategy.ACTIVE_SUCCESSOR: [],
+            RecommendationStrategy.BRIDGE: [],
+        }
+        mock_rec = self._make_recommender(all_results=all_results)
+
+        import src.cli.citation as citation_module
+
+        monkeypatch.setattr(
+            citation_module, "_build_recommender", lambda **kw: mock_rec
+        )
+
+        result = runner.invoke(citation_app, ["related", "paper:s2:abc123", "--json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert "similar" in data
+        assert len(data["similar"]) == 1
+        assert data["similar"][0]["paper_id"] == "paper:s2:related1"
+
+    def test_related_with_k_option(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        all_results = {
+            RecommendationStrategy.SIMILAR: [],
+            RecommendationStrategy.INFLUENTIAL_PREDECESSOR: [],
+            RecommendationStrategy.ACTIVE_SUCCESSOR: [],
+            RecommendationStrategy.BRIDGE: [],
+        }
+        mock_rec = self._make_recommender(all_results=all_results)
+
+        import src.cli.citation as citation_module
+
+        monkeypatch.setattr(
+            citation_module, "_build_recommender", lambda **kw: mock_rec
+        )
+
+        result = runner.invoke(
+            citation_app, ["related", "paper:s2:abc123", "--k", "10"]
+        )
+        assert result.exit_code == 0
+        mock_rec.recommend_all.assert_called_once_with(
+            "paper:s2:abc123", k_per_strategy=10
+        )
+
+
+# ---------------------------------------------------------------------------
+# `arisp citation influence`
+# ---------------------------------------------------------------------------
+
+
+def _make_influence_metrics(
+    paper_id: str = "paper:s2:abc123",
+    citation_count: int = 42,
+    citation_velocity: float = 5.3,
+    pagerank_score: float = 0.001234,
+    hub_score: float = 0.0,
+    authority_score: float = 0.0,
+) -> MagicMock:
+    m = MagicMock()
+    m.paper_id = paper_id
+    m.citation_count = citation_count
+    m.citation_velocity = citation_velocity
+    m.pagerank_score = pagerank_score
+    m.hub_score = hub_score
+    m.authority_score = authority_score
+    return m
+
+
+class TestInfluenceCommand:
+    def test_influence_happy_path(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        metrics = _make_influence_metrics()
+        mock_scorer = MagicMock()
+        mock_scorer.compute_for_paper = AsyncMock(return_value=metrics)
+
+        import src.services.intelligence.citation.influence_scorer as scorer_module
+
+        monkeypatch.setattr(
+            scorer_module.InfluenceScorer,
+            "from_paths",
+            lambda *, db_path, cache_ttl: mock_scorer,
+        )
+        monkeypatch.setenv(_DB_ENV_VAR, "/tmp/c.db")
+
+        result = runner.invoke(citation_app, ["influence", "paper:s2:abc123"])
+        assert result.exit_code == 0, result.output
+        assert "citation_count" in result.output
+        assert "42" in result.output
+        assert "pagerank_score" in result.output
+        mock_scorer.compute_for_paper.assert_called_once_with("paper:s2:abc123")
+
+    def test_influence_renders_all_metrics(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        metrics = _make_influence_metrics(
+            citation_count=10,
+            citation_velocity=2.5,
+            pagerank_score=0.00042,
+            hub_score=0.1,
+            authority_score=0.2,
+        )
+        mock_scorer = MagicMock()
+        mock_scorer.compute_for_paper = AsyncMock(return_value=metrics)
+
+        import src.services.intelligence.citation.influence_scorer as scorer_module
+
+        monkeypatch.setattr(
+            scorer_module.InfluenceScorer,
+            "from_paths",
+            lambda *, db_path, cache_ttl: mock_scorer,
+        )
+        monkeypatch.setenv(_DB_ENV_VAR, "/tmp/c.db")
+
+        result = runner.invoke(citation_app, ["influence", "paper:s2:abc123"])
+        assert result.exit_code == 0, result.output
+        for field in [
+            "citation_count",
+            "citation_velocity",
+            "pagerank_score",
+            "hub_score",
+            "authority_score",
+        ]:
+            assert field in result.output, f"Missing field: {field}"
+
+    def test_influence_invalid_paper_id_exits_nonzero(self, runner: CliRunner) -> None:
+        result = runner.invoke(citation_app, ["influence", "bad/id"])
+        assert result.exit_code != 0
+
+    def test_influence_service_failure_exits_nonzero(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mock_scorer = MagicMock()
+        mock_scorer.compute_for_paper = AsyncMock(side_effect=RuntimeError("DB error"))
+
+        import src.services.intelligence.citation.influence_scorer as scorer_module
+
+        monkeypatch.setattr(
+            scorer_module.InfluenceScorer,
+            "from_paths",
+            lambda *, db_path, cache_ttl: mock_scorer,
+        )
+        monkeypatch.setenv(_DB_ENV_VAR, "/tmp/c.db")
+
+        result = runner.invoke(citation_app, ["influence", "paper:s2:abc123"])
+        assert result.exit_code != 0
+
+    def test_influence_json_flag(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        metrics = _make_influence_metrics(citation_count=99, pagerank_score=0.0042)
+        mock_scorer = MagicMock()
+        mock_scorer.compute_for_paper = AsyncMock(return_value=metrics)
+
+        import src.services.intelligence.citation.influence_scorer as scorer_module
+
+        monkeypatch.setattr(
+            scorer_module.InfluenceScorer,
+            "from_paths",
+            lambda *, db_path, cache_ttl: mock_scorer,
+        )
+        monkeypatch.setenv(_DB_ENV_VAR, "/tmp/c.db")
+
+        result = runner.invoke(citation_app, ["influence", "paper:s2:abc123", "--json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["paper_id"] == "paper:s2:abc123"
+        assert data["citation_count"] == 99
+        assert "pagerank_score" in data
+        assert "hub_score" in data
+        assert "authority_score" in data
+
+    def test_influence_max_age_days_option(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--max-age-days passes the correct cache_ttl to InfluenceScorer."""
+        from datetime import timedelta
+
+        metrics = _make_influence_metrics()
+        mock_scorer_instance = MagicMock()
+        mock_scorer_instance.compute_for_paper = AsyncMock(return_value=metrics)
+        built_kwargs: dict = {}
+
+        def fake_from_paths(*, db_path: Path, cache_ttl: object) -> MagicMock:
+            built_kwargs["cache_ttl"] = cache_ttl
+            return mock_scorer_instance
+
+        import src.services.intelligence.citation.influence_scorer as scorer_module
+
+        monkeypatch.setattr(
+            scorer_module.InfluenceScorer, "from_paths", fake_from_paths
+        )
+        monkeypatch.setenv(_DB_ENV_VAR, "/tmp/cit.db")
+
+        result = runner.invoke(
+            citation_app,
+            ["influence", "paper:s2:abc123", "--max-age-days", "3"],
+        )
+        assert result.exit_code == 0, result.output
+        assert built_kwargs.get("cache_ttl") == timedelta(days=3)
+
+    def test_influence_db_path_option(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--db-path is forwarded to InfluenceScorer.from_paths."""
+        captured: dict = {}
+        metrics = _make_influence_metrics()
+        mock_scorer_instance = MagicMock()
+        mock_scorer_instance.compute_for_paper = AsyncMock(return_value=metrics)
+
+        def fake_from_paths(*, db_path: Path, cache_ttl: object) -> MagicMock:
+            captured["db_path"] = db_path
+            return mock_scorer_instance
+
+        import src.services.intelligence.citation.influence_scorer as scorer_module
+
+        monkeypatch.setattr(
+            scorer_module.InfluenceScorer, "from_paths", fake_from_paths
+        )
+
+        result = runner.invoke(
+            citation_app,
+            ["influence", "paper:s2:abc123", "--db-path", "/tmp/x.db"],
+        )
+        assert result.exit_code == 0, result.output
+        assert captured["db_path"] == Path("/tmp/x.db")
+
+
+# ---------------------------------------------------------------------------
+# `arisp citation path`
+# ---------------------------------------------------------------------------
+
+
+def _make_graph_node(node_id: str) -> MagicMock:
+    n = MagicMock()
+    n.node_id = node_id
+    return n
+
+
+class TestPathCommand:
+    def test_path_happy_path(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        nodes = [
+            _make_graph_node("paper:s2:aaa"),
+            _make_graph_node("paper:s2:bbb"),
+            _make_graph_node("paper:s2:ccc"),
+        ]
+        mock_store = MagicMock()
+        mock_store.shortest_path = MagicMock(return_value=nodes)
+
+        import src.cli.citation as citation_module
+
+        monkeypatch.setattr(citation_module, "_build_store", lambda **kw: mock_store)
+
+        result = runner.invoke(citation_app, ["path", "paper:s2:aaa", "paper:s2:ccc"])
+        assert result.exit_code == 0, result.output
+        assert "paper:s2:aaa" in result.output
+        assert "paper:s2:ccc" in result.output
+        assert "->" in result.output
+        mock_store.shortest_path.assert_called_once_with("paper:s2:aaa", "paper:s2:ccc")
+
+    def test_path_no_path_found_exits_nonzero(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mock_store = MagicMock()
+        mock_store.shortest_path = MagicMock(return_value=None)
+
+        import src.cli.citation as citation_module
+
+        monkeypatch.setattr(citation_module, "_build_store", lambda **kw: mock_store)
+
+        result = runner.invoke(citation_app, ["path", "paper:s2:aaa", "paper:s2:zzz"])
+        assert result.exit_code != 0
+        assert "No path" in result.output
+
+    def test_path_invalid_from_paper_id_exits_nonzero(self, runner: CliRunner) -> None:
+        result = runner.invoke(citation_app, ["path", "bad/from", "paper:s2:ccc"])
+        assert result.exit_code != 0
+
+    def test_path_invalid_to_paper_id_exits_nonzero(self, runner: CliRunner) -> None:
+        result = runner.invoke(citation_app, ["path", "paper:s2:aaa", "bad/to"])
+        assert result.exit_code != 0
+
+    def test_path_service_failure_exits_nonzero(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mock_store = MagicMock()
+        mock_store.shortest_path = MagicMock(side_effect=RuntimeError("DB error"))
+
+        import src.cli.citation as citation_module
+
+        monkeypatch.setattr(citation_module, "_build_store", lambda **kw: mock_store)
+
+        result = runner.invoke(citation_app, ["path", "paper:s2:aaa", "paper:s2:ccc"])
+        assert result.exit_code != 0
+
+    def test_path_json_flag_with_path(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        nodes = [
+            _make_graph_node("paper:s2:aaa"),
+            _make_graph_node("paper:s2:bbb"),
+        ]
+        mock_store = MagicMock()
+        mock_store.shortest_path = MagicMock(return_value=nodes)
+
+        import src.cli.citation as citation_module
+
+        monkeypatch.setattr(citation_module, "_build_store", lambda **kw: mock_store)
+
+        result = runner.invoke(
+            citation_app,
+            ["path", "paper:s2:aaa", "paper:s2:bbb", "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["path"] == ["paper:s2:aaa", "paper:s2:bbb"]
+        assert data["length"] == 1
+
+    def test_path_json_flag_no_path(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mock_store = MagicMock()
+        mock_store.shortest_path = MagicMock(return_value=None)
+
+        import src.cli.citation as citation_module
+
+        monkeypatch.setattr(citation_module, "_build_store", lambda **kw: mock_store)
+
+        result = runner.invoke(
+            citation_app,
+            ["path", "paper:s2:aaa", "paper:s2:zzz", "--json"],
+        )
+        assert result.exit_code != 0
+        # Output may contain structlog JSON lines first; find the line with "path"
+        json_line = next(
+            line for line in result.output.splitlines() if '"path"' in line
+        )
+        data = json.loads(json_line)
+        assert data["path"] is None
+
+    def test_path_logs_paper_not_found(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Structured event ``citation_cli_paper_not_found`` emitted on None path."""
+        import src.cli.citation as citation_module
+
+        monkeypatch.setattr(citation_module, "logger", structlog.get_logger())
+
+        mock_store = MagicMock()
+        mock_store.shortest_path = MagicMock(return_value=None)
+        monkeypatch.setattr(citation_module, "_build_store", lambda **kw: mock_store)
+
+        with structlog.testing.capture_logs() as logs:
+            result = runner.invoke(
+                citation_app, ["path", "paper:s2:aaa", "paper:s2:zzz"]
+            )
+        assert result.exit_code != 0
+        events = [e for e in logs if e.get("event") == "citation_cli_paper_not_found"]
+        assert len(events) == 1
+
+    def test_path_length_shown_in_output(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        nodes = [
+            _make_graph_node("paper:s2:a"),
+            _make_graph_node("paper:s2:b"),
+            _make_graph_node("paper:s2:c"),
+        ]
+        mock_store = MagicMock()
+        mock_store.shortest_path = MagicMock(return_value=nodes)
+
+        import src.cli.citation as citation_module
+
+        monkeypatch.setattr(citation_module, "_build_store", lambda **kw: mock_store)
+
+        result = runner.invoke(citation_app, ["path", "paper:s2:a", "paper:s2:c"])
+        assert result.exit_code == 0
+        assert "2 hop" in result.output
+
+    def test_path_db_path_forwarded_to_store_builder(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: dict = {}
+        nodes = [_make_graph_node("paper:s2:a"), _make_graph_node("paper:s2:b")]
+        mock_store = MagicMock()
+        mock_store.shortest_path = MagicMock(return_value=nodes)
+
+        def fake_build_store(*, db_path: Optional[Path] = None) -> MagicMock:
+            captured["db_path"] = db_path
+            return mock_store
+
+        import src.cli.citation as citation_module
+
+        monkeypatch.setattr(citation_module, "_build_store", fake_build_store)
+
+        result = runner.invoke(
+            citation_app,
+            ["path", "paper:s2:a", "paper:s2:b", "--db-path", "/tmp/q.db"],
+        )
+        assert result.exit_code == 0, result.output
+        assert captured["db_path"] == Path("/tmp/q.db")
+
+
+# ---------------------------------------------------------------------------
+# Error logging: @handle_errors logs command_failed events
+# ---------------------------------------------------------------------------
+
+
+class TestErrorLogging:
+    def test_build_service_failure_logs_error_event(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """@handle_errors catches and logs service failures via structlog."""
+        import src.cli.citation as citation_module
+        import src.cli.utils as utils_module
+
+        monkeypatch.setattr(utils_module, "logger", structlog.get_logger())
+
+        mock_gb = MagicMock()
+        mock_gb.build_for_paper = AsyncMock(side_effect=RuntimeError("oops"))
+        monkeypatch.setattr(
+            citation_module, "_build_graph_builder", lambda **kw: mock_gb
+        )
+
+        with structlog.testing.capture_logs() as logs:
+            result = runner.invoke(citation_app, ["build", "paper:s2:abc123"])
+
+        assert result.exit_code != 0
+        events = [e for e in logs if e.get("event") == "command_failed"]
+        assert len(events) >= 1

--- a/tests/unit/cli/test_citation_cli.py
+++ b/tests/unit/cli/test_citation_cli.py
@@ -999,7 +999,9 @@ class TestPathCommand:
         assert "paper:s2:aaa" in result.output
         assert "paper:s2:ccc" in result.output
         assert "->" in result.output
-        mock_store.shortest_path.assert_called_once_with("paper:s2:aaa", "paper:s2:ccc")
+        mock_store.shortest_path.assert_called_once_with(
+            "paper:s2:aaa", "paper:s2:ccc", max_depth=6
+        )
 
     def test_path_no_path_found_exits_nonzero(
         self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/cli/test_citation_cli.py
+++ b/tests/unit/cli/test_citation_cli.py
@@ -13,11 +13,12 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import Optional
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import ANY, AsyncMock, MagicMock
 
 import pytest
 import structlog
 import structlog.testing
+import typer
 from typer.testing import CliRunner
 
 from src.cli.citation import (
@@ -47,14 +48,6 @@ def runner() -> CliRunner:
     return CliRunner()
 
 
-@pytest.fixture
-def db_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
-    """Point the CLI's citation DB env var at a temp file."""
-    db_path = tmp_path / "citation.db"
-    monkeypatch.setenv(_DB_ENV_VAR, str(db_path))
-    return db_path
-
-
 # ---------------------------------------------------------------------------
 # _resolve_db_path
 # ---------------------------------------------------------------------------
@@ -63,11 +56,50 @@ def db_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
 class TestResolveDbPath:
     def test_env_unset_returns_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv(_DB_ENV_VAR, raising=False)
-        assert _resolve_db_path() == Path("./data/citation.db")
+        result = _resolve_db_path()
+        # sanitize_storage_path resolves to an absolute path; the default
+        # should still end with the canonical db filename.
+        assert result.name == "citation.db"
+        assert result.is_absolute()
 
-    def test_env_set_returns_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv(_DB_ENV_VAR, "/tmp/cit.db")
-        assert _resolve_db_path() == Path("/tmp/cit.db")
+    def test_env_set_returns_env(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        db_path = tmp_path / "cit.db"
+        monkeypatch.setenv(_DB_ENV_VAR, str(db_path))
+        result = _resolve_db_path()
+        assert result == db_path.resolve()
+
+    def test_env_set_traversal_raises_security_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A path with directory traversal is rejected at the CLI boundary."""
+        from src.utils.security import SecurityError
+
+        monkeypatch.setenv(_DB_ENV_VAR, "../../etc/x.db")
+        with pytest.raises(SecurityError):
+            _resolve_db_path()
+
+    def test_handle_errors_translates_security_error_to_clean_exit(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """SecurityError from _resolve_db_path produces exit 1 + generic message."""
+        from src.utils.security import SecurityError
+
+        import src.cli.citation as citation_module
+
+        monkeypatch.setattr(
+            citation_module,
+            "_build_store",
+            lambda **kw: (_ for _ in ()).throw(
+                SecurityError("path outside approved roots")
+            ),
+        )
+
+        result = runner.invoke(citation_app, ["path", "paper:s2:a", "paper:s2:b"])
+        assert result.exit_code != 0
+        # Generic message shown, not the raw SecurityError detail
+        assert "Operation failed" in result.output
 
 
 # ---------------------------------------------------------------------------
@@ -81,19 +113,19 @@ class TestValidatePaperId:
         _validate_paper_id("paper:s2:abc123")
 
     def test_empty_string_raises_bad_parameter(self) -> None:
-        with pytest.raises(Exception, match="non-empty"):
+        with pytest.raises(typer.BadParameter, match="non-empty"):
             _validate_paper_id("")
 
     def test_whitespace_only_raises_bad_parameter(self) -> None:
-        with pytest.raises(Exception, match="non-empty"):
+        with pytest.raises(typer.BadParameter, match="non-empty"):
             _validate_paper_id("   ")
 
     def test_too_long_raises_bad_parameter(self) -> None:
-        with pytest.raises(Exception, match="exceeds max"):
+        with pytest.raises(typer.BadParameter, match="exceeds max"):
             _validate_paper_id("a" * 513)
 
     def test_invalid_chars_raises_bad_parameter(self) -> None:
-        with pytest.raises(Exception, match="Invalid paper_id format"):
+        with pytest.raises(typer.BadParameter, match="Invalid paper_id format"):
             _validate_paper_id("paper/with/slashes")
 
 
@@ -223,7 +255,9 @@ class TestBuildCommand:
         assert result.exit_code == 0, result.output
         assert "paper:s2:abc123" in result.output
         assert "nodes_added" in result.output
-        mock_gb.build_for_paper.assert_called_once()
+        mock_gb.build_for_paper.assert_called_once_with(
+            "paper:s2:abc123", depth=1, direction=ANY
+        )
 
     def test_build_json_flag(
         self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
@@ -368,7 +402,7 @@ class TestExpandCommand:
         assert result.exit_code == 0, result.output
         assert "papers_visited" in result.output
         assert "10" in result.output
-        mock_crawler.crawl.assert_called_once()
+        mock_crawler.crawl.assert_called_once_with("paper:s2:abc123", config=ANY)
 
     def test_expand_invalid_paper_id_exits_nonzero(self, runner: CliRunner) -> None:
         result = runner.invoke(citation_app, ["expand", "bad/id"])
@@ -815,14 +849,9 @@ class TestInfluenceCommand:
         mock_scorer = MagicMock()
         mock_scorer.compute_for_paper = AsyncMock(return_value=metrics)
 
-        import src.services.intelligence.citation.influence_scorer as scorer_module
+        import src.cli.citation as citation_module
 
-        monkeypatch.setattr(
-            scorer_module.InfluenceScorer,
-            "from_paths",
-            lambda *, db_path, cache_ttl: mock_scorer,
-        )
-        monkeypatch.setenv(_DB_ENV_VAR, "/tmp/c.db")
+        monkeypatch.setattr(citation_module, "_build_scorer", lambda **kw: mock_scorer)
 
         result = runner.invoke(citation_app, ["influence", "paper:s2:abc123"])
         assert result.exit_code == 0, result.output
@@ -844,14 +873,9 @@ class TestInfluenceCommand:
         mock_scorer = MagicMock()
         mock_scorer.compute_for_paper = AsyncMock(return_value=metrics)
 
-        import src.services.intelligence.citation.influence_scorer as scorer_module
+        import src.cli.citation as citation_module
 
-        monkeypatch.setattr(
-            scorer_module.InfluenceScorer,
-            "from_paths",
-            lambda *, db_path, cache_ttl: mock_scorer,
-        )
-        monkeypatch.setenv(_DB_ENV_VAR, "/tmp/c.db")
+        monkeypatch.setattr(citation_module, "_build_scorer", lambda **kw: mock_scorer)
 
         result = runner.invoke(citation_app, ["influence", "paper:s2:abc123"])
         assert result.exit_code == 0, result.output
@@ -874,14 +898,9 @@ class TestInfluenceCommand:
         mock_scorer = MagicMock()
         mock_scorer.compute_for_paper = AsyncMock(side_effect=RuntimeError("DB error"))
 
-        import src.services.intelligence.citation.influence_scorer as scorer_module
+        import src.cli.citation as citation_module
 
-        monkeypatch.setattr(
-            scorer_module.InfluenceScorer,
-            "from_paths",
-            lambda *, db_path, cache_ttl: mock_scorer,
-        )
-        monkeypatch.setenv(_DB_ENV_VAR, "/tmp/c.db")
+        monkeypatch.setattr(citation_module, "_build_scorer", lambda **kw: mock_scorer)
 
         result = runner.invoke(citation_app, ["influence", "paper:s2:abc123"])
         assert result.exit_code != 0
@@ -893,14 +912,9 @@ class TestInfluenceCommand:
         mock_scorer = MagicMock()
         mock_scorer.compute_for_paper = AsyncMock(return_value=metrics)
 
-        import src.services.intelligence.citation.influence_scorer as scorer_module
+        import src.cli.citation as citation_module
 
-        monkeypatch.setattr(
-            scorer_module.InfluenceScorer,
-            "from_paths",
-            lambda *, db_path, cache_ttl: mock_scorer,
-        )
-        monkeypatch.setenv(_DB_ENV_VAR, "/tmp/c.db")
+        monkeypatch.setattr(citation_module, "_build_scorer", lambda **kw: mock_scorer)
 
         result = runner.invoke(citation_app, ["influence", "paper:s2:abc123", "--json"])
         assert result.exit_code == 0, result.output
@@ -914,7 +928,7 @@ class TestInfluenceCommand:
     def test_influence_max_age_days_option(
         self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """--max-age-days passes the correct cache_ttl to InfluenceScorer."""
+        """--max-age-days passes the correct cache_ttl to _build_scorer."""
         from datetime import timedelta
 
         metrics = _make_influence_metrics()
@@ -922,16 +936,15 @@ class TestInfluenceCommand:
         mock_scorer_instance.compute_for_paper = AsyncMock(return_value=metrics)
         built_kwargs: dict = {}
 
-        def fake_from_paths(*, db_path: Path, cache_ttl: object) -> MagicMock:
+        def fake_build_scorer(
+            *, db_path: Optional[Path] = None, cache_ttl: object = None
+        ) -> MagicMock:
             built_kwargs["cache_ttl"] = cache_ttl
             return mock_scorer_instance
 
-        import src.services.intelligence.citation.influence_scorer as scorer_module
+        import src.cli.citation as citation_module
 
-        monkeypatch.setattr(
-            scorer_module.InfluenceScorer, "from_paths", fake_from_paths
-        )
-        monkeypatch.setenv(_DB_ENV_VAR, "/tmp/cit.db")
+        monkeypatch.setattr(citation_module, "_build_scorer", fake_build_scorer)
 
         result = runner.invoke(
             citation_app,
@@ -943,21 +956,21 @@ class TestInfluenceCommand:
     def test_influence_db_path_option(
         self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """--db-path is forwarded to InfluenceScorer.from_paths."""
+        """--db-path is forwarded to _build_scorer."""
         captured: dict = {}
         metrics = _make_influence_metrics()
         mock_scorer_instance = MagicMock()
         mock_scorer_instance.compute_for_paper = AsyncMock(return_value=metrics)
 
-        def fake_from_paths(*, db_path: Path, cache_ttl: object) -> MagicMock:
+        def fake_build_scorer(
+            *, db_path: Optional[Path] = None, cache_ttl: object = None
+        ) -> MagicMock:
             captured["db_path"] = db_path
             return mock_scorer_instance
 
-        import src.services.intelligence.citation.influence_scorer as scorer_module
+        import src.cli.citation as citation_module
 
-        monkeypatch.setattr(
-            scorer_module.InfluenceScorer, "from_paths", fake_from_paths
-        )
+        monkeypatch.setattr(citation_module, "_build_scorer", fake_build_scorer)
 
         result = runner.invoke(
             citation_app,
@@ -1173,3 +1186,61 @@ class TestErrorLogging:
         assert result.exit_code != 0
         events = [e for e in logs if e.get("event") == "command_failed"]
         assert len(events) >= 1
+        ev = events[0]
+        assert "error" in ev
+        assert "oops" in ev["error"]
+        assert ev.get("error_type") == "RuntimeError"
+
+    def test_handle_errors_generic_user_message(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """@handle_errors emits the generic user-facing message on failure."""
+        import src.cli.citation as citation_module
+
+        mock_gb = MagicMock()
+        mock_gb.build_for_paper = AsyncMock(side_effect=RuntimeError("internal detail"))
+        monkeypatch.setattr(
+            citation_module, "_build_graph_builder", lambda **kw: mock_gb
+        )
+
+        result = runner.invoke(citation_app, ["build", "paper:s2:abc123"])
+        assert result.exit_code != 0
+        # The generic user-facing message MUST appear in the output.
+        assert "Operation failed" in result.output
+        # The raw exception message must NOT appear outside of any
+        # structured log lines (structlog JSON contains it in the "error"
+        # key, which is acceptable — the user-facing *plain text* should
+        # not expose raw internals).
+        non_json_lines = [
+            line
+            for line in result.output.splitlines()
+            if not line.strip().startswith("{")
+        ]
+        assert not any("internal detail" in ln for ln in non_json_lines)
+
+    def test_handle_errors_trunc_in_log(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """@handle_errors logs a truncated error string, not the full exception."""
+        import src.cli.citation as citation_module
+        import src.cli.utils as utils_module
+
+        monkeypatch.setattr(utils_module, "logger", structlog.get_logger())
+
+        long_msg = "x" * 300
+        mock_gb = MagicMock()
+        mock_gb.build_for_paper = AsyncMock(side_effect=ValueError(long_msg))
+        monkeypatch.setattr(
+            citation_module, "_build_graph_builder", lambda **kw: mock_gb
+        )
+
+        with structlog.testing.capture_logs() as logs:
+            result = runner.invoke(citation_app, ["build", "paper:s2:abc123"])
+
+        assert result.exit_code != 0
+        events = [e for e in logs if e.get("event") == "command_failed"]
+        assert events
+        logged_error = events[0]["error"]
+        # _trunc caps at 200 chars + suffix
+        assert len(logged_error) <= 220
+        assert "[...truncated]" in logged_error

--- a/tests/unit/storage/intelligence_graph/test_unified_graph.py
+++ b/tests/unit/storage/intelligence_graph/test_unified_graph.py
@@ -532,6 +532,62 @@ class TestShortestPath:
         path = graph_store.shortest_path("paper:missing", "paper:missing")
         assert path is None
 
+    def test_shortest_path_max_depth_bounds_bfs(
+        self, graph_store: SQLiteGraphStore
+    ) -> None:
+        """``max_depth`` causes BFS to return ``None`` when target is beyond bound.
+
+        Graph: p:0 -> p:1 -> p:2 -> p:3
+        With max_depth=1 the BFS only expands one hop from p:0, so p:3
+        (3 hops away) is unreachable and None is returned.
+        """
+        for i in range(4):
+            graph_store.add_node(f"p:md:{i}", NodeType.PAPER, {})
+        for i in range(3):
+            graph_store.add_edge(
+                f"edge:md:{i}:{i+1}",
+                f"p:md:{i}",
+                f"p:md:{i+1}",
+                EdgeType.CITES,
+                {},
+            )
+        # Without bound, full path is found.
+        path_full = graph_store.shortest_path("p:md:0", "p:md:3")
+        assert path_full is not None
+        assert len(path_full) == 4  # 4 nodes, 3 hops
+
+        # With max_depth=2, p:md:3 (3 hops away) is NOT reachable.
+        path_bounded = graph_store.shortest_path("p:md:0", "p:md:3", max_depth=2)
+        assert path_bounded is None
+
+        # With max_depth=3, p:md:3 IS exactly reachable.
+        path_exact = graph_store.shortest_path("p:md:0", "p:md:3", max_depth=3)
+        assert path_exact is not None
+        assert [n.node_id for n in path_exact] == [
+            "p:md:0",
+            "p:md:1",
+            "p:md:2",
+            "p:md:3",
+        ]
+
+    def test_shortest_path_max_depth_none_is_unbounded(
+        self, graph_store: SQLiteGraphStore
+    ) -> None:
+        """``max_depth=None`` (the default) leaves BFS fully unbounded."""
+        for i in range(3):
+            graph_store.add_node(f"p:unb:{i}", NodeType.PAPER, {})
+        for i in range(2):
+            graph_store.add_edge(
+                f"edge:unb:{i}:{i+1}",
+                f"p:unb:{i}",
+                f"p:unb:{i+1}",
+                EdgeType.CITES,
+                {},
+            )
+        path = graph_store.shortest_path("p:unb:0", "p:unb:2", max_depth=None)
+        assert path is not None
+        assert len(path) == 3
+
 
 class TestMetrics:
     """Tests for graph metrics."""

--- a/tests/unit/test_cli_coverage.py
+++ b/tests/unit/test_cli_coverage.py
@@ -112,7 +112,9 @@ class TestCLICoverage:
         with patch("src.cli.utils.ConfigManager", side_effect=Exception("Unexpected")):
             result = runner.invoke(app, ["run"])
             assert result.exit_code == 1
-            assert "Error" in result.stdout
+            # Generic message written to stderr (err=True); use result.output
+            # which merges stdout+stderr in Typer's CliRunner.
+            assert "Operation failed" in result.output
 
     def test_process_topics_no_papers(self):
         """Test processing with no papers found - via ResearchPipeline"""
@@ -453,8 +455,8 @@ class TestSynthesizeCommand:
                 result = runner.invoke(app, ["synthesize"])
 
                 assert result.exit_code == 1
-                # Error now displayed by generic handle_errors decorator
-                assert "Error" in result.stdout
+                # Generic message written to stderr; use result.output.
+                assert "Operation failed" in result.output
 
 
 class TestDryRunPhase1:

--- a/tests/unit/test_cli_extended.py
+++ b/tests/unit/test_cli_extended.py
@@ -104,5 +104,6 @@ def test_run_unexpected_error(mock_components):
 
     result = runner.invoke(app, ["run"])
     assert result.exit_code == 1
-    # Error now displayed by generic handle_errors decorator
-    assert "Error" in result.stdout
+    # Generic message written to stderr (err=True in handle_errors H-3 fix);
+    # result.output merges stdout+stderr in Typer's CliRunner.
+    assert "Operation failed" in result.output


### PR DESCRIPTION
## Summary

- Implements `arisp citation` CLI subcommand group (Phase 9.2 Week 3, REQ-9.2.6) with 5 subcommands: `build`, `expand`, `related`, `influence`, `path`
- Wires `CitationGraphBuilder`, `CitationCrawler`, `CitationRecommender`, `InfluenceScorer`, and `SQLiteGraphStore.shortest_path` to the CLI; no business logic lives in the CLI layer
- Adds 62 CliRunner tests with 100% line + branch coverage on `src/cli/citation.py`

## Test plan

- [x] `pytest tests/unit/cli/test_citation_cli.py` — 62 tests pass
- [x] `pytest tests/unit/cli/` — 200 tests pass (all CLI tests)
- [x] `pytest` (full suite) — 5354 passed, 99.17% combined coverage
- [x] `black --check`, `flake8`, `mypy` — all clean
- [x] `./verify.sh` — all checks passed (pre-push hook confirmed)
- [x] Happy path, invalid paper_id, service failure, `--json` flag, and structured log event assertions for each subcommand
- [x] DI seams: all `_build_*` helpers patchable at module boundary
- [x] `citation_cli_paper_not_found` structured log event emitted when path returns None