### PR TITLE
feat(phase-9.5-B): activate Phase 7.2 citation exploration in production (PR α)

### DIFF
--- a/.omc/plans/phase-9.5-execution-plan.md
+++ b/.omc/plans/phase-9.5-execution-plan.md
@@ -131,41 +131,49 @@ C ramps Week 3 (data models, generator, CLI), runs first brief Week 4
 
 ### Weeks 2-3: Workstream B — Discovery Breadth
 
+> **Plan revision (PR α, 2026-05-12):** Pre-execution audit revealed **Phase 7.2 already shipped the core mechanisms** — `QueryExpander` (`src/utils/query_expander.py`), `CitationExplorer` (`src/services/citation_explorer.py`), and DEEP-mode wiring in `DiscoveryPhase` (`discovery.py:227-228`). The original B.1–B.9 task list assumed greenfield; reality is that production never *activated* Phase 7.2 (no `query_expansion`/`citation_exploration` keys in `research_config.yaml`).
+>
+> **Revised execution: two PRs.**
+>
+> - **PR α (this commit):** Add `citation_exploration: enabled: true` to prod config to activate what already exists; amend spec/plan to reflect as-built reality. Citation expansion runs without LLM, so it ships today even with OQ-9.5.1 unresolved. Query expansion stays off until OQ-9.5.1 is sorted.
+> - **PR β (next):** Six concrete gaps tracked as B-G1 through B-G6 in the spec. Highest priority is **B-G6** (`pipeline_health_breadth_metric` event) — without it we can't verify activation broadens the funnel.
+>
+> The original B.1–B.9 task list below is preserved for traceability; each item is annotated with its as-built status from the audit.
+
 **Objective:** Activate citation expansion in the daily flow; share QueryExpander across monitoring + discovery.
 
-**Week 2 Deliverables:**
-1. `src/services/llm/query_expander.py` — extracted shared service
-2. `src/services/intelligence/monitoring/` updated to consume from shared location (no behavior change)
-3. `src/services/discovery/citation_expansion.py` — new wrapper around Phase 9.2 `BFSCrawler` for daily-loop use
+**PR α Deliverables (this commit):**
+1. `config/research_config.yaml` — add `citation_exploration` section (`enabled: true`, depth=1, fwd+bwd both on, 10 each)
+2. `docs/specs/PHASE_9.5_RELIABILITY_BREADTH_LEARNING_SPEC.md` §4 — annotate each REQ with as-built status; add §4.3 gap summary
+3. `.omc/plans/phase-9.5-execution-plan.md` — this revision block
 
-**Week 3 Deliverables:**
-1. `src/orchestration/phases/discovery.py` updated to invoke citation expansion + query variants
-2. `ScoredPaper.source` field added per spec Section 6
-3. `pipeline_health_breadth_metric` event emitted
-4. Configuration support in `config/research_config.yaml` (with sensible defaults so existing configs continue to work)
-5. CLI flag `--no-citation-expansion` for opt-out
+**PR β Deliverables (deferred, depends on OQ-9.5.1 partly):**
+1. `pipeline_health_breadth_metric` event in `DiscoveryPhase.execute()` end-of-run (B-G6, HIGH)
+2. Seed-selection algorithm aligned with spec (B-G1, MED)
+3. Reconcile field naming for provenance (B-G5, LOW)
+4. After OQ-9.5.1 resolves: activate query expansion + add `recent_paper_titles` + 7-day TTL (B-G2/G3/G4)
 
-**Detailed TODOs:**
+**Original detailed TODOs (B.1–B.9), annotated with as-built status:**
 
-| ID | Task | Acceptance Criteria | REQ |
+| ID | Task | As-built status | REQ |
 |---|---|---|---|
-| B.1 | Extract `QueryExpander` from monitoring | Shared class in `src/services/llm/query_expander.py`; monitoring uses it; existing monitoring tests pass | REQ-9.5.2.2 |
-| B.2 | Add 7-day cache to `QueryExpander` | Cache key = `(base_query, hash(sorted(titles)))`; TTL configurable | REQ-9.5.2.2 |
-| B.3 | Build `CitationExpansionService` | Wraps `BFSCrawler`; honors quality_threshold, seed cap, candidate cap, hop count, directions | REQ-9.5.2.1 |
-| B.4 | Wire citation expansion into `DiscoveryPhase` | After provider queries + quality filter, expansion adds candidates; respects rate limits; degrades gracefully | REQ-9.5.2.1 |
-| B.5 | Wire query variants into `DiscoveryPhase` | Original query + N variants run through each provider; per-variant deduplication | REQ-9.5.2.2 |
-| B.6 | Add `source` and `seed_paper_id` to `ScoredPaper` | Pydantic model updated; all existing call sites set `source` correctly; tests assert provenance is preserved end-to-end | REQ-9.5.2.3 |
-| B.7 | Implement `pipeline_health_breadth_metric` | Event emitted at end of `DiscoveryPhase` with breakdown by source | REQ-9.5.2.4 |
-| B.8 | Display source in Delta brief | Existing `DeltaGenerator` updated to show `source` per paper | REQ-9.5.2.3 |
-| B.9 | Unit + integration tests for B | 99%+ coverage; recorded `BFSCrawler` response fixture for citation expansion test | All B REQs |
+| B.1 | Extract `QueryExpander` from monitoring | ✅ **Already shipped** in Phase 7.2 at `src/utils/query_expander.py`; monitoring consumes it (`_tier1_factory.py:35,78`). Discovery uses a different class (`QueryIntelligenceService`) — see B-G3. | REQ-9.5.2.2 |
+| B.2 | Add 7-day cache to `QueryExpander` | ⚠️ In-memory cache exists (`query_expander.py:57`); 7-day TTL not implemented. Tracked as **B-G4**. | REQ-9.5.2.2 |
+| B.3 | Build `CitationExpansionService` | ✅ Already exists as `CitationExplorer` (`src/services/citation_explorer.py`); uses Phase 7.2's own implementation, NOT the Phase 9.2 `BFSCrawler` the original spec referenced. Functionally equivalent for daily-loop use. | REQ-9.5.2.1 |
+| B.4 | Wire citation expansion into `DiscoveryPhase` | ✅ Wired via `pipeline.py:_create_discovery_phase` → `DiscoveryPhase(multi_source_enabled=True)` → DEEP mode. Gated on config presence. PR α flips the config switch. | REQ-9.5.2.1 |
+| B.5 | Wire query variants into `DiscoveryPhase` | ✅ Wired in DEEP mode (same path). PR α does NOT activate (blocked on OQ-9.5.1); tracked as **B-G2**. | REQ-9.5.2.2 |
+| B.6 | Add `source` and `seed_paper_id` to `ScoredPaper` | ⚠️ Phase 7.2 ships `discovery_source` + `discovery_method` on `PaperMetadata` with values like `"arxiv"`, `"forward_citation"`. Field names differ from spec's `source`/`seed_paper_id`. Tracked as **B-G5**. | REQ-9.5.2.3 |
+| B.7 | Implement `pipeline_health_breadth_metric` | ❌ **Not done.** Per-source counts are logged separately (`discover_deep_citation_exploration` event) but no aggregated end-of-run event. Tracked as **B-G6 (HIGH)**. | REQ-9.5.2.4 |
+| B.8 | Display source in Delta brief | ❌ **Not done.** `DeltaGenerator` doesn't show provenance. Tracked as part of **B-G5**. | REQ-9.5.2.3 |
+| B.9 | Unit + integration tests for B | ⚠️ Existing Phase 7.2 tests (`tests/unit/test_phase_7_2_integration.py`) cover aggregation + query-expansion fallback. PR β adds tests for B-G1, B-G6 specifically. | All B REQs |
 
-**Review Gate G2:** End of Week 3
-- ✅ All B REQs implemented
+**Review Gate G2:** End of PR β
+- ✅ All B REQs implemented OR explicitly deferred with rationale
 - ✅ `verify.sh` passes
-- ✅ Manual run shows ≥10 net-new papers from `citation_expansion` in a single run (≥20 averaged target deferred to 7-day rolling measurement post-merge)
-- ✅ Monitoring service still functions identically (regression check)
+- ✅ Manual run after PR α shows DEEP mode activated (`phase72_discovery_enabled` log event present); manual run after PR β shows ≥10 net-new papers from citation expansion in a single run via the new `pipeline_health_breadth_metric` event
+- ✅ Monitoring service still functions identically (regression check via existing `tests/unit/services/intelligence/monitoring/`)
 
-**Risk:** Citation expansion may produce many low-relevance candidates if seed papers are noisy. Mitigation: existing `QualityFilterService` runs after expansion, filtering as for any other provider result.
+**Risk:** Citation expansion may produce many low-relevance candidates if seed papers are noisy. Mitigation: existing `QualityFilterService` runs after expansion, filtering as for any other provider result. Additional mitigation in B-G1: replace top-10-by-discovery-order seed selection with last-7-days quality-≥-0.7 cohort for higher-signal seeds.
 
 ---
 

--- a/config/research_config.yaml
+++ b/config/research_config.yaml
@@ -113,6 +113,27 @@ settings:
     ttl_pdf_days: 7
     ttl_extraction_days: 30
 
+  # Citation exploration (Phase 7.2 capability, activated by Phase 9.5
+  # Workstream B). When enabled, the discovery phase runs in DEEP mode:
+  # for the top-N papers from initial provider results, traverse forward
+  # citations + backward references via Semantic Scholar to broaden the
+  # candidate pool beyond the narrow initial query slice.
+  #
+  # Phase 9.5 Workstream B activation:
+  # - citation_exploration is enabled here (REQ-9.5.2.1, broadens the
+  #   discovery funnel without requiring an LLM)
+  # - query_expansion is intentionally NOT enabled until OQ-9.5.1 (LLM
+  #   provider strategy) is resolved; DEEP mode gracefully falls back to
+  #   the original query when no LLM is available, so citation expansion
+  #   still runs.
+  citation_exploration:
+    enabled: true
+    forward: true                 # follow forward citations
+    backward: true                # follow backward references
+    max_citation_depth: 1         # 1 hop only (cap API cost + noise)
+    max_forward_per_paper: 10
+    max_backward_per_paper: 10
+
   # Notification Settings (Phase 3.7)
   notification_settings:
     slack:

--- a/docs/specs/PHASE_9.5_RELIABILITY_BREADTH_LEARNING_SPEC.md
+++ b/docs/specs/PHASE_9.5_RELIABILITY_BREADTH_LEARNING_SPEC.md
@@ -227,17 +227,19 @@ The URL-scheme rejection guard at the extractor entry point is a defense-in-dept
 
 ## 4. Workstream B — Discovery Breadth
 
-**Objective:** Increase the diversity of papers reaching extraction without adding new providers. Two mechanisms: (1) citation expansion using the already-shipped Phase 9.2 work, (2) LLM-driven query variants extracted as a shared service from Phase 9.1 monitoring.
+**Objective:** Increase the diversity of papers reaching extraction without adding new providers. Two mechanisms: (1) citation expansion using the already-shipped Phase 7.2 `CitationExplorer`, (2) LLM-driven query variants via the already-shipped Phase 7.2 `QueryIntelligenceService`.
+
+> **Audit correction (PR α, 2026-05-12):** The original wording of this section assumed Workstream B was greenfield work. A code audit at branch creation time revealed that **Phase 7.2 (Discovery Expansion) already shipped both mechanisms** — `src/utils/query_expander.py`, `src/services/citation_explorer.py`, and the `multi_source_enabled` path in `src/orchestration/phases/discovery.py:227-228`. What was missing was production *activation* (the prod `research_config.yaml` had no `query_expansion` or `citation_exploration` section, so `_create_discovery_phase` fell through to single-source mode) and a small set of genuine gaps listed at the end of this section. Each REQ below is annotated with its **as-built status** plus the residual gap.
 
 ### 4.1 Requirements
 
 #### REQ-9.5.2.1: Citation expansion in daily discovery
 The `DiscoveryPhase` SHALL, after running provider queries and quality filtering, expand the candidate pool by traversing the citation neighborhood of recently extracted high-quality papers.
 
-**Algorithm:**
+**Algorithm (as-spec'd):**
 
 1. Identify "seed" papers: papers extracted in the last 7 days for the current topic with `quality_score >= 0.7`. Cap at 10 seeds per topic (highest-scored first).
-2. For each seed, traverse 1 hop in both directions (forward citations + backward references) using the existing `BFSCrawler`.
+2. For each seed, traverse 1 hop in both directions (forward citations + backward references).
 3. Deduplicate candidates against:
    - The current run's discovery results (in-memory)
    - The global registry (already extracted)
@@ -247,20 +249,22 @@ The `DiscoveryPhase` SHALL, after running provider queries and quality filtering
 **Configuration** (`config/research_config.yaml`):
 
 ```yaml
-discovery:
-  citation_expansion:
-    enabled: true            # default: true
-    seed_quality_threshold: 0.7
-    max_seeds_per_topic: 10
-    max_candidates_per_topic: 50
-    hop_count: 1
-    directions: ["forward", "backward"]
+settings:
+  citation_exploration:
+    enabled: true
+    forward: true
+    backward: true
+    max_citation_depth: 1
+    max_forward_per_paper: 10
+    max_backward_per_paper: 10
 ```
+
+> **As-built status (PR α activates; PR β closes gaps):** The traversal infrastructure is shipped — `src/services/citation_explorer.py` walks Semantic Scholar forward/backward citations and `DiscoveryPhase._discover_topic` invokes it via DEEP mode (`discovery.py:227-228`). PR α turns the feature on in `config/research_config.yaml`. The seed-selection algorithm in Phase 7.2 differs from the spec: it takes the top 10 papers from the *current* run's provider results (`src/services/discovery/service.py:1131`), not "papers extracted in the last 7 days with quality_score ≥ 0.7". This divergence is acceptable for PR α (still broadens vs. single-source) and is tracked as **Gap B-G1** for PR β.
 
 #### REQ-9.5.2.2: Shared query expansion service
 Phase 9.1 monitoring contains LLM-based query expansion logic. This SHALL be extracted into a shared `QueryExpander` service usable by both monitoring and the daily discovery flow.
 
-**Interface:**
+**Interface (as-spec'd):**
 ```python
 class QueryExpander:
     async def expand(
@@ -276,8 +280,20 @@ class QueryExpander:
 
 **Activation in daily flow:** `DiscoveryPhase` SHALL run the original query plus expanded variants through each provider, deduplicating across queries.
 
+> **As-built status:** Two query-expansion paths exist in the codebase, neither matching the spec interface:
+> - `src/utils/query_expander.py::QueryExpander.expand(query, max_variants)` — used by Phase 9.1 monitoring; in-memory cache, no TTL.
+> - `src/services/discovery/service.py` calls `QueryIntelligenceService.enhance(...)` from DEEP mode — used by discovery.
+>
+> Both ignore `recent_paper_titles`. **PR α does NOT activate query expansion** in `research_config.yaml` because it requires a working LLM, which is currently blocked on **OQ-9.5.1 (LLM provider strategy)**. Citation expansion (above) runs without LLM, so DEEP mode still adds value via citation traversal alone (the `query_service is None` branch at `service.py:1056-1064` falls through to the original query and continues with citation work). Once OQ-9.5.1 is resolved, PR β will:
+>
+> - **Gap B-G2:** Add `query_expansion: enabled: true` to prod config to activate the existing path.
+> - **Gap B-G3:** Add `recent_paper_titles` parameter to `QueryExpander` (and reconcile with `QueryIntelligenceService`).
+> - **Gap B-G4:** Add 7-day TTL to `QueryExpander._cache`.
+
 #### REQ-9.5.2.3: Tag candidate provenance
 Every paper added to the candidate pool SHALL carry a `source` field with one of: `provider:arxiv`, `provider:semantic_scholar`, `provider:huggingface`, `citation_expansion`, `query_variant`. This is used in the Delta brief and for diagnostic tracking.
+
+> **As-built status:** Phase 7.2 ships `discovery_source` and `discovery_method` fields on `PaperMetadata` (`src/models/paper.py:63`) and `ResultAggregator` populates them with values like `"arxiv"`, `"semantic_scholar"`, `"forward_citation"`, `"backward_citation"` (`src/services/citation_explorer.py:135, 151`). Field name and value vocabulary differ from the spec but the *function* is provided. **Gap B-G5:** PR β should either align the spec to the as-built names or rename the as-built fields to match the spec; either way, no new tracking is needed.
 
 #### REQ-9.5.2.4: Discovery breadth metric
 The system SHALL emit `pipeline_health_breadth_metric` at end-of-run with:
@@ -286,6 +302,19 @@ The system SHALL emit `pipeline_health_breadth_metric` at end-of-run with:
 - Net new papers (post-dedup) by `source`
 
 **SLO indicator:** Citation-expansion contribution SHALL be ≥ 20 net-new papers per run averaged over 7 days, once enabled.
+
+> **As-built status:** Per-source counts are logged separately (e.g. `discover_deep_citation_exploration` event with `forward` + `backward` counts at `discovery/service.py:1150-1152`) but there is no aggregated `pipeline_health_breadth_metric` event analogous to the Phase 9.5 Workstream A `pipeline_health_abstract_fallback_rate` event. **Gap B-G6:** PR β implements this single new event in `DiscoveryPhase.execute()` end-of-run, with the same shape as the abstract-fallback SLO event (rate, counts, threshold, within_slo).
+
+### 4.3 Gap summary for follow-up PR β
+
+| Gap | Description | Source REQ | Priority |
+|---|---|---|---|
+| **B-G1** | Seed selection: replace hardcoded top-10 with "last-7-days, quality ≥ 0.7" cohort | REQ-9.5.2.1 | MED — current behavior still broadens; spec algorithm gives higher-signal seeds |
+| **B-G2** | Activate `query_expansion: enabled: true` in `research_config.yaml` | REQ-9.5.2.2 | BLOCKED on OQ-9.5.1 |
+| **B-G3** | Add `recent_paper_titles` param to `QueryExpander.expand` | REQ-9.5.2.2 | LOW — only matters if seeds inform variant generation |
+| **B-G4** | Add 7-day TTL to `QueryExpander._cache` | REQ-9.5.2.2 | LOW — bounded cache size; current in-memory is fine for single-process runs |
+| **B-G5** | Reconcile `discovery_source` / `discovery_method` field naming with spec's `source` / `seed_paper_id` (or amend spec) | REQ-9.5.2.3 | LOW — function works; cosmetic |
+| **B-G6** | Implement `pipeline_health_breadth_metric` end-of-run event | REQ-9.5.2.4 | **HIGH** — without this, we can't verify the activation actually broadens the funnel |
 
 ### 4.2 Security Requirements
 


### PR DESCRIPTION
**Phase 9.5 Workstream B PR α** — turns on what's already in the code.

## Why

Pre-execution audit revealed Phase 7.2 (Discovery Expansion) already shipped query expansion, citation exploration, and DEEP-mode wiring in `DiscoveryPhase`. The original Workstream B task list (B.1–B.9) was written assuming greenfield work — but production never *activated* Phase 7.2: \`config/research_config.yaml\` had no \`query_expansion\` or \`citation_exploration\` keys, so \`pipeline.py:_create_discovery_phase\` fell through to single-source SURFACE mode.

Net effect today: production daily runs use ArXiv only, despite the multi-provider + citation-expansion code being in the repo since Phase 7.2.

## What this PR does

- ✏️ \`config/research_config.yaml\` — adds \`settings.citation_exploration\` block (\`enabled: true\`, depth=1, fwd+bwd both on, 10 each). This flips DiscoveryPhase to DEEP mode (\`discovery.py:227-228\`) and activates Phase 7.2's \`CitationExplorer\`.
- ✏️ \`docs/specs/PHASE_9.5_RELIABILITY_BREADTH_LEARNING_SPEC.md\` §4 — annotates each REQ-9.5.2.x with as-built status; new §4.3 gap summary with six concrete follow-up gaps for PR β.
- ✏️ \`.omc/plans/phase-9.5-execution-plan.md\` — plan revision block at the top of Workstream B explaining the audit findings and the two-PR split.

## What this PR does NOT do (deferred to PR β)

- ❌ Add \`query_expansion: enabled: true\` — blocked on **OQ-9.5.1 (LLM provider strategy)**. DEEP mode falls back gracefully to original-query when LLM is unavailable, so citation expansion still runs without it.
- ❌ Implement \`pipeline_health_breadth_metric\` event (gap **B-G6**, HIGH priority). Without it we can't yet measure activation empirically; that's the top item in PR β.
- ❌ Replace hardcoded top-10 seed selection with the spec's \"last-7-days, quality_score≥0.7\" cohort (gap **B-G1**, MED).
- ❌ Reconcile \`discovery_source\`/\`discovery_method\` field naming with spec's \`source\`/\`seed_paper_id\` (gap **B-G5**, LOW).

## Audit findings — what Phase 7.2 already shipped vs. what was missing

| Spec'd Workstream B task | As-built status |
|---|---|
| B.1 — Extract QueryExpander from monitoring | ✅ Already shipped at \`src/utils/query_expander.py\` |
| B.2 — 7-day cache on QueryExpander | ⚠️ In-memory cache exists, no TTL → gap **B-G4** |
| B.3 — Build CitationExpansionService | ✅ Exists as \`CitationExplorer\` (Phase 7.2's own impl, not Phase 9.2's BFSCrawler — functionally equivalent) |
| B.4 — Wire citation expansion into DiscoveryPhase | ✅ Wired via \`_create_discovery_phase\`; gated on config presence; PR α flips the switch |
| B.5 — Wire query variants into DiscoveryPhase | ✅ Wired (same path); PR α does NOT activate (OQ-9.5.1) → gap **B-G2** |
| B.6 — \`source\` / \`seed_paper_id\` provenance | ⚠️ Phase 7.2 ships \`discovery_source\` / \`discovery_method\` with different names → gap **B-G5** |
| B.7 — \`pipeline_health_breadth_metric\` | ❌ Not done → gap **B-G6 (HIGH)** |
| B.8 — Display source in Delta brief | ❌ Not done → part of **B-G5** |

## Operational expectations after merge

- The next daily run will log \`phase72_discovery_enabled\` (proof of activation) and invoke \`CitationExplorer\` for the top-10 papers per topic.
- Up to ~200 extra Semantic Scholar API calls per topic (within existing 100-req/min rate limit).
- Without **B-G6** we can't yet measure broadening empirically; ops can grep \`discover_deep_citation_exploration\` events meanwhile for forward/backward counts.

## Verification

- \`./verify.sh\` PASS (Black, Flake8, Mypy, pragma audit, full pytest)
- **5,492 tests pass**; coverage **99.17%** (above 99% gate)
- No source code changed — config + docs only
- Config parses cleanly via \`ConfigManager + Pydantic\`

## Test plan

- [x] verify.sh green
- [x] Config parses via real \`ConfigManager.load_config()\`
- [ ] Reviewer: confirm activation strategy (citation_exploration on, query_expansion off) matches preference
- [ ] Reviewer: confirm two-PR split (α now, β after OQ-9.5.1) is preferred over one larger PR
- [ ] Post-merge: monitor next daily run for \`phase72_discovery_enabled\` event + per-topic citation counts in \`discover_deep_citation_exploration\`
- [ ] Post-merge: open PR β starting with **B-G6** (\`pipeline_health_breadth_metric\` event) so we can measure broadening