### PR TITLE
docs(phase-9.5): plan reliability + breadth + learning synthesis

### DIFF
--- a/.omc/plans/open-questions.md
+++ b/.omc/plans/open-questions.md
@@ -189,4 +189,52 @@ class SubscriptionManager:
 
 ---
 
-*Last updated: 2026-04-24 (5 Phase 9 decisions resolved: SR-9.3 entity sanitization, SR-9.5 subscription limits finalized)*
+## Phase 9.5: Pipeline Reliability, Discovery Breadth, and Learning Synthesis - 2026-05-09
+
+**Context:** Production diagnostic on 2026-05-09 revealed that the live pipeline produces degraded output (~70% abstract-only fallback, 54% PDF extraction failure due to URL-as-Path bug, silent Anthropic auth failure) and that discovery is structurally narrow (single effective provider, static topics, citation graph not in daily loop). Phase 9.5 inserted before 9.3/9.4 to address these gaps. See [PHASE_9.5_RELIABILITY_BREADTH_LEARNING_SPEC.md](../../docs/specs/PHASE_9.5_RELIABILITY_BREADTH_LEARNING_SPEC.md).
+
+### Architecture Decisions
+
+- [ ] **OQ-9.5.1: LLM provider strategy** — Current Gemini free-tier (5 RPM) is incompatible with daily volume (~180 papers); Anthropic key is invalid (401). Workstream A surfaces this; Workstream C requires a working provider with adequate quota for weekly synthesis.
+
+  **Options:**
+  - (a) Move to paid Gemini tier (raises RPM substantially; lowest friction if Google billing is set up)
+  - (b) Rotate Anthropic key and use Claude Haiku/Sonnet as primary (better quality for synthesis; requires Anthropic billing)
+  - (c) Stay on free tier; throttle pipeline (fewer topics, slower extraction; no external billing)
+  - (d) Local LLM for extraction (Ollama + small model); paid API only for weekly synthesis
+
+  **Resolution Status:** Deferred to user (per AskUserQuestion 2026-05-09). 9.5 plan accommodates any choice via config; user decision required before Workstream C Week 4.
+
+- [ ] **OQ-9.5.2: Citation expansion seed selection** — REQ-9.5.2.1 caps seeds at 10 per topic by `quality_score`. Should seeds also be biased toward papers the user has interacted with (Phase 7 feedback signals)?
+
+  **Default for 9.5:** Pure quality_score. Revisit when integrating with Phase 9.4 frontier detection.
+
+- [ ] **OQ-9.5.3: Learning Brief cadence** — Spec defaults to weekly. Some users may want daily mini-briefs and a weekly comprehensive one.
+
+  **Default for 9.5:** Weekly only. Daily briefs deferred until weekly is proven valuable.
+
+- [ ] **OQ-9.5.4: HuggingFace and Semantic Scholar provider audit outcome** — REQ-9.5.1.5 audits these providers and either fixes their PDF resolution or documents them as non-PDF-bearing. The audit outcome determines whether either is removed from the default discovery chain.
+
+  **Resolution:** Resolve during Workstream A implementation; update spec Section 11 if audit materially changes the "single effective provider" framing.
+
+### Scope Clarifications
+
+- [x] **9.5 explicitly does NOT add new providers** (Crossref/CORE/etc.) — DECIDED 2026-05-09 per user AskUserQuestion answer (option "Add PDF-bearing providers" was NOT selected; user chose citation expansion + LLM query auto-expansion + auto-rotate via 9.4 instead). 9.5 audits existing providers only; new provider integration is left to a future phase.
+
+- [x] **Topic auto-rotation deferred behind 9.4** — DECIDED 2026-05-09. User selected "auto-rotate / auto-discover topics" as a desired capability, but it depends on Phase 9.4 frontier detection. 9.5 ships only citation expansion + LLM query variants as breadth mechanisms; topic rotation is the natural follow-up once 9.4 lands.
+
+- [x] **Phase 9.3 and 9.4 deferred behind 9.5** — DECIDED 2026-05-09. Both depend on a working ingestion pipeline (which 9.5 restores) and benefit from a broader candidate pool (which 9.5 provides). Recommended post-9.5 order: 9.4 → 9.3 (revisit during 9.5 closeout).
+
+### Security Considerations
+
+- [x] **Provider health probes MUST NOT log API keys** — DECIDED 2026-05-09 (SR-9.5.A.1). Health check log events SHALL include provider name and HTTP status / error class only. No auth header values, request bodies, or response bodies SHALL be logged.
+
+- [x] **Type guard MUST NOT swallow path traversal** — DECIDED 2026-05-09 (SR-9.5.A.2). The `http:`/`https:` rejection guard runs AFTER existing path sanitization in `src/utils/path_sanitization.py`, not as a replacement.
+
+- [x] **Learning brief MUST NOT re-load raw PDF text** — DECIDED 2026-05-09 (SR-9.5.C.1). Synthesis prompt consumes only already-extracted structured fields; raw PDF text SHALL NOT be re-loaded or re-sent to the LLM. This bounds privacy/copyright exposure to what extraction has already approved.
+
+- [x] **Learning brief LLM response sanitization** — DECIDED 2026-05-09 (SR-9.5.C.2). Output parsed with permissive Markdown parser; `<script>`, `<iframe>`, etc. stripped; orphan citations (`[paper_id_X]` not in input set) removed with log warning.
+
+---
+
+*Last updated: 2026-05-09 (Phase 9.5 inserted: 4 open questions tracked, 3 scope clarifications resolved, 4 security decisions resolved)*

--- a/.omc/plans/phase-9.5-execution-plan.md
+++ b/.omc/plans/phase-9.5-execution-plan.md
@@ -1,0 +1,335 @@
+# Phase 9.5: Pipeline Reliability, Discovery Breadth, and Learning Synthesis - Execution Plan
+
+**Version:** 1.0
+**Created:** 2026-05-09
+**Status:** DRAFT — pending user review
+**Spec:** [docs/specs/PHASE_9.5_RELIABILITY_BREADTH_LEARNING_SPEC.md](../../docs/specs/PHASE_9.5_RELIABILITY_BREADTH_LEARNING_SPEC.md)
+
+---
+
+## Executive Summary
+
+This plan details the four-week execution strategy for Phase 9.5, which inserts before Phases 9.3 (Knowledge Graph) and 9.4 (Frontier Detection) to address two production gaps: (1) the ingestion pipeline produces degraded output (54% PDF extraction failure, ~70% abstract-only fallback, silent provider auth failures), (2) discovery is structurally narrow (single effective provider, static topics, citation graph not in daily loop, monitoring service returning 0 new papers).
+
+Three workstreams are executed largely sequentially because each depends on the previous: Workstream A (Reliability) gates Workstream C (Learning Synthesis) — there is no value in synthesizing when extraction is broken. Workstream B (Breadth) is largely independent of A and can run in parallel during Week 2.
+
+---
+
+## Context
+
+### Dependencies (Verified Complete)
+- Phase 9.1 Complete (Monitoring service) — degraded in production; will be repaired by Workstream A
+- Phase 9.2 Complete (Citation graph) — built but not in daily loop; will be wired by Workstream B
+- Phase 5.1 Complete (LLM Service Decomposition) — `QueryExpander` extraction in B builds on this
+- Phase 3.7 Complete (Cross-Topic Synthesis) — `LearningBriefGenerator` in C builds on this
+
+### Goal
+Restore the production pipeline to producing useful per-paper extractions, then layer cross-paper weekly synthesis on top — so the user's daily output is curated learning, not a list of titles.
+
+---
+
+## Work Objectives
+
+### Primary Objectives
+1. Eliminate the URL-as-Path bug in `paper_processor.py` and prevent recurrence via type guard
+2. Surface LLM provider failures at startup with explicit, actionable signals
+3. Wire Phase 9.2 citation expansion into the daily discovery loop
+4. Extract `QueryExpander` to a shared service used by both monitoring and discovery
+5. Ship a weekly Learning Brief output that synthesizes per-paper extraction into cross-paper learning
+
+### Secondary Objectives
+1. Audit HuggingFace and Semantic Scholar provider PDF resolution; fix or document
+2. Establish a `using_abstract_fallback` SLO indicator in daily-run logs
+3. Tag candidate provenance (`source` field) for downstream attribution and diagnostics
+
+---
+
+## Guardrails
+
+### Must Have
+- 99%+ test coverage for all new modules (CLAUDE.md requirement)
+- 100% test pass rate (0 failures)
+- All security requirements (SR-9.5.A.x, SR-9.5.B.x, SR-9.5.C.x) verified
+- Integration test that exercises a real ArXiv URL end-to-end (regression guard for REQ-9.5.1.1)
+- All new structured-log events documented in observability docs
+- Backward compatibility for existing CLI commands and config files
+- LearningBriefJob registered with APScheduler following `MonitoringCheckJob` pattern
+
+### Must NOT Have
+- Direct PDF URL → Path conversion in any new code (REQ-9.5.1.2 type guard enforces)
+- Silent fallback to abstract-only without logging the underlying failure cause
+- Citation expansion bypassing existing rate limiters
+- Learning Brief regenerating from raw PDF text (must consume only structured extraction outputs)
+- Hardcoded LLM provider in any new code (provider chosen via config per OQ-9.5.1)
+- New paper-discovery providers (Crossref, CORE, etc. are explicitly out of scope)
+
+---
+
+## Sequencing Strategy
+
+```
+Week   1   2   3   4
+       |---|---|---|---|
+       |== A: Reliability ==|
+           |== B: Breadth ==|
+               |== C: Learning ==========|
+
+A blocks C (no value synthesizing broken extractions)
+B is independent of A; runs Weeks 2-3 in parallel with C ramp-up
+C ramps Week 3 (data models, generator, CLI), runs first brief Week 4
+```
+
+### Track Assignments
+
+| Track | Workstream | Duration | Parallel? | Dependencies |
+|---|---|---|---|---|
+| **A** | Reliability | Week 1 | No | None |
+| **B** | Breadth | Weeks 2-3 | Yes (with C ramp) | A complete (provider health needed for shared QueryExpander) |
+| **C** | Learning Synthesis | Weeks 3-4 | Yes (with B) | A complete (extraction quality), B optional (broader corpus improves brief) |
+
+---
+
+## Task Flow
+
+### Week 1: Workstream A — Pipeline Reliability
+
+**Objective:** Fix the broken extraction path; make provider failures loud.
+
+**Deliverables:**
+1. `src/services/pdf_acquisition.py` — shared `acquire_pdf()` helper (new)
+2. `src/orchestration/paper_processor.py` — refactored to use `acquire_pdf()`
+3. `src/services/extraction_service.py` — refactored to use `acquire_pdf()`
+4. PDF extractor entry-point type guard rejecting `http:`/`https:` paths
+5. `src/services/llm/health_check.py` — `ProviderHealthChecker` class (new)
+6. Health check invoked at startup of services in `src/services/extraction_service.py`, `src/services/intelligence/monitoring/`, `src/services/learning/` (when shipped)
+7. `pipeline_health_abstract_fallback_rate` event emitted at end of `DailyResearchJob`
+8. Provider audit notes: `docs/audits/2026-05_provider_pdf_audit.md`
+
+**Detailed TODOs:**
+
+| ID | Task | Acceptance Criteria | REQ |
+|---|---|---|---|
+| A.1 | Create `pdf_acquisition.py` with `acquire_pdf()` | Returns `Path` on success, `None` if no URL, raises typed exceptions on download failure | REQ-9.5.1.1 |
+| A.2 | Refactor `paper_processor.py:138-145` to call `acquire_pdf()` | No `Path(str(url))` pattern remains in source; integration test with real ArXiv URL passes | REQ-9.5.1.1 |
+| A.3 | Refactor `extraction_service.py:172-179` to call `acquire_pdf()` | Behavior unchanged; existing tests still pass; no duplicate download logic remains | REQ-9.5.1.1 |
+| A.4 | Add type guard at extractor entry | `pdf_path.startswith(('http:', 'https:'))` raises `InvalidPDFPathError` with calling-site name | REQ-9.5.1.2 |
+| A.5 | Implement `ProviderHealthChecker` | Probes Anthropic + Google with 1-token completions in parallel; ≤2s budget; logs structured events | REQ-9.5.1.3 |
+| A.6 | Wire health check into service startup | Each LLM-using service calls checker on first use per process; failed providers marked unavailable | REQ-9.5.1.3 |
+| A.7 | Implement `pipeline_health_abstract_fallback_rate` metric | Event emitted at `DailyResearchJob` completion with `rate: float` over current run | REQ-9.5.1.4 |
+| A.8 | Audit HuggingFace + Semantic Scholar PDF resolution | Documented in `docs/audits/2026-05_provider_pdf_audit.md`; either bug fixed OR provider deprecated in default chain | REQ-9.5.1.5 |
+| A.9 | Unit + integration tests for all of A | 99%+ coverage on new modules; regression test using real ArXiv URL passes | All A REQs |
+
+**Review Gate G1:** End of Week 1
+- ✅ All A REQs implemented
+- ✅ `verify.sh` passes
+- ✅ Manual run of `python -m src.cli run --config config/research_config.yaml` shows `using_abstract_fallback` rate ≤ 30% on next daily-equivalent run (target ≤20% measured over 7 days post-merge)
+- ✅ Provider health check fails loudly when Anthropic key is invalid (verified by deliberately bad-key test)
+
+**Risk:** A.8 audit may reveal that HuggingFace fundamentally returns models/datasets, not papers, requiring removal from the default chain. This is an acceptable outcome documented in spec Section 11 OQ-9.5.4.
+
+---
+
+### Weeks 2-3: Workstream B — Discovery Breadth
+
+**Objective:** Activate citation expansion in the daily flow; share QueryExpander across monitoring + discovery.
+
+**Week 2 Deliverables:**
+1. `src/services/llm/query_expander.py` — extracted shared service
+2. `src/services/intelligence/monitoring/` updated to consume from shared location (no behavior change)
+3. `src/services/discovery/citation_expansion.py` — new wrapper around Phase 9.2 `BFSCrawler` for daily-loop use
+
+**Week 3 Deliverables:**
+1. `src/orchestration/phases/discovery.py` updated to invoke citation expansion + query variants
+2. `ScoredPaper.source` field added per spec Section 6
+3. `pipeline_health_breadth_metric` event emitted
+4. Configuration support in `config/research_config.yaml` (with sensible defaults so existing configs continue to work)
+5. CLI flag `--no-citation-expansion` for opt-out
+
+**Detailed TODOs:**
+
+| ID | Task | Acceptance Criteria | REQ |
+|---|---|---|---|
+| B.1 | Extract `QueryExpander` from monitoring | Shared class in `src/services/llm/query_expander.py`; monitoring uses it; existing monitoring tests pass | REQ-9.5.2.2 |
+| B.2 | Add 7-day cache to `QueryExpander` | Cache key = `(base_query, hash(sorted(titles)))`; TTL configurable | REQ-9.5.2.2 |
+| B.3 | Build `CitationExpansionService` | Wraps `BFSCrawler`; honors quality_threshold, seed cap, candidate cap, hop count, directions | REQ-9.5.2.1 |
+| B.4 | Wire citation expansion into `DiscoveryPhase` | After provider queries + quality filter, expansion adds candidates; respects rate limits; degrades gracefully | REQ-9.5.2.1 |
+| B.5 | Wire query variants into `DiscoveryPhase` | Original query + N variants run through each provider; per-variant deduplication | REQ-9.5.2.2 |
+| B.6 | Add `source` and `seed_paper_id` to `ScoredPaper` | Pydantic model updated; all existing call sites set `source` correctly; tests assert provenance is preserved end-to-end | REQ-9.5.2.3 |
+| B.7 | Implement `pipeline_health_breadth_metric` | Event emitted at end of `DiscoveryPhase` with breakdown by source | REQ-9.5.2.4 |
+| B.8 | Display source in Delta brief | Existing `DeltaGenerator` updated to show `source` per paper | REQ-9.5.2.3 |
+| B.9 | Unit + integration tests for B | 99%+ coverage; recorded `BFSCrawler` response fixture for citation expansion test | All B REQs |
+
+**Review Gate G2:** End of Week 3
+- ✅ All B REQs implemented
+- ✅ `verify.sh` passes
+- ✅ Manual run shows ≥10 net-new papers from `citation_expansion` in a single run (≥20 averaged target deferred to 7-day rolling measurement post-merge)
+- ✅ Monitoring service still functions identically (regression check)
+
+**Risk:** Citation expansion may produce many low-relevance candidates if seed papers are noisy. Mitigation: existing `QualityFilterService` runs after expansion, filtering as for any other provider result.
+
+---
+
+### Weeks 3-4: Workstream C — Targeted Learning Synthesis
+
+**Objective:** Generate the first weekly Learning Brief.
+
+**Week 3 Deliverables (parallel with B):**
+1. `src/models/learning.py` — `LearningBriefRequest`, `LearningBriefSection`, `LearningBrief` Pydantic models
+2. `src/services/learning/__init__.py` — package init
+3. `src/services/learning/brief_generator.py` — `LearningBriefGenerator` class (consumes structured extraction outputs, calls LLM, parses response, sanitizes)
+4. CLI commands `arisp learning generate|latest|list`
+
+**Week 4 Deliverables:**
+1. `src/scheduling/learning_brief_job.py` — `LearningBriefJob(BaseJob)` registered with APScheduler
+2. Configuration support in `config/research_config.yaml`
+3. Cost guardrail enforced (per-brief cap; sample by quality if over budget)
+4. First production weekly brief generated; user reviews; iterate on prompt if needed
+
+**Detailed TODOs:**
+
+| ID | Task | Acceptance Criteria | REQ |
+|---|---|---|---|
+| C.1 | Define `LearningBrief*` Pydantic models | Strict Pydantic V2; serialization round-trips clean | REQ-9.5.3.1 |
+| C.2 | Build `LearningBriefGenerator` | Loads papers from registry by date range + quality threshold; assembles prompt; calls LLM with cost cap; parses response into sections | REQ-9.5.3.1, REQ-9.5.3.2 |
+| C.3 | Add prompt template for synthesis | System message, user message format, citation requirement; stored in `src/services/learning/prompts/` | REQ-9.5.3.2 |
+| C.4 | Cost guardrail | Pre-flight estimate of token count; sample papers by quality if estimate exceeds budget; hard-stop if budget exceeded mid-call | REQ-9.5.3.2 |
+| C.5 | Engineering Tips section selection | LLM-judged criteria documented in prompt; output validated to contain ≥3 tips when input has ≥10 papers | REQ-9.5.3.3 |
+| C.6 | Empty-week skip logic | If `len(papers) < min_papers_for_brief`, log `learning_brief_skipped_insufficient_papers` and exit cleanly | REQ-9.5.3.6 |
+| C.7 | LLM response sanitization | Markdown parsed permissively; active content stripped; orphan citations removed with warning | SR-9.5.C.2 |
+| C.8 | CLI commands | `generate`, `latest`, `list` work; `--dry-run` shows input papers without LLM call | REQ-9.5.3.4 |
+| C.9 | `LearningBriefJob` APScheduler integration | Pattern after `MonitoringCheckJob`; default Sunday 23:00 UTC; failures logged not raised | REQ-9.5.3.5 |
+| C.10 | Unit + integration tests for C | 99%+ coverage; integration test with 10 fixture papers + stubbed LLM returning structured response | All C REQs |
+| C.11 | Generate first production brief | Manually trigger via CLI; user reviews; iterate prompt if needed | REQ-9.5.3.1 |
+
+**Review Gate G3:** End of Week 4
+- ✅ All C REQs implemented
+- ✅ `verify.sh` passes
+- ✅ First production weekly Learning Brief generated and contains substantive cross-paper findings (manual user review)
+- ✅ LLM cost ≤$5
+
+**Risk:** First brief may be unusable if extraction quality is still degraded (Workstream A insufficient) or if LLM provider is misconfigured (OQ-9.5.1 unresolved). Mitigation: `--dry-run` mode to validate input before spending; manual review gate before declaring REQ-9.5.3 complete.
+
+---
+
+## Success Criteria
+
+### Per-Workstream Verification
+
+Each workstream must pass before proceeding:
+
+1. **Test Coverage:** 99%+ for all new modules
+2. **Test Pass Rate:** 100% (0 failures)
+3. **Code Quality:** Black, Flake8, Mypy clean (`./verify.sh` green)
+4. **Security:** All SR-9.5.x requirements verified
+5. **Documentation:** Docstrings complete, CLI `--help` accurate, new structured-log events documented
+6. **Integration:** No regressions to existing daily-run pipeline
+
+### Phase 9.5 Overall Success
+- All three workstreams complete and integrated
+- `using_abstract_fallback` rate ≤20% on 7-day rolling window post-merge
+- ≥1 weekly Learning Brief generated with substantive findings
+- Phase 9.3 and 9.4 unblocked
+
+---
+
+## Risk Mitigation
+
+| Risk | Mitigation |
+|---|---|
+| URL-as-Path fix breaks existing tests using mocked Path("http...") | Audit test suite first (`grep -rn 'Path.*http' tests/`); update fixtures with the fix in same PR |
+| LLM provider question (OQ-9.5.1) unresolved when Workstream C ships | C is provider-agnostic via config; spec accommodates any choice; user can decide before C ships without rework |
+| Citation expansion explodes candidate pool | Hard caps in REQ-9.5.2.1; existing QualityFilterService runs after expansion |
+| Provider audit removes HuggingFace from default chain | Documented as acceptable outcome (spec OQ-9.5.4); 9.5 remains valuable with ArXiv-only |
+| First weekly brief is low quality | `--dry-run` mode for validation; manual review gate; iterative prompt tuning before declaring complete |
+| Workstream B introduces N+1 LLM calls (one per query variant per topic) | Variant cache (7-day TTL) bounds LLM calls; per-topic variant cap (default 3) bounds per-run cost |
+| Schedule slip cascades into 9.3/9.4 | Workstreams are independently shippable; if C slips, A+B can ship as 9.5.1 with C as 9.5.2 |
+
+---
+
+## Handoff Points
+
+### Workstream A → Workstream C
+- Reliable extraction outputs (`Source: PDF` not `Source: Abstract`) for Learning Brief input
+- Provider health checks confirm LLM availability before brief generation
+
+### Workstream B → Phase 9.4
+- Citation expansion service is reusable by future frontier-detection work
+- `QueryExpander` is reusable by future topic auto-discovery
+
+### Workstream C → User
+- Weekly learning brief delivered to `output/learning_briefs/`
+- CLI `arisp learning latest` for on-demand review
+
+---
+
+## Review/QA Gates
+
+| Gate | Timing | Scope | Exit Criteria |
+|---|---|---|---|
+| G0 | Plan approval | All workstreams | User approves spec + execution plan |
+| G1 | End Week 1 | Workstream A | All A REQs pass; abstract-fallback rate ≤30% on next manual run |
+| G2 | End Week 3 | Workstream B | All B REQs pass; ≥10 net-new papers from citation_expansion in a manual run |
+| G3 | End Week 4 | Workstream C + integration | First weekly brief generated; user reviews; ≥3 substantive findings cited |
+
+### Gate Protocol
+1. Implementation completes in worktree
+2. Code review verifies quality, security, coverage
+3. Manual verification end-to-end against acceptance criteria
+4. Gate passes only when all three approve
+
+---
+
+## Estimated Effort
+
+| Workstream | Duration | Complexity |
+|---|---|---|
+| A: Reliability | 1 week | LOW-MEDIUM |
+| B: Breadth | 2 weeks (parallel) | MEDIUM |
+| C: Learning Synthesis | 2 weeks (parallel) | MEDIUM |
+| **Total** | **4 weeks** | N/A |
+
+---
+
+## Open Questions (Persisted)
+
+See `.omc/plans/open-questions.md` for tracked decisions and open items (Phase 9.5 section).
+
+### Key Open Question Blocking Workstream C
+**OQ-9.5.1: LLM provider strategy** — The current Gemini free-tier (5 RPM) is incompatible with daily volume; Anthropic key is invalid. Workstream A surfaces this; Workstream C requires a working provider. Options documented in spec Section 11. **User decision needed before Workstream C Week 4.**
+
+---
+
+## Appendix: New File Structure
+
+```
+src/services/pdf_acquisition.py       # NEW (Workstream A)
+src/services/llm/health_check.py      # NEW (Workstream A)
+src/services/llm/query_expander.py    # NEW (extracted from monitoring) (Workstream B)
+src/services/discovery/
+    citation_expansion.py             # NEW (Workstream B)
+src/services/learning/
+    __init__.py                       # NEW (Workstream C)
+    brief_generator.py                # NEW (Workstream C)
+    prompts/
+        synthesis_system.txt          # NEW (Workstream C)
+        synthesis_user_template.txt   # NEW (Workstream C)
+src/scheduling/learning_brief_job.py  # NEW (Workstream C)
+src/models/learning.py                # NEW (Workstream C)
+src/cli/learning.py                   # NEW (Workstream C)
+
+docs/audits/
+    2026-05_provider_pdf_audit.md     # NEW (Workstream A)
+
+config/research_config.yaml           # EXTENDED (B + C config blocks)
+src/orchestration/paper_processor.py  # MODIFIED (Workstream A)
+src/services/extraction_service.py    # MODIFIED (Workstream A)
+src/orchestration/phases/discovery.py # MODIFIED (Workstream B)
+src/models/discovery.py               # MODIFIED (source field, Workstream B)
+src/output/delta_generator.py         # MODIFIED (display source, Workstream B)
+src/services/intelligence/monitoring/ # MODIFIED (consume shared QueryExpander, Workstream B)
+```
+
+---
+
+**Document Status:** DRAFT
+**Next Step:** User review/approval, then handoff to implementation in `feature/phase-9.5-pipeline-reliability` worktree (Workstream A first)

--- a/docs/PHASED_DELIVERY_PLAN.md
+++ b/docs/PHASED_DELIVERY_PLAN.md
@@ -356,6 +356,62 @@ ARISP Paper Registry + LLM Service
 
 ---
 
+### Phase 9: Research Intelligence Layer
+**Status:** 🔄 **IN PROGRESS** (9.1 + 9.2 shipped; 9.5 inserted; 9.3 + 9.4 deferred behind 9.5)
+**Duration:** ~12-14 weeks total across all sub-phases
+**Dependencies:** Phase 8 Complete (DRA), Phase 3.5 (Registry), Phase 6 Core (Enhanced Discovery)
+**Goal:** Transform ARISP from reactive paper-discovery system into proactive, relationship-aware research intelligence platform
+
+#### Sub-Phase Status
+
+| Sub-Phase | Title | Status | Notes |
+|---|---|---|---|
+| **9.1** | Monitoring (subscriptions, ArXiv polling, LLM query expansion, digests) | ✅ Shipped | Currently degraded in production (see 9.5); will be repaired by 9.5 Workstream A |
+| **9.2** | Citation Graph (BFS crawl, bibliographic coupling, recommender, co-citation) | ✅ Shipped | Built and CLI-accessible (#147, #150, #151, #152); not yet wired into daily discovery loop (see 9.5 Workstream B) |
+| **9.5** | Pipeline Reliability, Discovery Breadth, Learning Synthesis | 📋 Planning | **NEW** — addresses production pipeline gaps; blocks 9.3/9.4. See [PHASE_9.5_RELIABILITY_BREADTH_LEARNING_SPEC.md](specs/PHASE_9.5_RELIABILITY_BREADTH_LEARNING_SPEC.md) |
+| **9.3** | Knowledge Graph (entity extraction, cross-paper compare) | ⏸️ Deferred | Behind 9.5; will benefit from 9.5's reliability improvements and broader candidate pool |
+| **9.4** | Frontier Detection (trends, emergence, gaps) | ⏸️ Deferred | Behind 9.5; recommended order after 9.5 closeout: 9.4 then 9.3 (revisit during 9.5 closeout) |
+
+**Details:** See [PHASE_9_RESEARCH_INTELLIGENCE_SPEC.md](specs/PHASE_9_RESEARCH_INTELLIGENCE_SPEC.md) for the full Phase 9 specification.
+
+---
+
+### Phase 9.5: Pipeline Reliability, Discovery Breadth, and Targeted Learning Synthesis
+**Status:** 📋 **Planning** (drafted 2026-05-09)
+**Duration:** 4 weeks
+**Dependencies:** Phase 9.1 (shipped, degraded), Phase 9.2 (shipped), Phase 5.1 (LLM decomposition), Phase 3.7 (cross-topic synthesis)
+**Blocks:** Phase 9.3, Phase 9.4
+**Goal:** Restore the production pipeline to producing useful per-paper extractions, then layer cross-paper weekly synthesis on top — so daily output is curated learning, not a list of titles.
+
+#### Problem Addressed
+Production pipeline diagnostic (2026-05-09) reveals two interdependent gaps the original Phase 9 plan does not cover:
+
+1. **Ingestion produces degraded output.** ~54% of papers fail PDF extraction due to a URL-as-Path bug in `src/orchestration/paper_processor.py:138-145`; ~63% of LLM extraction attempts fail due to free-tier quota exhaustion; the Anthropic fallback provider is offline (invalid API key, silent degradation). Daily Delta briefs are abstract-only title lists.
+
+2. **Discovery is structurally narrow.** Only ArXiv reliably returns PDF-bearing papers (HuggingFace returns 0 after filtering, Semantic Scholar reports `pdf_available: 0`); topics are hand-picked and never rotate; the Phase 9.2 citation graph exists but is not used in the daily discovery loop; the Phase 9.1 monitoring service returns 0 new papers per cycle (cascading failure from broken Anthropic key).
+
+#### Three Workstreams
+
+**Workstream A: Pipeline Reliability (Week 1)** — fixes the URL-as-Path bug, surfaces LLM provider failures at startup with explicit signals, audits broken HuggingFace/SS provider PDF resolution, defines `using_abstract_fallback` SLO indicator. **Blocks Workstream C.**
+
+**Workstream B: Discovery Breadth (Weeks 2-3, parallel with C ramp)** — wires Phase 9.2 citation expansion into the daily flow (1-hop neighborhood of high-quality recent papers); extracts `QueryExpander` to a shared service used by both monitoring and discovery; tags candidate provenance for diagnostic attribution. **Does NOT add new providers in 9.5** (Crossref/CORE/etc. are explicitly out of scope).
+
+**Workstream C: Targeted Learning Synthesis (Weeks 3-4)** — adds a new weekly Learning Brief output that synthesizes successfully-extracted per-paper data into cross-paper findings: novel techniques, new benchmarks, contradictions, SOTA changes, engineering tips. CLI: `arisp learning generate|latest|list`; APScheduler `LearningBriefJob` runs weekly.
+
+#### Success Metrics
+- `using_abstract_fallback` rate ≤20% (baseline: ~70%)
+- PDF extraction success rate ≥95% (baseline: ~46%)
+- Net new papers via citation_expansion ≥20/run averaged over 7 days (baseline: 0)
+- Weekly Learning Brief generated with ≥3 substantive cited findings
+- Phase 9.3 and 9.4 unblocked
+
+#### Open Question (User Decision Needed Before Workstream C)
+LLM provider strategy: paid Gemini tier vs. rotate Anthropic key + paid Claude vs. throttle to free tier vs. local model. Workstream C is provider-agnostic via config; choice can land before C ships without rework.
+
+**Details:** See [PHASE_9.5_RELIABILITY_BREADTH_LEARNING_SPEC.md](specs/PHASE_9.5_RELIABILITY_BREADTH_LEARNING_SPEC.md) and [phase-9.5-execution-plan.md](../.omc/plans/phase-9.5-execution-plan.md).
+
+---
+
 ### Phase 4: Production Hardening
 **Duration:** 1 week
 **Dependencies:** Phase 3.6 (with security gates passed)

--- a/docs/specs/PHASE_9.5_RELIABILITY_BREADTH_LEARNING_SPEC.md
+++ b/docs/specs/PHASE_9.5_RELIABILITY_BREADTH_LEARNING_SPEC.md
@@ -1,0 +1,583 @@
+# Phase 9.5: Pipeline Reliability, Discovery Breadth, and Targeted Learning Synthesis
+
+**Version:** 1.0
+**Status:** 📋 Planning
+**Timeline:** 4 weeks
+**Date:** 2026-05-09
+**Dependencies:**
+- Phase 9.1 Complete (Monitoring service shipped — but currently degraded; see Problem Statement)
+- Phase 9.2 Complete (Citation graph shipped — but not wired into daily flow; see Problem Statement)
+- Phase 5.1 Complete (LLM Service Decomposition)
+- Phase 3.7 Complete (Cross-Topic Synthesis)
+
+**Blocks:** Phase 9.3 (Knowledge Graph) and Phase 9.4 (Frontier Detection) are deferred until Phase 9.5 completion.
+
+---
+
+## Architecture Reference
+
+This phase addresses two production gaps observed in the live daily pipeline as of 2026-05-09:
+
+1. **The ingestion pipeline produces degraded output.** ~54% of papers fail PDF extraction due to a URL-as-Path bug; ~63% of LLM extraction attempts fail due to free-tier quota exhaustion; the Anthropic fallback provider is offline (invalid API key). Daily Delta briefs are abstract-only title lists rather than the targeted learnings the system was designed to produce.
+
+2. **Discovery is structurally narrow.** Topic queries are hand-picked and static; only ArXiv reliably returns PDF-bearing papers (HuggingFace returns 0 after filtering, Semantic Scholar reports `pdf_available: 0`); the Phase 9.2 citation graph exists but is not used in the daily discovery loop; the Phase 9.1 monitoring service returns 0 new papers per cycle because LLM-based query expansion fails silently when the Anthropic provider is unavailable.
+
+**Architectural Gaps Addressed:**
+- ❌ Gap: PDF download path is duplicated across `extraction_service.py` and `paper_processor.py`, with the orchestration layer bypassing `download_pdf()` entirely
+- ❌ Gap: External provider failures (auth, quota) degrade silently into abstract-only fallback, with no clear runtime signal
+- ❌ Gap: Daily discovery is single-source-effective (ArXiv) and single-query-per-topic, exhausting against narrow topic slices
+- ❌ Gap: Citation graph (Phase 9.2) is queryable via CLI but not integrated into the discovery candidate pool
+- ❌ Gap: Per-paper extraction outputs (prompts, code, metrics, summaries) are not synthesized into cross-paper learning briefs that answer "what advanced this week"
+
+**Components Added:**
+- Reliability: shared download pipeline, provider startup health checks, abstract-fallback SLO
+- Breadth: `CitationExpansionService` (wraps existing `BFSCrawler` for daily-loop use), shared `QueryExpander` extracted from monitoring, multi-source PDF resolution audit
+- Learning: `LearningBriefGenerator`, `LearningBriefJob` (APScheduler), CLI `arisp learning` namespace
+
+**Components NOT Added** (explicitly out of scope):
+- ❌ New paper-discovery providers beyond fixing existing ones (no Crossref/CORE in 9.5)
+- ❌ Topic auto-rotation via frontier detection (depends on Phase 9.4, deferred)
+- ❌ Replacement of LLM provider strategy (provider choice is an open question, see Section 11)
+- ❌ Multi-user features
+
+**Coverage Targets:**
+- Reliability components: ≥99% (existing project standard)
+- Breadth components: ≥99%
+- Learning synthesis: ≥99%
+
+---
+
+## 1. Executive Summary
+
+Phase 9.5 stabilizes ARISP's production pipeline and closes the loop between discovery, extraction, and learning. It addresses three interdependent problems:
+
+| Workstream | Problem Today | Outcome |
+|---|---|---|
+| **A. Reliability** | 54% PDF extraction failure (URL-as-Path bug); silent provider degradation; ~70% of papers fall back to abstract-only | <20% abstract-fallback rate; loud failure on provider auth issues |
+| **B. Discovery Breadth** | Static hand-picked topics; single effective provider (ArXiv); citation graph not in daily loop | Daily candidate pool 2-3× larger via citation expansion + LLM query variants |
+| **C. Targeted Learning Synthesis** | Per-run Delta briefs are title lists; no cross-paper synthesis of "what advanced" | Weekly Learning Brief per topic answering "novel techniques, new benchmarks, contradictions, SOTA changes" with citations |
+
+**What This Phase Is:**
+- ✅ Production reliability hardening of an existing, shipping pipeline
+- ✅ Activation of already-built Phase 9.2 citation work in the daily flow
+- ✅ A new synthesis output that turns extraction into actionable learning briefs
+
+**What This Phase Is NOT:**
+- ❌ A redesign of discovery, extraction, or LLM architecture
+- ❌ A new provider integration (existing broken ones get audited; nothing new added)
+- ❌ Phase 9.3 or 9.4 work — those are explicitly deferred behind 9.5
+
+**Key Achievement:** Restore the pipeline's ability to produce useful per-paper extractions, then layer cross-paper weekly synthesis on top — so the user's daily output is a curated learning brief, not a list of titles.
+
+---
+
+## 2. Problem Statement
+
+### 2.1 Diagnostic Findings (2026-05-09 daily run)
+
+The following observations come from `logs/daily_run_2026-05-09.log` and direct code inspection. Each finding is reproducible.
+
+#### 2.1.1 PDF extraction is broken via URL-as-Path
+
+`src/orchestration/paper_processor.py:138-145`:
+
+```python
+if paper.open_access_pdf:
+    ...
+    pdf_result = await self.fallback_pdf_service.extract_with_fallback(
+        pdf_path=Path(str(paper.open_access_pdf))   # ← bug
+    )
+```
+
+The orchestration layer bypasses `PDFService.download_pdf()` and casts the URL string directly into a `Path`. `Path("https://...")` collapses double slashes to `https:/...`, which then fails as a non-existent local file:
+
+```
+{"error": "no such file: 'https:/arxiv.org/pdf/2605.06641v1'", "event": "pymupdf_extraction_failed"}
+```
+
+`src/services/extraction_service.py:172-218` does this correctly (downloads first, passes a real `Path`). The two paths have diverged.
+
+**Impact:** 97 of 180 papers (54%) fail PDF extraction per daily run. All fall back to abstract-only.
+
+#### 2.1.2 LLM extraction is throttled to ~5 RPM
+
+The active provider is `gemini-2.5-flash` on the free tier (5 requests/minute):
+
+```
+"error": "429 RESOURCE_EXHAUSTED ... Quota exceeded for metric:
+generate_content_free_tier_requests, limit: 5, model: gemini-2.5-flash"
+```
+
+**Impact:** 113 `llm_extraction_failed` events per run; many papers receive no extraction at all even when the PDF was successfully downloaded.
+
+#### 2.1.3 Anthropic fallback is offline (invalid key)
+
+```
+"Provider anthropic failed: Error code: 401 - 'invalid x-api-key'"
+```
+
+**Impact:** Multi-provider failover (Phase 3.3) cannot engage; LLM-based query expansion in monitoring (Phase 9.1) silently disables itself; the user has no startup-time signal that this provider is unusable.
+
+#### 2.1.4 Discovery is effectively single-source
+
+From the same daily run, by provider:
+
+| Provider | Returned | PDFs available |
+|---|---|---|
+| ArXiv | ~20/topic | 100% |
+| Semantic Scholar | ~20/topic | **0%** (`pdf_available: 0` in every event) |
+| HuggingFace | 0/topic | N/A (fetches 100, filters all out — likely returning models/datasets, not papers) |
+
+**Impact:** Despite the multi-provider architecture, only ArXiv contributes papers to the extraction pipeline.
+
+#### 2.1.5 Topics are hand-picked and never rotate
+
+`config/research_config.yaml` contains 8 narrow topics (e.g., "Tree of Thoughts AND machine translation"). They have run daily for >30 days against ArXiv's narrow daily slice. Average duplication rate per daily run is ~28% (not "always," as the user perceived — but trending upward as ArXiv's recent slice is exhausted). Two topics on 2026-05-09 saw 80% and 48% duplication.
+
+#### 2.1.6 Citation graph is built but not in the daily loop
+
+Phase 9.2 shipped `BFSCrawler`, `BibliographicCouplingAnalyzer`, `CitationRecommender`, and the `arisp citation` CLI (#147, #150, #151, #152). None of these are invoked by `DiscoveryPhase` in the daily pipeline. The citation neighborhood of high-quality recently-extracted papers is not added to the candidate pool.
+
+#### 2.1.7 Monitoring service returns 0 new papers per cycle
+
+`logs/monitor_check_2026-05-09.log` shows `monitor_cycle_complete` events with `seen: 0, new: 0` consistently. Three contributing causes: (a) ArXiv-only by ADR decision (`open-questions.md` 2026-04-24), (b) query expansion fails because the only configured expander provider is Anthropic (broken — see 2.1.3), (c) subscription windows are narrower than the discovery service's.
+
+#### 2.1.8 Output is title-only
+
+Inspection of `output/prompt-engineering-machine-translation-multilingual/runs/2026-05-09_Delta.md` shows every paper marked `Source: 📋 Abstract` — no full-text extraction, no extracted prompts/code/metrics. The "delta brief" is a list of titles plus quality scores. There is no cross-paper synthesis at the daily level beyond Phase 3.7's optional cross-topic synthesis (which is per-run, not weekly, and is bypassed when extractions fail).
+
+### 2.2 Why the Existing Phase 9 Plan Doesn't Cover This
+
+The Phase 9 plan (`.omc/plans/phase-9-execution-plan.md`) assumes a working ingestion pipeline and layers four intelligence pillars on top: 9.1 Monitoring, 9.2 Citation, 9.3 Knowledge, 9.4 Frontier. The plan does not address:
+
+- Pipeline reliability regressions in the underlying extraction path
+- Activation of 9.2 in the production daily loop (it ships standalone CLI capabilities only)
+- Synthesis of per-paper extraction into cross-paper learning briefs distinct from the existing per-run Delta and per-topic synthesis outputs
+
+Phase 9.5 inserts before 9.3 and 9.4 to close these gaps.
+
+---
+
+## 3. Workstream A — Pipeline Reliability
+
+**Objective:** Restore the extraction pipeline to producing useful per-paper output. This workstream blocks Workstreams B and C — there is no value in broadening discovery or synthesizing learnings if extraction itself is broken.
+
+### 3.1 Requirements
+
+#### REQ-9.5.1.1: Single download path for all PDF extraction
+The system SHALL use exactly one code path to materialize a PDF URL into a local file before extraction. Both `src/services/extraction_service.py` and `src/orchestration/paper_processor.py` SHALL invoke `PDFService.download_pdf()` (or a shared helper) before passing a `Path` to any extractor.
+
+**Scenario: Orchestration uses shared download**
+**Given** a `PaperMetadata` with `open_access_pdf="https://arxiv.org/pdf/2605.06641v1"`
+**When** `paper_processor.py` processes the paper
+**Then** the URL SHALL be downloaded to a local `Path` via `PDFService.download_pdf()`
+**And** the local `Path` SHALL be passed to `FallbackPDFService.extract_with_fallback()`
+**And no** event SHALL be logged with `pdf_path` matching `^https?:/`.
+
+#### REQ-9.5.1.2: Type guard against URL-as-Path
+The PDF extractor entry points SHALL reject any `pdf_path` value whose string representation begins with `http:` or `https:` (case-insensitive). Rejection SHALL raise a typed exception with an actionable message naming the calling site.
+
+**Rationale:** Defense-in-depth so a future caller cannot recreate the bug silently.
+
+#### REQ-9.5.1.3: Provider startup health check
+On startup of any service that uses an LLM provider (extraction, monitoring, learning brief generation), each configured provider SHALL be probed with a single minimal request. Results SHALL be logged as one of:
+
+- `provider_health_check_passed` (level=info)
+- `provider_health_check_failed` (level=error) with provider name, error class, and remediation hint
+
+Probes that fail SHALL NOT prevent service startup, but the failed provider SHALL be marked unavailable in the provider registry until the next probe. A subsequent runtime call to an unavailable provider SHALL fail-fast (no retry), so the user sees the issue immediately rather than buried in retry noise.
+
+**Probe Examples:**
+- Anthropic: 1-token completion against `claude-haiku-*` (cheapest)
+- Google: 1-token completion against `gemini-*-flash` (cheapest)
+
+**Cost:** ≈$0.00001 per probe per startup, run once per process.
+
+#### REQ-9.5.1.4: Abstract-fallback SLO
+The system SHALL track the percentage of papers that fall back to abstract-only extraction over a rolling 7-day window. The metric SHALL be exposed as a structured log event `pipeline_health_abstract_fallback_rate` emitted at the end of each daily run, with the rate as a float.
+
+**SLO:** `using_abstract_fallback` rate ≤ 20% on any 7-day rolling window.
+**Current baseline:** ~70% (per 2026-05-09 sample).
+
+**Note:** The metric is an SLO indicator, not a hard gate. Phase 9.5 does not add automated alerting (deferred to Phase 4 production-hardening); the metric is for human review of `logs/daily_run_*.log`.
+
+#### REQ-9.5.1.5: Provider integration audit
+For each non-ArXiv provider in the discovery chain (HuggingFace, Semantic Scholar), the implementation SHALL be audited and either:
+
+- (a) Fixed so that PDF-bearing papers are returned with a usable `open_access_pdf` URL, OR
+- (b) Documented as non-PDF-bearing (e.g., "Semantic Scholar API plan does not return open-access PDFs") with a deprecation notice in the daily-run log if the provider continues to return zero PDFs
+
+**Out of scope:** Adding new providers (Crossref, CORE, OpenAlex-as-PDF-source). Phase 9.5 audits and either fixes or documents existing ones; new provider work is left to a future phase.
+
+### 3.2 Security Requirements
+
+#### SR-9.5.A.1: Provider health probes MUST NOT log API keys
+Health probe events SHALL include provider name and HTTP status / error class only. No auth header values, request bodies containing secrets, or response bodies SHALL be logged.
+
+#### SR-9.5.A.2: Type guard MUST NOT swallow path traversal attempts
+The `http:`/`https:` rejection guard SHALL run AFTER existing path sanitization in `src/utils/path_sanitization.py`, not as a replacement. A malicious path like `../../../etc/passwd` must still be caught by the existing sanitizer.
+
+---
+
+## 4. Workstream B — Discovery Breadth
+
+**Objective:** Increase the diversity of papers reaching extraction without adding new providers. Two mechanisms: (1) citation expansion using the already-shipped Phase 9.2 work, (2) LLM-driven query variants extracted as a shared service from Phase 9.1 monitoring.
+
+### 4.1 Requirements
+
+#### REQ-9.5.2.1: Citation expansion in daily discovery
+The `DiscoveryPhase` SHALL, after running provider queries and quality filtering, expand the candidate pool by traversing the citation neighborhood of recently extracted high-quality papers.
+
+**Algorithm:**
+
+1. Identify "seed" papers: papers extracted in the last 7 days for the current topic with `quality_score >= 0.7`. Cap at 10 seeds per topic (highest-scored first).
+2. For each seed, traverse 1 hop in both directions (forward citations + backward references) using the existing `BFSCrawler`.
+3. Deduplicate candidates against:
+   - The current run's discovery results (in-memory)
+   - The global registry (already extracted)
+4. Cap the citation-expansion contribution at 50 candidates per topic per run (to bound API cost and avoid swamping the deduplication stage).
+5. Tag candidates with `source: "citation_expansion"` and `seed_paper_id` for downstream attribution in the Delta brief.
+
+**Configuration** (`config/research_config.yaml`):
+
+```yaml
+discovery:
+  citation_expansion:
+    enabled: true            # default: true
+    seed_quality_threshold: 0.7
+    max_seeds_per_topic: 10
+    max_candidates_per_topic: 50
+    hop_count: 1
+    directions: ["forward", "backward"]
+```
+
+#### REQ-9.5.2.2: Shared query expansion service
+Phase 9.1 monitoring contains LLM-based query expansion logic. This SHALL be extracted into a shared `QueryExpander` service usable by both monitoring and the daily discovery flow.
+
+**Interface:**
+```python
+class QueryExpander:
+    async def expand(
+        self,
+        base_query: str,
+        recent_paper_titles: list[str],   # ≤20 titles
+        n_variants: int = 3,
+    ) -> list[str]:
+        """Generate n_variants alternative queries informed by recent corpus."""
+```
+
+**Caching:** Variants SHALL be cached for 7 days per `(base_query, hash(sorted(recent_paper_titles)))` key. Daily runs reuse the same variants for a week unless titles change materially.
+
+**Activation in daily flow:** `DiscoveryPhase` SHALL run the original query plus expanded variants through each provider, deduplicating across queries.
+
+#### REQ-9.5.2.3: Tag candidate provenance
+Every paper added to the candidate pool SHALL carry a `source` field with one of: `provider:arxiv`, `provider:semantic_scholar`, `provider:huggingface`, `citation_expansion`, `query_variant`. This is used in the Delta brief and for diagnostic tracking.
+
+#### REQ-9.5.2.4: Discovery breadth metric
+The system SHALL emit `pipeline_health_breadth_metric` at end-of-run with:
+- Total candidates discovered
+- Breakdown by `source`
+- Net new papers (post-dedup) by `source`
+
+**SLO indicator:** Citation-expansion contribution SHALL be ≥ 20 net-new papers per run averaged over 7 days, once enabled.
+
+### 4.2 Security Requirements
+
+#### SR-9.5.B.1: Citation expansion respects rate limits
+The shared `BFSCrawler` already implements Semantic Scholar / OpenAlex rate limiting (Phase 9.2). Daily-loop activation SHALL NOT bypass these limits. If rate limits are hit, citation expansion SHALL gracefully degrade (skip remaining seeds for this run) rather than blocking the discovery phase.
+
+#### SR-9.5.B.2: Query variants subject to existing input validation
+LLM-generated query variants SHALL pass through the same input validation as user-configured queries before being sent to providers. Specifically: length cap, character whitelist, and provider-specific syntax sanitization.
+
+---
+
+## 5. Workstream C — Targeted Learning Synthesis
+
+**Objective:** Convert successfully-extracted per-paper data into a weekly cross-paper learning brief that answers: "what actually advanced our understanding this week?"
+
+### 5.1 Requirements
+
+#### REQ-9.5.3.1: Learning Brief output type
+The system SHALL produce a new artifact `output/learning_briefs/YYYY-WW_Learning_Brief.md` weekly, distinct from per-run Delta briefs and per-run cross-topic syntheses.
+
+**Cadence:** Weekly by default (configurable). Generated at end-of-week (Sunday UTC).
+
+**Scope:** All papers extracted in the last 7 days across all topics with `extraction_status == "success"` and `Source: PDF` (i.e., excluding abstract-only fallbacks).
+
+**Format:**
+
+```markdown
+---
+date_range: 2026-05-03 to 2026-05-09
+papers_analyzed: 47
+topics_covered: ["tree-of-thoughts-and-mt", "rl-robotics", ...]
+quality_threshold: 0.7
+---
+
+# Learning Brief: Week 19 of 2026
+
+## Novel Techniques Introduced
+- [paper_id_1] introduced X technique that achieves Y on benchmark Z
+- ...
+
+## New Benchmarks & Datasets
+- ...
+
+## Contradictions With Prior Claims
+- [paper_id_3] reports finding contrary to [paper_id_4] on ...
+
+## Results That Change Current SOTA
+- ...
+
+## Practical Engineering Tips
+- For implementing X, see [paper_id_5]'s Section 3.2 on ...
+
+## Cross-Topic Connections
+- The [paper_id_6] approach in MT may be transferable to RL setup in [paper_id_7]
+```
+
+#### REQ-9.5.3.2: LLM prompt structure for synthesis
+The brief SHALL be generated by a single LLM call (or chunked if context exceeds 200K tokens) with the following prompt structure:
+
+- System message: Defines role, output structure, citation requirements
+- User message: Concatenated extraction outputs (`engineering_summary`, `code_snippets`, `evaluation_metrics`, `system_prompts`) for each paper, prefixed with `[paper_id]`
+- Output requirement: Every claim in the brief must cite at least one `[paper_id]`
+
+**Provider:** Whichever LLM provider is selected per the open question in Section 11. Defaults to the same provider used for extraction.
+
+**Cost guardrail:** Each weekly brief is capped at $5 USD of LLM spend (configurable). If the corpus exceeds the budget, papers SHALL be sampled by `quality_score` (highest first).
+
+#### REQ-9.5.3.3: Cross-topic engineering tips
+The brief SHALL include a dedicated "Practical Engineering Tips" section that surfaces extracted code snippets and system prompts judged most likely to be implementable by an engineering team. Selection criteria (LLM-judged):
+
+- Clarity of implementation
+- Generality (transferable across tasks)
+- Reproducibility (specific hyperparameters, datasets named)
+
+#### REQ-9.5.3.4: CLI commands
+```
+arisp learning generate [--week N] [--year YYYY] [--dry-run]
+arisp learning latest
+arisp learning list
+```
+
+- `generate` invokes the synthesis on demand. `--dry-run` shows the input papers without LLM call.
+- `latest` prints the most recent brief to stdout.
+- `list` shows all generated briefs with date ranges and paper counts.
+
+#### REQ-9.5.3.5: Scheduled job integration
+A `LearningBriefJob(BaseJob)` SHALL be added to `src/scheduling/`, following the pattern of `DailyResearchJob` and `MonitoringCheckJob`. It SHALL run weekly (default: Sunday 23:00 UTC, configurable). Failures SHALL log `learning_brief_generation_failed` and SHALL NOT crash the scheduler.
+
+#### REQ-9.5.3.6: Empty-week handling
+If the previous 7 days produced fewer than `min_papers_for_brief` papers (default: 5), the job SHALL log `learning_brief_skipped_insufficient_papers` and SHALL NOT generate a brief or call the LLM.
+
+### 5.2 Security Requirements
+
+#### SR-9.5.C.1: Learning brief MUST NOT leak per-paper PDF content beyond extraction targets
+The synthesis prompt SHALL only consume already-extracted structured fields (`engineering_summary`, `code_snippets`, etc.). Raw PDF text SHALL NOT be re-loaded or re-sent to the LLM. This bounds privacy/copyright exposure to what extraction has already approved.
+
+#### SR-9.5.C.2: LLM response sanitization
+The brief output SHALL be parsed with a permissive Markdown parser before write. Any embedded `<script>`, `<iframe>`, or other active content SHALL be stripped. Citations matching `[paper_id_X]` SHALL be validated against the actual paper IDs in the input set; orphan citations SHALL be removed with a log warning.
+
+---
+
+## 6. Data Models
+
+New Pydantic models in `src/models/learning.py`:
+
+```python
+class LearningBriefRequest(BaseModel):
+    week_iso: str                     # "2026-W19"
+    start_date: date
+    end_date: date
+    min_quality_score: float = 0.7
+    min_papers: int = 5
+    max_cost_usd: float = 5.0
+    llm_provider: str | None = None   # default: extraction provider
+
+class LearningBriefSection(BaseModel):
+    heading: str
+    items: list[str]                  # markdown bullet text
+    cited_paper_ids: list[str]
+
+class LearningBrief(BaseModel):
+    week_iso: str
+    generated_at: datetime
+    papers_analyzed: list[str]        # paper_ids
+    topics_covered: list[str]
+    cost_usd: float
+    sections: list[LearningBriefSection]
+    output_path: Path
+```
+
+New Pydantic models in `src/models/discovery.py` (additions):
+
+```python
+class CandidateSource(str, Enum):
+    PROVIDER_ARXIV = "provider:arxiv"
+    PROVIDER_SEMANTIC_SCHOLAR = "provider:semantic_scholar"
+    PROVIDER_HUGGINGFACE = "provider:huggingface"
+    CITATION_EXPANSION = "citation_expansion"
+    QUERY_VARIANT = "query_variant"
+
+# Add to existing ScoredPaper:
+class ScoredPaper(BaseModel):
+    ...
+    source: CandidateSource
+    seed_paper_id: str | None = None  # for citation_expansion only
+```
+
+---
+
+## 7. Success Metrics
+
+### 7.1 Per-Workstream Metrics
+
+| Workstream | Metric | Baseline (2026-05-09) | Target (post-9.5) |
+|---|---|---|---|
+| A — Reliability | `using_abstract_fallback` rate | ~70% | ≤20% |
+| A — Reliability | PDF extraction success rate | ~46% (83/180) | ≥95% |
+| A — Reliability | Provider health visible at startup | ❌ buried in retries | ✅ explicit event |
+| B — Breadth | Net new papers via citation_expansion (avg/run) | 0 | ≥20 |
+| B — Breadth | Topics with query variants active | 0 | all |
+| B — Breadth | Effective providers contributing PDFs | 1 (ArXiv) | 1 fixed + audit complete on others |
+| C — Learning | Weekly briefs generated | 0 | 1/week |
+| C — Learning | Briefs containing ≥3 cited "novel techniques" findings | N/A | ≥80% of briefs |
+| C — Learning | LLM cost per brief | N/A | ≤$5 |
+
+### 7.2 Phase 9.5 Overall Success
+
+Phase 9.5 is considered complete when:
+1. All three workstreams' requirements pass with 99%+ test coverage
+2. The next daily run after deployment shows `using_abstract_fallback` rate < 20% (verified manually from `logs/daily_run_*.log`)
+3. The first weekly Learning Brief is generated and contains substantive cross-paper findings (manually reviewed)
+4. Phase 9.3 and 9.4 are unblocked (their dependencies on 9.5 are satisfied)
+
+---
+
+## 8. Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| URL-as-Path fix breaks existing tests that mocked the old path | Audit test suite for `Path("https://...")` patterns before code change; update fixtures together with the fix |
+| Provider health checks add startup latency | Probes are async and run in parallel; budget ≤2s total for 2-3 providers |
+| Citation expansion explodes API call count | Hard caps on seeds and candidates per topic; existing rate limiters from Phase 9.2 enforced |
+| Learning Brief LLM cost exceeds budget | Per-brief cost cap; sample by quality if over budget; weekly cadence (not daily) bounds spend |
+| Audit of HuggingFace/SS reveals they're fundamentally not PDF-bearing | Document and remove from default chain; this is an acceptable outcome for 9.5, not a blocker |
+| LLM provider question unresolved at start of Workstream C | Workstream C is implementation-agnostic on provider; specific provider plumbed via config; user decision can land before C ships |
+| Learning Brief synthesis quality is poor on first attempt | Iterative prompt tuning during Week 4; manual review of first 2-3 briefs before declaring success |
+
+---
+
+## 9. Resequencing of Phase 9.3 and 9.4
+
+Phase 9.5 inserts before 9.3 (Knowledge Graph) and 9.4 (Frontier Detection). The original Phase 9 plan dependencies still hold:
+- 9.3 requires 9.2 (✅ shipped)
+- 9.4 requires 9.2 (✅ shipped)
+
+Both will benefit from 9.5's reliability improvements (their LLM-heavy work cannot succeed if extraction is broken or providers are silently down). Both will benefit from 9.5's broader candidate pool (more papers → richer knowledge graph and frontier signal).
+
+**Recommended order after 9.5:** 9.4 (Frontier) before 9.3 (Knowledge), because frontier detection enables the topic auto-rotation deferred from 9.5's Workstream B and provides the highest-leverage discovery improvement. This is a reversal of the original Phase 9 plan order; revisit during 9.5 closeout.
+
+---
+
+## 10. Implementation Notes
+
+### 10.1 Shared Download Path (Workstream A)
+
+The cleanest refactor: extract PDF acquisition into a small helper used by both `extraction_service.py` and `paper_processor.py`:
+
+```python
+# src/services/pdf_acquisition.py (new)
+async def acquire_pdf(
+    pdf_service: PDFService,
+    paper: PaperMetadata,
+) -> Path | None:
+    """Materialize a paper's open_access_pdf URL into a local Path.
+
+    Returns None if the paper has no PDF URL. Raises typed exceptions
+    on download failure.
+    """
+    if not paper.open_access_pdf:
+        return None
+    return await pdf_service.download_pdf(
+        url=str(paper.open_access_pdf),
+        paper_id=paper.paper_id,
+    )
+```
+
+Both call sites then call `acquire_pdf(...)` and pass the result to extractors. The type guard in REQ-9.5.1.2 lives at the extractor entry point as defense-in-depth.
+
+### 10.2 QueryExpander Extraction (Workstream B)
+
+The expander already exists inside `src/services/intelligence/monitoring/`. Extract to `src/services/llm/query_expander.py` as a provider-agnostic class. Update monitoring to consume from the shared location. No behavior change for monitoring; gain is reuse by `DiscoveryPhase`.
+
+### 10.3 LearningBriefJob (Workstream C)
+
+Pattern after `MonitoringCheckJob` (Phase 9.1) and `DailyResearchJob`. Schedule via APScheduler with a cron trigger:
+
+```yaml
+schedule:
+  learning_brief:
+    cron: "0 23 * * 0"        # Sunday 23:00 UTC
+    enabled: true
+```
+
+### 10.4 Test Strategy
+
+- **Unit:** Each new component covered ≥99%
+- **Integration:**
+  - End-to-end test using a real ArXiv URL (not a mocked Path) to prevent regression of REQ-9.5.1.1
+  - Provider health check test using mocked HTTP failures
+  - Citation expansion test using a recorded `BFSCrawler` response fixture
+  - Learning brief test with a corpus of 10 fixture papers and a stubbed LLM that returns a structured response
+- **Manual:** First 2-3 production weekly briefs reviewed by user before declaring REQ-9.5.3.x complete
+
+---
+
+## 11. Open Questions
+
+These are surfaced here and tracked in `.omc/plans/open-questions.md`:
+
+### OQ-9.5.1: LLM provider strategy
+**Context:** Workstream A surfaces that the current Gemini free-tier (5 RPM) is incompatible with the daily volume (~180 papers), and the Anthropic key is invalid. Workstream C adds weekly synthesis cost. Decision needed before Workstream A ships.
+
+**Options:**
+- (a) Move to paid Gemini tier (raises RPM substantially)
+- (b) Rotate Anthropic key and use Claude Haiku/Sonnet as primary
+- (c) Stay on free tier; throttle pipeline (fewer topics, slower extraction)
+- (d) Local LLM for extraction (Ollama + a small model); paid API only for synthesis
+
+**Status:** Deferred to user (per AskUserQuestion 2026-05-09). 9.5 plan accommodates any choice via config.
+
+### OQ-9.5.2: Citation expansion seed selection
+**Context:** REQ-9.5.2.1 caps seeds at 10 per topic by `quality_score`. Should seeds also be biased toward papers the user has interacted with (Phase 7 feedback signals)?
+
+**Default:** Pure quality_score for 9.5; revisit when integrating with Phase 9.4 frontier detection.
+
+### OQ-9.5.3: Learning Brief cadence
+**Context:** Spec defaults to weekly. Some users may want daily mini-briefs and a weekly comprehensive one.
+
+**Default:** Weekly only for 9.5. Daily briefs deferred until weekly is proven valuable.
+
+### OQ-9.5.4: HuggingFace and Semantic Scholar provider audit outcome
+**Context:** REQ-9.5.1.5 audits these and either fixes or documents. Outcome of the audit determines whether either is removed from the default discovery chain.
+
+**Default:** Resolve during Workstream A implementation; update spec if the outcome materially changes Workstream B's "single effective provider" framing.
+
+---
+
+## 12. References
+
+- `logs/daily_run_2026-05-09.log` — diagnostic source
+- `logs/monitor_check_2026-05-09.log` — diagnostic source
+- `src/orchestration/paper_processor.py:138-145` — bug location
+- `src/services/extraction_service.py:172-218` — correct download pattern
+- [PHASE_9_RESEARCH_INTELLIGENCE_SPEC.md](PHASE_9_RESEARCH_INTELLIGENCE_SPEC.md) — parent phase spec
+- [.omc/plans/phase-9-execution-plan.md](../../.omc/plans/phase-9-execution-plan.md) — original Phase 9 execution plan
+- [.omc/plans/phase-9.5-execution-plan.md](../../.omc/plans/phase-9.5-execution-plan.md) — Phase 9.5 execution plan (this phase)
+
+---
+
+**Document Status:** DRAFT — pending user review
+**Next Step:** User review of this spec; on approval, execute per `phase-9.5-execution-plan.md`


### PR DESCRIPTION
## Summary
- Inserts **Phase 9.5** before 9.3/9.4 to address production gaps observed in the 2026-05-09 daily-run diagnostic (54% PDF extraction failure due to URL-as-Path bug, ~70% abstract-only fallback, silent Anthropic 401, single effective discovery provider, citation graph not in daily loop)
- Three workstreams: **A. Pipeline Reliability** (Week 1, blocks C), **B. Discovery Breadth** (Weeks 2-3, wires already-shipped 9.2 work into daily flow), **C. Targeted Learning Synthesis** (Weeks 3-4, new weekly Learning Brief output)
- Phase 9.3 (Knowledge Graph) and 9.4 (Frontier Detection) deferred behind 9.5; recommended post-9.5 order: 9.4 → 9.3 (revisit at 9.5 closeout)

## Files
- ➕ `docs/specs/PHASE_9.5_RELIABILITY_BREADTH_LEARNING_SPEC.md` — full spec with diagnostic findings, REQ-9.5.x.y, SR-9.5.x, success metrics, open questions
- ➕ `.omc/plans/phase-9.5-execution-plan.md` — week-by-week TODOs, gates, risk mitigations
- ✏️ `docs/PHASED_DELIVERY_PLAN.md` — adds Phase 9 status table and Phase 9.5 entry (roadmap was stale at v3.0 / 2026-04-13 with no Phase 9 content)
- ✏️ `.omc/plans/open-questions.md` — 4 open questions (LLM provider deferred to user), 3 scope clarifications, 4 security decisions

## Diagnostic Evidence (from `logs/daily_run_2026-05-09.log`)
- **PDF extraction:** 97/180 papers fail with `"no such file: 'https:/arxiv.org/pdf/...'"` — URL gets cast through `Path()` in `src/orchestration/paper_processor.py:138-145`, collapsing `https://` to `https:/`. The correct download path exists in `src/services/extraction_service.py:172-218`; the two paths have diverged.
- **LLM extraction:** 113 `llm_extraction_failed` events from Gemini free-tier (5 RPM) quota exhaustion.
- **Anthropic auth:** 401 `'invalid x-api-key'` silently disables multi-provider failover and the Phase 9.1 monitoring service's LLM-based query expansion.
- **Discovery:** Only ArXiv returns PDF-bearing papers per provider event metadata. HuggingFace fetches 100 results and filters all to 0; Semantic Scholar reports `pdf_available: 0` on every event.
- **Output:** Every paper in `output/*/runs/2026-05-09_Delta.md` shows `Source: 📋 Abstract` — no full-text extraction, no extracted prompts/code/metrics.

## Open Questions Requiring User Decision
- **OQ-9.5.1: LLM provider strategy** — paid Gemini vs. rotate Anthropic key vs. throttle to free tier vs. local model. Workstream C is provider-agnostic via config; choice can land before C ships without rework.

Other 3 open questions (citation seed selection, Learning Brief cadence, audit outcomes) have sensible defaults and can resolve during implementation.

## What This PR Is NOT
- ❌ Code changes — bug fixes (URL-as-Path, provider health checks) land in a separate PR (`feature/phase-9.5-pipeline-reliability`) blocked behind this planning PR per agreed workflow
- ❌ A redesign of Phase 9 — Phases 9.1, 9.2 already shipped and remain valid; 9.5 wires + repairs them without replacing
- ❌ New provider integration — Crossref/CORE/etc. explicitly out of scope for 9.5 (per user AskUserQuestion answer)

## Test plan
This PR is documentation-only; pre-push hook still ran full pytest as configured (5447 tests passed, 99.13% combined coverage).

- [x] `./verify.sh` equivalent passes (pre-push hook executed it)
- [x] Markdown renders clean in GitHub preview (no broken links, headers consistent)
- [ ] User reviews spec and execution plan
- [ ] User decides on OQ-9.5.1 (LLM provider strategy) before code PR's Workstream C work begins
- [ ] On approval, follow-up PR `feature/phase-9.5-pipeline-reliability` opens with Workstream A code fixes